### PR TITLE
P0.5 — elasticsql: enforce maxQueryResults no-LIMIT cap (join-safe)

### DIFF
--- a/core/src/main/scala/app/softnetwork/elastic/client/ResultCapContext.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/ResultCapContext.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import scala.util.DynamicVariable
+
+/** Execution-scoped carrier for the per-call "suppress the single-index result cap" signal (Story
+  * P0.5, ADR §D4.1 / Architecture Decision AD-1).
+  *
+  * This is a license-agnostic '''mechanism''' that lives in the Apache core. It carries NO quota
+  * value and makes NO enforcement decision — it only records, for the duration of one
+  * `gateway.run(...)` call on the current thread, whether that call is a JOIN '''leg''' (whose
+  * input must NOT be capped, or the join silently returns wrong results) versus a direct
+  * single-index query (which IS capped at the licensed `maxQueryResults`).
+  *
+  * ==Why a thread-scoped carrier and not a method/implicit parameter==
+  *
+  * Every read path — direct query AND join leg — funnels through `GatewayApi.run(sql: String)` →
+  * `run(statement)` → `ExtensionRegistry.findHandler(statement).execute(statement, client)`. None
+  * of those signatures has a slot for a per-call flag, and widening them would ripple across all ES
+  * clients, every `Executor`, and the arrow streaming seam. The cap '''decision''' (which lives in
+  * the closed `EnforcedDqlExtension`) is taken '''synchronously on the caller thread''', before the
+  * first `Future`/Elasticsearch boundary, so a thread-scoped read observes the value the leg
+  * executor (local joins) or the inbound-header middleware (federation legs) set around the `run`
+  * call. The boolean rests on the single-license-per-deployment invariant (the sidecar already
+  * knows its own cap, so only a boolean — not an explicit row count — needs to ride the wire).
+  *
+  * Default = `false` (do NOT suppress → the cap applies). Join-leg executors flip it to `true` only
+  * for the scope of the leg.
+  */
+object ResultCapContext {
+
+  private val suppress: DynamicVariable[Boolean] = new DynamicVariable[Boolean](false)
+
+  /** `true` when the current call is a JOIN leg and the single-index result cap must be skipped. */
+  def isSuppressed: Boolean = suppress.value
+
+  /** Run `body` with cap suppression enabled for the current thread (and any synchronous callee on
+    * it), restoring the previous value on exit. Used by the arrow join-leg executors
+    * (`LocalConnection.execute` for local joins; the inbound-header middleware for federation legs)
+    * to wrap the `gateway.run(...)` that materializes a leg.
+    */
+  def suppressed[T](body: => T): T = suppress.withValue(true)(body)
+
+  /** Run `body` with an explicit suppression value (rarely needed; prefer [[suppressed]]). */
+  def withSuppressed[T](value: Boolean)(body: => T): T = suppress.withValue(value)(body)
+}

--- a/core/src/main/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtension.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtension.scala
@@ -19,6 +19,7 @@ package app.softnetwork.elastic.client.extensions
 import akka.actor.ActorSystem
 import app.softnetwork.elastic.client._
 import app.softnetwork.elastic.client.result._
+import app.softnetwork.elastic.client.scroll.ScrollConfig
 import app.softnetwork.elastic.licensing._
 import app.softnetwork.elastic.sql.query._
 import com.typesafe.config.Config
@@ -33,12 +34,31 @@ import scala.concurrent.{ExecutionContext, Future}
   * ✅ Applies Community quotas by default
   * ✅ Can be upgraded with Pro license
   * }}}
