### PR TITLE
refactor(licensing): remove configurable api-url from LicenseConfig

### DIFF
--- a/licensing/src/main/resources/reference.conf
+++ b/licensing/src/main/resources/reference.conf
@@ -4,7 +4,6 @@ softclient4es {
     key = ${?SOFTCLIENT4ES_LICENSE_KEY}
     api-key = ""
     api-key = ${?SOFTCLIENT4ES_API_KEY}
-    api-url = "https://license.softclient4es.com"
     connect-timeout = 10s
     read-timeout = 10s
 

--- a/licensing/src/main/scala/app/softnetwork/elastic/licensing/LicenseConfig.scala
+++ b/licensing/src/main/scala/app/softnetwork/elastic/licensing/LicenseConfig.scala
@@ -23,7 +23,6 @@ import scala.concurrent.duration._
 case class LicenseConfig(
   key: Option[String],
   apiKey: Option[String],
-  apiUrl: String,
   connectTimeout: FiniteDuration,
   readTimeout: FiniteDuration,
   refreshEnabled: Boolean,
@@ -53,7 +52,6 @@ object LicenseConfig {
 
     val gracePeriod = license.getDuration("grace-period").toMillis.millis
 
-    val apiUrl = license.getString("api-url")
     val connectTimeout = license.getDuration("connect-timeout").toMillis.millis
     val readTimeout = license.getDuration("read-timeout").toMillis.millis
 
@@ -62,7 +60,6 @@ object LicenseConfig {
     LicenseConfig(
       key = key,
       apiKey = apiKey,
-      apiUrl = apiUrl,
       connectTimeout = connectTimeout,
       readTimeout = readTimeout,
       refreshEnabled = refreshEnabled,

--- a/licensing/src/test/scala/app/softnetwork/elastic/licensing/LicenseConfigSpec.scala
+++ b/licensing/src/test/scala/app/softnetwork/elastic/licensing/LicenseConfigSpec.scala
@@ -39,7 +39,6 @@ class LicenseConfigSpec extends AnyFlatSpec with Matchers {
     cfg.refreshInterval shouldBe 24.hours
     cfg.telemetryEnabled shouldBe true
     cfg.gracePeriod shouldBe 14.days
-    cfg.apiUrl shouldBe "https://license.softclient4es.com"
     cfg.cacheDir should include(".softclient4es")
   }
 
@@ -90,11 +89,6 @@ class LicenseConfigSpec extends AnyFlatSpec with Matchers {
     cfg.gracePeriod shouldBe 7.days
   }
 
-  "custom api-url" should "be parsed correctly" in {
-    val cfg = configFrom("""softclient4es.license.api-url = "https://custom.example.com" """)
-    cfg.apiUrl shouldBe "https://custom.example.com"
-  }
-
   "custom cache-dir" should "be parsed correctly" in {
     val cfg = configFrom("""softclient4es.license.cache-dir = "/tmp/test-cache" """)
     cfg.cacheDir shouldBe "/tmp/test-cache"
@@ -111,13 +105,11 @@ class LicenseConfigSpec extends AnyFlatSpec with Matchers {
         }
         telemetry.enabled = false
         grace-period = 30d
-        api-url = "https://staging.license.softclient4es.com"
         cache-dir = "/opt/licenses"
       }
     """)
     cfg.key shouldBe Some("eyJ.test.jwt")
     cfg.apiKey shouldBe Some("sk-custom")
-    cfg.apiUrl shouldBe "https://staging.license.softclient4es.com"
     cfg.refreshEnabled shouldBe false
     cfg.refreshInterval shouldBe 6.hours
     cfg.telemetryEnabled shouldBe false


### PR DESCRIPTION
The license-server host must NOT be client-overridable: a client able to repoint it (via HOCON api-url / env) to a server it controls could bypass license enforcement (forged JWKS, fabricated 'valid' responses). Drop the apiUrl field from LicenseConfig, its config read, and the api-url key from reference.conf. The host is now a hardcoded constant in the Elastic-License extensions layer (LicenseEndpoint.ApiUrl), read directly by the licensing clients — not from this Apache-licensed, forkable config.

Tests updated accordingly (the api-url parse assertions removed).