+  *
+  * Story P0.5 — this is the '''Community baseline''' handler (priority 100, Apache-OSS, always
+  * loaded). It applies two single-index result-boundary rules at the licensed `maxQueryResults`:
+  *
+  *   1. explicit `LIMIT` > finite quota → hard `402` reject (unchanged, intentional asymmetry); 2.
+  *      no `LIMIT` + finite quota + NOT a JOIN leg → drive the scroll bounded by
+  *      `ScrollConfig.maxDocuments = maxQueryResults` (enforced by the existing `.take` at
+  *      `ScrollApi`), and attach an additive [[ResultTruncation]] so the truncation is never
+  *      silent.
+  *
+  * The cap is '''suppressed for JOIN legs''' ([[ResultCapContext.isSuppressed]]) so a cross-index
+  * JOIN — local or federated — never has a per-leg input truncated (which would silently corrupt
+  * the join). The JOINED output is capped downstream (arrow `JoinExecutor` /
+  * `FederationFlightProducer`).
+  *
+  * The quota '''source''' is exposed via the overridable [[resolveQuota]] seam: the closed
+  * `EnforcedDqlExtension` (priority &lt; 100, in `softclient4es-extensions`) extends this class and
+  * overrides it to the licensed `LicenseManager`, making the paid enforcement un-forkable while
+  * this OSS baseline keeps working for the Community tier.
   */
 //format:on
 class CoreDqlExtension extends ExtensionSpi {
 
-  private var licenseManager: Option[LicenseManager] = None
-  private val logger = org.slf4j.LoggerFactory.getLogger(getClass)
+  protected var licenseManager: Option[LicenseManager] = None
+  protected val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
   override def extensionId: String = "core-dql"
   override def extensionName: String = "Core DQL Quotas"
@@ -99,41 +119,123 @@ class CoreDqlExtension extends ExtensionSpi {
   // ✅ QUOTA CHECK LOGIC (in extension, not in core)
   // ════════════════════════════════════════════════════════════════════
 
-  private def checkQuotasAndExecute(
+  /** The quota source for the result cap. OSS baseline = the initialized `LicenseManager`'s quotas
+    * (Community by default). The closed `EnforcedDqlExtension` overrides this to the '''licensed'''
+    * `LicenseManager` so the paid cap is un-forkable.
+    */
+  protected def resolveQuota(manager: LicenseManager): Quota = manager.quotas
+
+  protected def checkQuotasAndExecute(
     dql: DqlStatement,
     manager: LicenseManager,
     client: ElasticClientApi
   )(implicit system: ActorSystem): Future[ElasticResult[QueryResult]] = {
     implicit val ec: ExecutionContext = system.dispatcher
 
-    val quota = manager.quotas
+    val quota = resolveQuota(manager)
 
     dql match {
       case single: SingleSearch =>
-        single.limit match {
-          case Some(l) if quota.maxQueryResults.exists(_ < l.limit) =>
-            logger.warn(
-              s"⚠️ Query result limit (${l.limit}) exceeds license quota (${quota.maxQueryResults.get})"
-            )
-            Future.successful(
-              ElasticFailure(
-                ElasticError(
-                  message =
-                    s"Query result limit (${l.limit}) exceeds license quota (${quota.maxQueryResults.get}). Upgrade to Pro license.",
-                  statusCode = Some(402),
-                  operation = Some("license")
-                )
-              )
-            )
+        capOrReject(single, quota, client)
 
+      // Defensive: a typed-DSL SelectStatement wrapping a SingleSearch. The parser never emits this
+      // for `run(sql)` (it yields a bare SingleSearch — see the ROUTING VERDICT), but
+      // ExtensionSpi.execute takes a Statement; if some caller hands us a SelectStatement we still
+      // enforce, rather than fall through uncapped.
+      case select: SelectStatement =>
+        select.statement match {
+          case Some(single: SingleSearch) =>
+            capOrReject(single.copy(score = select.score), quota, client)
           case _ =>
-            // Quota OK, execute
-            client.dqlExecutor.execute(single)
+            client.dqlExecutor.execute(dql)
         }
 
       case _ =>
-        // Other DQL types (no quota check needed)
+        // Other DQL types (SHOW…, MultiSearch/UNION, etc.) — no single-index result cap. JOIN paths
+        // are enforced downstream (arrow); UNION is multi-index and out of scope for this story.
         client.dqlExecutor.execute(dql)
     }
+  }
+
+  /** Apply the single-index result-boundary rule (ADR D4) at the (licensed) quota.
+    *   - explicit LIMIT > finite quota → 402 reject (intentional asymmetry)
+    *   - no LIMIT, finite quota, NOT a join leg → cap the scroll + flag truncated
+    *   - explicit LIMIT ≤ quota / unlimited / join leg → execute unchanged
+    */
+  protected def capOrReject(
+    single: SingleSearch,
+    quota: Quota,
+    client: ElasticClientApi
+  )(implicit system: ActorSystem): Future[ElasticResult[QueryResult]] = {
+    implicit val ec: ExecutionContext = system.dispatcher
+
+    (single.limit, quota.maxQueryResults) match {
+      // (1) Explicit LIMIT over a finite quota → hard 402 (UNCHANGED).
+      case (Some(l), Some(max)) if max < l.limit =>
+        logger.warn(
+          s"⚠️ Query result limit (${l.limit}) exceeds license quota ($max)"
+        )
+        Future.successful(
+          ElasticFailure(
+            ElasticError(
+              message =
+                s"Query result limit (${l.limit}) exceeds license quota ($max). Upgrade to Pro license.",
+              statusCode = Some(402),
+              operation = Some("license")
+            )
+          )
+        )
+
+      // (2) No LIMIT, finite quota, the query would take the UNBOUNDED scroll branch, and NOT a
+      //     JOIN leg → cap the scroll stream at `max` via ScrollConfig.maxDocuments (enforced by
+      //     ScrollApi's `.take`) and flag truncation.
+      //
+      //     `single.fields.nonEmpty` MIRRORS `SearchExecutor` (GatewayApi.scala:146): only a
+      //     no-LIMIT query with explicit projection fields takes the unbounded `scroll` branch —
+      //     the ONLY over-quota path. A no-LIMIT query with empty `fields` (aggregations / GROUP BY
+      //     / `SELECT *`) takes the `searchAsync` branch, which ES bounds by
+      //     `index.max_result_window` (≤10k ≤ every tier quota) → can never exceed, needs no cap,
+      //     and must NOT be re-routed to scroll (it would mishandle aggregation buckets). JOIN legs
+      //     (ResultCapContext.isSuppressed) also skip the cap so the join input is not truncated.
+      case (None, Some(max)) if single.fields.nonEmpty && !ResultCapContext.isSuppressed =>
+        logger.info(
+          s"ℹ️ No LIMIT on single-index scroll query; capping the stream at license quota ($max rows) and flagging truncation"
+        )
+        cappedScroll(single, max, client)
+
+      // (3) Explicit LIMIT within quota, OR unlimited quota (Enterprise), OR the bounded
+      //     searchAsync branch (no-LIMIT + empty fields / aggregations), OR a suppressed JOIN leg
+      //     → execute unchanged, no truncation flag.
+      case _ =>
+        client.dqlExecutor.execute(single)
+    }
+  }
+
+  /** Drive the single-index scroll bounded by `maxDocuments = max` and attach a
+    * [[ResultTruncation]] to the produced [[QueryStream]]. `client` is a full `ElasticClientApi`,
+    * which mixes `ScrollApi`, so `scroll(statement, config)` is directly available. The
+    * `searchAsync` branch is intentionally NOT used: it would issue a single `size = max` search,
+    * which Elasticsearch rejects when `max > index.max_result_window` (default 10k) — i.e. for Pro
+    * (1M). Scroll / PIT pages past `max_result_window` natively, serving any N up to the quota
+    * across ES 6/7/8/9.
+    */
+  protected def cappedScroll(
+    single: SingleSearch,
+    max: Int,
+    client: ElasticClientApi
+  )(implicit system: ActorSystem): Future[ElasticResult[QueryResult]] = {
+    implicit val context: ConversionContext = NativeContext
+    val source =
+      client.scroll(single, ScrollConfig(maxDocuments = Some(max.toLong)))
+    val warning =
+      s"Result capped to $max rows (license quota). " +
+      s"Add an explicit LIMIT <= $max, or upgrade for more rows."
+    val signal = ResultTruncation(
+      truncated = true,
+      limit = max.toLong,
+      totalRows = None, // capped at source — pre-cap total intentionally not scanned (OQ-4)
+      warning = warning
+    )
+    Future.successful(ElasticSuccess(QueryStream(source, truncation = Some(signal))))
   }
 }

--- a/core/src/main/scala/app/softnetwork/elastic/client/repl/StreamingReplExecutor.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/repl/StreamingReplExecutor.scala
@@ -62,7 +62,7 @@ class StreamingReplExecutor(gateway: ElasticClientApi)(implicit
         val executionTime = (System.nanoTime() - startTime).nanos
 
         elasticResult match {
-          case ElasticSuccess(QueryStream(source)) =>
+          case ElasticSuccess(QueryStream(source, _)) =>
             // Store stream context for later consumption
             activeStream = Some(StreamContext(source.map(_._1), sql, startTime))
             ExecutionSuccess(

--- a/core/src/main/scala/app/softnetwork/elastic/client/result/CsvFormatter.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/result/CsvFormatter.scala
@@ -23,7 +23,7 @@ object CsvFormatter {
   @tailrec
   def format(result: QueryResult): String = {
     result match {
-      case QueryRows(rows) if rows.nonEmpty =>
+      case QueryRows(rows, _) if rows.nonEmpty =>
         val columns = rows.head.keys.toSeq
         val header = columns.mkString(",")
         val body = rows
@@ -33,7 +33,7 @@ object CsvFormatter {
           .mkString("\n")
         s"$header\n$body"
 
-      case QueryStructured(response) if response.results.nonEmpty =>
+      case QueryStructured(response, _) if response.results.nonEmpty =>
         format(QueryRows(response.results))
 
       case _ =>

--- a/core/src/main/scala/app/softnetwork/elastic/client/result/JsonFormatter.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/result/JsonFormatter.scala
@@ -27,7 +27,7 @@ object JsonFormatter {
 
   def format(result: QueryResult, executionTime: Duration): String = {
     result match {
-      case QueryRows(rows) =>
+      case QueryRows(rows, _) =>
         val json = JObject(
           "rows"              -> JArray(rows.map(rowToJson).toList),
           "count"             -> JInt(rows.size),
@@ -35,7 +35,7 @@ object JsonFormatter {
         )
         pretty(render(json))
 
-      case QueryStructured(response) =>
+      case QueryStructured(response, _) =>
         val json = JObject(
           "rows"              -> JArray(response.results.map(rowToJson).toList),
           "count"             -> JInt(response.results.size),

--- a/core/src/main/scala/app/softnetwork/elastic/client/result/ResultRenderer.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/result/ResultRenderer.scala
@@ -48,10 +48,10 @@ object ResultRenderer {
       case EmptyResult =>
         renderEmpty()
 
-      case QueryRows(rows) =>
+      case QueryRows(rows, _) =>
         renderTable(rows, executionTime)
 
-      case QueryStructured(response) =>
+      case QueryStructured(response, _) =>
         renderTable(response.results, executionTime)
 
       case DmlResult(inserted, updated, deleted, rejected) =>
@@ -69,7 +69,7 @@ object ResultRenderer {
       case SQLResult(sql) =>
         renderSql(sql)
 
-      case QueryStream(_) =>
+      case QueryStream(_, _) =>
         renderStreamInfo()
 
       case StreamResult(estimatedSize, _) =>

--- a/core/src/main/scala/app/softnetwork/elastic/client/result/package.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/result/package.scala
@@ -393,17 +393,60 @@ package object result {
     def empty: QueryResult = EmptyResult
   }
 
+  /** Truncation metadata for a result that was capped at its source.
+    *
+    * Mirrors the JOIN path's `TruncationResult` (arrow `JoinLicenseGuard`) so single-index
+    * truncation surfaces through the identical driver channels: JDBC/ADBC `SQLWarning` SQLState
+    * `"01004"` and Flight schema metadata `x-result-truncated` / `x-result-total-rows` /
+    * `x-result-limit`.
+    *
+    * `totalRows = None` when the pre-cap total is unknown (the result was capped at the source and
+    * the stream never scanned past the limit — by design; see Story P0.5 OQ-4).
+    *
+    * @param truncated
+    *   whether the result was actually capped (rows available exceeded the limit)
+    * @param limit
+    *   the row-count cap that was applied (the licensed `maxQueryResults`)
+    * @param totalRows
+    *   the true pre-cap total when cheaply known (scroll first-response `hits.total`), else `None`
+    * @param warning
+    *   a human-readable, tier-aware message reusable verbatim as the `"01004"` `SQLWarning` text
+    */
+  case class ResultTruncation(
+    truncated: Boolean,
+    limit: Long,
+    totalRows: Option[Long],
+    warning: String
+  )
+
   // --------------------
   // DQL (SELECT)
   // --------------------
-  case class QueryRows(rows: Seq[ListMap[String, Any]]) extends QueryResult
 
-  case class QueryStream(
-    stream: Source[(ListMap[String, Any], ScrollMetrics), NotUsed]
+  /** A materialized set of result rows.
+    *
+    * Story P0.5: the additive, default-`None` `truncation` field carries the single-index result
+    * cap signal. Because the field has a default value, every `QueryRows(rows)` '''constructor'''
+    * call across core / arrow / jdbc keeps compiling unchanged. Positional '''pattern''' matches
+    * (`case QueryRows(rows)`) must add a trailing `_` (`case QueryRows(rows, _)`) — the compiler's
+    * synthetic extractor now binds both fields. (A custom 1-arg companion `unapply` was rejected:
+    * Scala 2.12 still prefers the synthetic 2-arg extractor, so it is not cross-version safe.)
+    */
+  case class QueryRows(
+    rows: Seq[ListMap[String, Any]],
+    truncation: Option[ResultTruncation] = None
   ) extends QueryResult
 
-  case class QueryStructured(response: ElasticResponse) extends QueryResult {
-    def asQueryRows: QueryRows = QueryRows(response.results)
+  case class QueryStream(
+    stream: Source[(ListMap[String, Any], ScrollMetrics), NotUsed],
+    truncation: Option[ResultTruncation] = None
+  ) extends QueryResult
+
+  case class QueryStructured(
+    response: ElasticResponse,
+    truncation: Option[ResultTruncation] = None
+  ) extends QueryResult {
+    def asQueryRows: QueryRows = QueryRows(response.results, truncation)
   }
 
   case class StreamResult(

--- a/core/src/test/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtensionSpec.scala
+++ b/core/src/test/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtensionSpec.scala
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client.extensions
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
+import app.softnetwork.elastic.client._
+import app.softnetwork.elastic.client.result._
+import app.softnetwork.elastic.client.scroll.{ScrollConfig, ScrollMetrics}
+import app.softnetwork.elastic.licensing._
+import app.softnetwork.elastic.sql.parser.Parser
+import app.softnetwork.elastic.sql.query.{SearchStatement, SelectStatement, SingleSearch}
+import com.typesafe.config.ConfigFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.collection.immutable.ListMap
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/** Unit tests for [[CoreDqlExtension]] — the Community-baseline single-index result cap (Story
+  * P0.5). No Docker / no Elasticsearch: a recording [[NopeClientApi]] captures the forwarded
+  * [[SearchStatement]] and the [[ScrollConfig]] so we assert the cap DECISION and the attached
+  * [[ResultTruncation]] directly.
+  *
+  * Seam (OQ-2 resolution): the production `CoreDqlExtension` drives `client.scroll(single, config)`
+  * for the no-LIMIT cap path and `client.dqlExecutor.execute(single)` (→ `SearchExecutor` →
+  * `scroll`/`searchAsync`) for the passthrough paths. The test client overrides BOTH `scroll` and
+  * `searchAsync` to record, so every branch is observable without a full ES stub or a `dqlExecutor`
+  * spy (which is a concrete `lazy val DqlRouterExecutor` and not cleanly mockable).
+  */
+class CoreDqlExtensionSpec extends AnyFlatSpec with Matchers {
+
+  implicit val system: ActorSystem = ActorSystem("core-dql-extension-test")
+
+  private val testLogger: Logger = LoggerFactory.getLogger(getClass)
+
+  // ---- license-manager + strategy stubs (mirror LicenseExecutorSpec) ----
+
+  private def managerWithQuota(q: Quota, tier: LicenseType): LicenseManager =
+    new LicenseManager {
+      override def validate(key: String): Either[LicenseError, LicenseKey] =
+        Left(InvalidLicense("test"))
+      override def hasFeature(feature: Feature): Boolean = true
+      override def quotas: Quota = q
+      override def licenseType: LicenseType = tier
+    }
+
+  private def strategy(mgr: LicenseManager): LicenseRefreshStrategy =
+    new LicenseRefreshStrategy {
+      override def initialize(): LicenseKey = LicenseKey.Community
+      override def refresh(): Either[LicenseError, LicenseKey] = Left(RefreshNotSupported)
+      override def licenseManager: LicenseManager = mgr
+    }
+
+  /** Records every statement forwarded to the scroll / searchAsync seam plus the scroll config, so
+    * tests can assert the cap decision (which path, what maxDocuments).
+    */
+  private class RecordingClient extends NopeClientApi {
+    override protected def logger: Logger = testLogger
+
+    val scrolledStatement = new AtomicReference[SearchStatement]()
+    val scrolledConfig = new AtomicReference[ScrollConfig]()
+    val searchedStatement = new AtomicReference[SearchStatement]()
+
+    override def scroll(
+      statement: SearchStatement,
+      config: ScrollConfig = ScrollConfig()
+    )(implicit
+      system: ActorSystem,
+      context: ConversionContext
+    ): Source[(ListMap[String, Any], ScrollMetrics), NotUsed] = {
+      scrolledStatement.set(statement)
+      scrolledConfig.set(config)
+      Source.empty[(ListMap[String, Any], ScrollMetrics)]
+    }
+
+    override def searchAsync(
+      statement: SearchStatement
+    )(implicit
+      ec: scala.concurrent.ExecutionContext,
+      context: ConversionContext
+    ): scala.concurrent.Future[ElasticResult[ElasticResponse]] = {
+      searchedStatement.set(statement)
+      scala.concurrent.Future.successful(
+        ElasticSuccess(
+          ElasticResponse(
+            sql = None,
+            query = "{}",
+            results = Seq(ListMap[String, Any]("ok" -> 1)),
+            fieldAliases = ListMap.empty,
+            aggregations = ListMap.empty
+          )
+        )
+      )
+    }
+  }
+
+  private def newExtension(quota: Quota, tier: LicenseType): CoreDqlExtension = {
+    val ext = new CoreDqlExtension()
+    ext.initialize(ConfigFactory.empty(), strategy(managerWithQuota(quota, tier)))
+    ext
+  }
+
+  private def run(
+    sql: String,
+    quota: Quota,
+    tier: LicenseType = LicenseType.Community
+  ): (RecordingClient, ElasticResult[QueryResult]) = {
+    val parsed = Parser(sql) match {
+      case Right(s) => s
+      case Left(e)  => fail(s"parse failed: ${e.msg}")
+    }
+    val client = new RecordingClient()
+    val ext = newExtension(quota, tier)
+    val res = Await.result(ext.execute(parsed, client), 5.seconds)
+    (client, res)
+  }
+
+  private def truncationOf(res: ElasticResult[QueryResult]): Option[ResultTruncation] =
+    res.asInstanceOf[ElasticSuccess[QueryResult]].value match {
+      case q: QueryRows       => q.truncation
+      case q: QueryStream     => q.truncation
+      case q: QueryStructured => q.truncation
+      case other              => fail(s"unexpected result variant: $other")
+    }
+
+  // ---- AC-6: routing verdict guard ----
+
+  behavior of "CoreDqlExtension routing"
+
+  it should "parse a single-index SELECT to a bare SingleSearch (not SelectStatement)" in {
+    Parser("SELECT a, b FROM idx") match {
+      case Right(_: SingleSearch) => succeed
+      case Right(_: SelectStatement) =>
+        fail("parser wrapped SELECT in SelectStatement — routing assumption broken")
+      case other => fail(s"unexpected parse result: $other")
+    }
+  }
+
+  // ---- AC-1 + AC-2: no-LIMIT on Community → capped scroll + truncation ----
+
+  behavior of "CoreDqlExtension no-LIMIT cap (Community)"
+
+  it should "drive a capped scroll (maxDocuments = quota) and flag truncation for a no-LIMIT single-index query" in {
+    val (client, res) = run("SELECT a, b FROM idx", Quota.Community)
+
+    res shouldBe a[ElasticSuccess[_]]
+
+    // AC-1: the scroll was driven bounded by maxDocuments = the Community quota.
+    client.scrolledStatement.get() shouldBe a[SingleSearch]
+    client.scrolledConfig.get().maxDocuments shouldBe Some(10000L)
+    // searchAsync must NOT be used for the over-quota path (would hit max_result_window on Pro).
+    client.searchedStatement.get() shouldBe null
+
+    // AC-2: truncation present and non-silent.
+    val trunc = truncationOf(res)
+    trunc.map(_.truncated) shouldBe Some(true)
+    trunc.map(_.limit) shouldBe Some(10000L)
+    trunc.flatMap(t => Some(t.warning)).getOrElse("") should not be empty
+  }
+
+  it should "cap a no-LIMIT query at the Pro quota (1,000,000) via scroll, never searchAsync" in {
+    val (client, res) = run("SELECT a, b FROM idx", Quota.Pro, LicenseType.Pro)
+
+    res shouldBe a[ElasticSuccess[_]]
+    client.scrolledConfig.get().maxDocuments shouldBe Some(1000000L)
+    client.searchedStatement.get() shouldBe null
+    truncationOf(res).map(_.limit) shouldBe Some(1000000L)
+  }
+
+  // ---- AC-3: explicit LIMIT within quota → untouched, no flag ----
+
+  behavior of "CoreDqlExtension explicit LIMIT within quota"
+
+  it should "forward an explicit LIMIT <= quota unchanged with no truncation flag" in {
+    val (client, res) = run("SELECT a FROM idx LIMIT 50", Quota.Community)
+
+    res shouldBe a[ElasticSuccess[_]]
+    // limit defined → SearchExecutor routes to searchAsync, not the capped scroll.
+    client.searchedStatement.get() match {
+      case s: SingleSearch => s.limit.map(_.limit) shouldBe Some(50)
+      case other           => fail(s"expected SingleSearch via searchAsync, got $other")
+    }
+    client.scrolledConfig.get() shouldBe null
+    truncationOf(res) shouldBe None
+  }
+
+  // ---- searchAsync-branch carve-out: no-LIMIT aggregation / empty-fields query is NOT capped ----
+
+  behavior of "CoreDqlExtension searchAsync-branch carve-out"
+
+  it should "NOT cap a no-LIMIT aggregation query (empty fields → searchAsync, bounded by max_result_window)" in {
+    // GROUP BY ⇒ SingleSearch.fields is empty ⇒ SearchExecutor routes to searchAsync, which ES
+    // bounds by index.max_result_window (≤10k ≤ quota). Capping it would mishandle aggregation
+    // buckets and re-route to scroll, so the cap MUST fall through to plain execution.
+    val (client, res) = run("SELECT category, count(*) FROM idx GROUP BY category", Quota.Community)
+
+    res shouldBe a[ElasticSuccess[_]]
+    // executed via searchAsync, NOT the capped scroll, and NOT truncation-flagged.
+    client.searchedStatement.get() shouldBe a[SingleSearch]
+    client.scrolledConfig.get() shouldBe null
+    truncationOf(res) shouldBe None
+  }
+
+  // ---- AC-4: explicit LIMIT over quota → 402 (intentional asymmetry) ----
+
+  behavior of "CoreDqlExtension explicit LIMIT over quota"
+
+  it should "reject an explicit LIMIT > quota with HTTP 402 (no truncation, no execution)" in {
+    val (client, res) = run("SELECT a FROM idx LIMIT 20000", Quota.Community)
+
+    res shouldBe a[ElasticFailure]
+    val err = res.asInstanceOf[ElasticFailure].elasticError
+    err.statusCode shouldBe Some(402)
+    err.operation shouldBe Some("license")
+    // never forwarded to any execution seam
+    client.scrolledStatement.get() shouldBe null
+    client.searchedStatement.get() shouldBe null
+  }
+
+  // ---- AC-5: Enterprise (unlimited) → uncapped ----
+
+  behavior of "CoreDqlExtension Enterprise unlimited"
+
+  it should "not cap a no-LIMIT query when maxQueryResults is None (Enterprise)" in {
+    val (client, res) = run("SELECT a, b FROM idx", Quota.Enterprise, LicenseType.Enterprise)
+
+    res shouldBe a[ElasticSuccess[_]]
+    // no-LIMIT + unlimited quota → plain passthrough scroll with the DEFAULT config (no cap).
+    client.scrolledStatement.get() shouldBe a[SingleSearch]
+    client.scrolledConfig.get().maxDocuments shouldBe None
+    truncationOf(res) shouldBe None
+  }
+
+  it should "not reject an arbitrarily large explicit LIMIT on Enterprise" in {
+    val (client, res) =
+      run("SELECT a FROM idx LIMIT 50000000", Quota.Enterprise, LicenseType.Enterprise)
+    res shouldBe a[ElasticSuccess[_]]
+    client.searchedStatement.get() match {
+      case s: SingleSearch => s.limit.map(_.limit) shouldBe Some(50000000)
+      case other           => fail(s"expected SingleSearch via searchAsync, got $other")
+    }
+  }
+
+  // ---- AC (join-leg carve-out): suppress flag bypasses the cap ----
+
+  behavior of "CoreDqlExtension join-leg suppression"
+
+  it should "NOT cap a no-LIMIT query when ResultCapContext is suppressed (a JOIN leg)" in {
+    val parsed = Parser("SELECT a, b FROM idx") match {
+      case Right(s) => s
+      case Left(e)  => fail(s"parse failed: ${e.msg}")
+    }
+    val client = new RecordingClient()
+    val ext = newExtension(Quota.Community, LicenseType.Community)
+
+    val res = ResultCapContext.suppressed {
+      Await.result(ext.execute(parsed, client), 5.seconds)
+    }
+
+    res shouldBe a[ElasticSuccess[_]]
+    // suppressed → falls through to the plain passthrough scroll (default config, no cap), and
+    // carries NO truncation flag, so the JOIN input is not silently truncated.
+    client.scrolledStatement.get() shouldBe a[SingleSearch]
+    client.scrolledConfig.get().maxDocuments shouldBe None
+    truncationOf(res) shouldBe None
+  }
+}

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/GatewayIntegrationTestKit.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/GatewayIntegrationTestKit.scala
@@ -117,7 +117,7 @@ trait GatewayIntegrationTestKit extends AnyFlatSpecLike with Matchers with Scala
     }
     res.isSuccess shouldBe true
     res.toOption.get match {
-      case QueryStream(stream) =>
+      case QueryStream(stream, _) =>
         val sink =
           Sink.fold[Seq[ListMap[String, Any]], (ListMap[String, Any], ScrollMetrics)](Seq.empty) {
             case (acc, (row, _)) =>
@@ -133,7 +133,7 @@ trait GatewayIntegrationTestKit extends AnyFlatSpecLike with Matchers with Scala
         } else {
           log.info(s"Rows: $results")
         }
-      case QueryStructured(response) =>
+      case QueryStructured(response, _) =>
         renderResults(startTime, res)
         val results =
           response.results.map(normalizeRow)
@@ -213,7 +213,7 @@ trait GatewayIntegrationTestKit extends AnyFlatSpecLike with Matchers with Scala
     renderResults(startTime, res)
     res.isSuccess shouldBe true
     res.toOption.get match {
-      case QueryStream(stream) =>
+      case QueryStream(stream, _) =>
         val sink =
           Sink.fold[Seq[ListMap[String, Any]], (ListMap[String, Any], ScrollMetrics)](Seq.empty) {
             case (acc, (row, _)) => acc :+ normalizeRow(row)
@@ -221,7 +221,7 @@ trait GatewayIntegrationTestKit extends AnyFlatSpecLike with Matchers with Scala
         stream.runWith(sink).futureValue
       case q: QueryRows =>
         q.rows.map(normalizeRow)
-      case QueryStructured(response) =>
+      case QueryStructured(response, _) =>
         response.results.map(normalizeRow)
       case other =>
         fail(s"Unexpected QueryResult type for SELECT: $other")

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/repl/ReplGatewayIntegrationSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/repl/ReplGatewayIntegrationSpec.scala
@@ -1259,7 +1259,7 @@ trait ReplGatewayIntegrationSpec extends ReplIntegrationTestKit {
 
     val watcherStatus = executeSync("SHOW WATCHER STATUS my_watcher_interval")
     watcherStatus match {
-      case ExecutionSuccess(QueryRows(rows), _) =>
+      case ExecutionSuccess(QueryRows(rows, _), _) =>
         rows.size shouldBe 1
         val row = rows.head
         log.info(s"Watcher Status: $row")
@@ -1272,7 +1272,7 @@ trait ReplGatewayIntegrationSpec extends ReplIntegrationTestKit {
     if (supportsQueryWatchers) {
       val watchers = executeSync("SHOW WATCHERS")
       watchers match {
-        case ExecutionSuccess(QueryRows(rows), _) =>
+        case ExecutionSuccess(QueryRows(rows, _), _) =>
           rows.find(row => row.get("id").contains("my_watcher_interval")) match {
             case Some(row) =>
               row.get("is_healthy") shouldBe Some(true)
@@ -1365,7 +1365,7 @@ trait ReplGatewayIntegrationSpec extends ReplIntegrationTestKit {
     val executePolicy = "EXECUTE ENRICH POLICY my_policy"
     val result = executeSync(executePolicy)
     result match {
-      case ExecutionSuccess(QueryRows(rows), _) =>
+      case ExecutionSuccess(QueryRows(rows, _), _) =>
         rows.size shouldBe 1
         val row = rows.head
         log.info(s"Policy Execution Result: $row")

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/repl/ReplIntegrationTestKit.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/repl/ReplIntegrationTestKit.scala
@@ -156,7 +156,7 @@ trait ReplIntegrationTestKit
 
     val success = res.asInstanceOf[ExecutionSuccess]
     success.result match {
-      case QueryStream(stream) =>
+      case QueryStream(stream, _) =>
         val sink = Sink.fold[Seq[Map[String, Any]], (Map[String, Any], ScrollMetrics)](Seq.empty) {
           case (acc, (row, _)) => acc :+ normalizeRow(row)
         }
@@ -170,7 +170,7 @@ trait ReplIntegrationTestKit
           log.info(s"Rows: $results")
         }
 
-      case QueryStructured(response) =>
+      case QueryStructured(response, _) =>
         val results = response.results.map(normalizeRow)
         if (rows.nonEmpty) {
           results.size shouldBe rows.size


### PR DESCRIPTION
Closes #127. Epic pricing-repackaging Phase 0, story P0.5 (leg 1 of 3: elasticsql-core).

## What
Close the advertised `maxQueryResults` quota gap for single-index `SELECT … FROM idx` queries with NO `LIMIT`. elasticsql-core provides the license-agnostic MECHANISM + the Community baseline.

## Design (= ScrollConfig.maxDocuments mechanism + EnforcedDqlExtension + arrow join-leg suppression)
- **NEW `ResultCapContext`** — thread-scoped `applyResultCap` suppress carrier (`DynamicVariable[Boolean]`, default = apply cap). `run(sql:String)` / `ExtensionSpi.execute` have no per-call flag slot and the cap decision runs synchronously before the first Future/ES boundary, so a thread-local read observes what the join-leg executor (local) / inbound-header middleware (federation) set around `run`. Consumed by softclient4es-arrow (leg 3).
- **Additive `ResultTruncation`** + default-`None` `truncation` on `QueryRows`/`QueryStream`/`QueryStructured` — source-compatible (constructors unchanged; positional matches updated `, _`). A custom 1-arg `unapply` was rejected: not Scala 2.12-safe.
- **`CoreDqlExtension` Community baseline:** explicit-`LIMIT`>quota → 402 (unchanged); no-`LIMIT` + finite quota + `fields.nonEmpty` (mirrors `SearchExecutor` scroll-branch — aggregations/`SELECT *` stay on bounded `searchAsync`, never re-routed) + not-suppressed → capped scroll via `ScrollConfig.maxDocuments` + `ResultTruncation`. `resolveQuota` seam lets the closed `EnforcedDqlExtension` (extensions leg) override to the licensed quota. NOT inject-`LIMIT`/flip-to-`searchAsync` (breaks Pro: 1M > `index.max_result_window`).

## Verification
`+ core/compile` (2.12 + 2.13), 9 new `CoreDqlExtensionSpec` + 12 `LicenseExecutorSpec` + 5 `ResultRendererSpec` green, headerCheck clean.

## Sibling PRs (same story)
- softclient4es-extensions: `EnforcedDqlExtension` (licensed-quota override) — feature/P0.5
- softclient4es-arrow: join-leg cap suppression (`LocalConnection` + `DownstreamConnection` header + sidecar middleware) + BLOCKING join-correctness Docker test — feature/P0.5

## Note
softclient4es-jdbc has 5 positional `QueryResult` pattern matches that will need `, _` at its next rebuild against this core SNAPSHOT (out of P0.5 scope, flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)