### PR TITLE
Release R1 — v0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ For programmatic access, add SoftClient4ES to your project.
 resolvers += "Softnetwork" at "https://softnetwork.jfrog.io/artifactory/releases/"
 
 // Choose your Elasticsearch version
-libraryDependencies += "app.softnetwork.elastic" %% "softclient4es8-java-client" % "0.19.0"
+libraryDependencies += "app.softnetwork.elastic" %% "softclient4es8-java-client" % "0.20.0"
 // Add the community extensions for materialized views (optional)
 libraryDependencies += "app.softnetwork.elastic" %% "softclient4es-community-extensions" % "0.1.4"
 // Add the JDBC driver if you want to use it from Scala (optional)

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ ThisBuild / organization := "app.softnetwork"
 
 name := "softclient4es"
 
-ThisBuild / version := "0.20-SNAPSHOT"
+ThisBuild / version := "0.20.0"
 
 ThisBuild / scalaVersion := scala213
 

--- a/core/src/main/scala/app/softnetwork/elastic/client/GatewayApi.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/GatewayApi.scala
@@ -1636,7 +1636,6 @@ class LicenseExecutor(
       "max_materialized_views" -> formatQuota(mgr.quotas.maxMaterializedViews),
       "max_clusters"           -> formatQuota(mgr.quotas.maxClusters),
       "max_result_rows"        -> formatQuota(mgr.quotas.maxQueryResults),
-      "max_concurrent_queries" -> formatQuota(mgr.quotas.maxConcurrentQueries),
       "max_joins"              -> formatQuota(mgr.quotas.maxJoins),
       "expires_at"             -> formatExpiry(key.expiresAt),
       "days_remaining"         -> key.daysRemaining.getOrElse(-1L),

--- a/core/src/main/scala/app/softnetwork/elastic/client/ResultCapContext.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/ResultCapContext.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import scala.util.DynamicVariable
+
+/** Execution-scoped carrier for the per-call "suppress the single-index result cap" signal (Story
+  * P0.5, ADR §D4.1 / Architecture Decision AD-1).
+  *
+  * This is a license-agnostic '''mechanism''' that lives in the Apache core. It carries NO quota
+  * value and makes NO enforcement decision — it only records, for the duration of one
+  * `gateway.run(...)` call on the current thread, whether that call is a JOIN '''leg''' (whose
+  * input must NOT be capped, or the join silently returns wrong results) versus a direct
+  * single-index query (which IS capped at the licensed `maxQueryResults`).
+  *
+  * ==Why a thread-scoped carrier and not a method/implicit parameter==
+  *
+  * Every read path — direct query AND join leg — funnels through `GatewayApi.run(sql: String)` →
+  * `run(statement)` → `ExtensionRegistry.findHandler(statement).execute(statement, client)`. None
+  * of those signatures has a slot for a per-call flag, and widening them would ripple across all ES
+  * clients, every `Executor`, and the arrow streaming seam. The cap '''decision''' (which lives in
+  * the closed `EnforcedDqlExtension`) is taken '''synchronously on the caller thread''', before the
+  * first `Future`/Elasticsearch boundary, so a thread-scoped read observes the value the leg
+  * executor (local joins) or the inbound-header middleware (federation legs) set around the `run`
+  * call. The boolean rests on the single-license-per-deployment invariant (the sidecar already
+  * knows its own cap, so only a boolean — not an explicit row count — needs to ride the wire).
+  *
+  * Default = `false` (do NOT suppress → the cap applies). Join-leg executors flip it to `true` only
+  * for the scope of the leg.
+  */
+object ResultCapContext {
+
+  private val suppress: DynamicVariable[Boolean] = new DynamicVariable[Boolean](false)
+
+  /** `true` when the current call is a JOIN leg and the single-index result cap must be skipped. */
+  def isSuppressed: Boolean = suppress.value
+
+  /** Run `body` with cap suppression enabled for the current thread (and any synchronous callee on
+    * it), restoring the previous value on exit. Used by the arrow join-leg executors
+    * (`LocalConnection.execute` for local joins; the inbound-header middleware for federation legs)
+    * to wrap the `gateway.run(...)` that materializes a leg.
+    */
+  def suppressed[T](body: => T): T = suppress.withValue(true)(body)
+
+  /** Run `body` with an explicit suppression value (rarely needed; prefer [[suppressed]]). */
+  def withSuppressed[T](value: Boolean)(body: => T): T = suppress.withValue(value)(body)
+}

--- a/core/src/main/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtension.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtension.scala
@@ -19,6 +19,7 @@ package app.softnetwork.elastic.client.extensions
 import akka.actor.ActorSystem
 import app.softnetwork.elastic.client._
 import app.softnetwork.elastic.client.result._
+import app.softnetwork.elastic.client.scroll.ScrollConfig
 import app.softnetwork.elastic.licensing._
 import app.softnetwork.elastic.sql.query._
 import com.typesafe.config.Config
@@ -33,12 +34,31 @@ import scala.concurrent.{ExecutionContext, Future}
   * ✅ Applies Community quotas by default
   * ✅ Can be upgraded with Pro license
   * }}}
+  *
+  * Story P0.5 — this is the '''Community baseline''' handler (priority 100, Apache-OSS, always
+  * loaded). It applies two single-index result-boundary rules at the licensed `maxQueryResults`:
+  *
+  *   1. explicit `LIMIT` > finite quota → hard `402` reject (unchanged, intentional asymmetry); 2.
+  *      no `LIMIT` + finite quota + NOT a JOIN leg → drive the scroll bounded by
+  *      `ScrollConfig.maxDocuments = maxQueryResults` (enforced by the existing `.take` at
+  *      `ScrollApi`), and attach an additive [[ResultTruncation]] so the truncation is never
+  *      silent.
+  *
+  * The cap is '''suppressed for JOIN legs''' ([[ResultCapContext.isSuppressed]]) so a cross-index
+  * JOIN — local or federated — never has a per-leg input truncated (which would silently corrupt
+  * the join). The JOINED output is capped downstream (arrow `JoinExecutor` /
+  * `FederationFlightProducer`).
+  *
+  * The quota '''source''' is exposed via the overridable [[resolveQuota]] seam: the closed
+  * `EnforcedDqlExtension` (priority &lt; 100, in `softclient4es-extensions`) extends this class and
+  * overrides it to the licensed `LicenseManager`, making the paid enforcement un-forkable while
+  * this OSS baseline keeps working for the Community tier.
   */
 //format:on
 class CoreDqlExtension extends ExtensionSpi {
 
-  private var licenseManager: Option[LicenseManager] = None
-  private val logger = org.slf4j.LoggerFactory.getLogger(getClass)
+  protected var licenseManager: Option[LicenseManager] = None
+  protected val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
   override def extensionId: String = "core-dql"
   override def extensionName: String = "Core DQL Quotas"
@@ -99,41 +119,123 @@ class CoreDqlExtension extends ExtensionSpi {
   // ✅ QUOTA CHECK LOGIC (in extension, not in core)
   // ════════════════════════════════════════════════════════════════════
 
-  private def checkQuotasAndExecute(
+  /** The quota source for the result cap. OSS baseline = the initialized `LicenseManager`'s quotas
+    * (Community by default). The closed `EnforcedDqlExtension` overrides this to the '''licensed'''
+    * `LicenseManager` so the paid cap is un-forkable.
+    */
+  protected def resolveQuota(manager: LicenseManager): Quota = manager.quotas
+
+  protected def checkQuotasAndExecute(
     dql: DqlStatement,
     manager: LicenseManager,
     client: ElasticClientApi
   )(implicit system: ActorSystem): Future[ElasticResult[QueryResult]] = {
     implicit val ec: ExecutionContext = system.dispatcher
 
-    val quota = manager.quotas
+    val quota = resolveQuota(manager)
 
     dql match {
       case single: SingleSearch =>
-        single.limit match {
-          case Some(l) if quota.maxQueryResults.exists(_ < l.limit) =>
-            logger.warn(
-              s"⚠️ Query result limit (${l.limit}) exceeds license quota (${quota.maxQueryResults.get})"
-            )
-            Future.successful(
-              ElasticFailure(
-                ElasticError(
-                  message =
-                    s"Query result limit (${l.limit}) exceeds license quota (${quota.maxQueryResults.get}). Upgrade to Pro license.",
-                  statusCode = Some(402),
-                  operation = Some("license")
-                )
-              )
-            )
+        capOrReject(single, quota, client)
 
+      // Defensive: a typed-DSL SelectStatement wrapping a SingleSearch. The parser never emits this
+      // for `run(sql)` (it yields a bare SingleSearch — see the ROUTING VERDICT), but
+      // ExtensionSpi.execute takes a Statement; if some caller hands us a SelectStatement we still
+      // enforce, rather than fall through uncapped.
+      case select: SelectStatement =>
+        select.statement match {
+          case Some(single: SingleSearch) =>
+            capOrReject(single.copy(score = select.score), quota, client)
           case _ =>
-            // Quota OK, execute
-            client.dqlExecutor.execute(single)
+            client.dqlExecutor.execute(dql)
         }
 
       case _ =>
-        // Other DQL types (no quota check needed)
+        // Other DQL types (SHOW…, MultiSearch/UNION, etc.) — no single-index result cap. JOIN paths
+        // are enforced downstream (arrow); UNION is multi-index and out of scope for this story.
         client.dqlExecutor.execute(dql)
     }
+  }
+
+  /** Apply the single-index result-boundary rule (ADR D4) at the (licensed) quota.
+    *   - explicit LIMIT > finite quota → 402 reject (intentional asymmetry)
+    *   - no LIMIT, finite quota, NOT a join leg → cap the scroll + flag truncated
+    *   - explicit LIMIT ≤ quota / unlimited / join leg → execute unchanged
+    */
+  protected def capOrReject(
+    single: SingleSearch,
+    quota: Quota,
+    client: ElasticClientApi
+  )(implicit system: ActorSystem): Future[ElasticResult[QueryResult]] = {
+    implicit val ec: ExecutionContext = system.dispatcher
+
+    (single.limit, quota.maxQueryResults) match {
+      // (1) Explicit LIMIT over a finite quota → hard 402 (UNCHANGED).
+      case (Some(l), Some(max)) if max < l.limit =>
+        logger.warn(
+          s"⚠️ Query result limit (${l.limit}) exceeds license quota ($max)"
+        )
+        Future.successful(
+          ElasticFailure(
+            ElasticError(
+              message =
+                s"Query result limit (${l.limit}) exceeds license quota ($max). Upgrade to Pro license.",
+              statusCode = Some(402),
+              operation = Some("license")
+            )
+          )
+        )
+
+      // (2) No LIMIT, finite quota, the query would take the UNBOUNDED scroll branch, and NOT a
+      //     JOIN leg → cap the scroll stream at `max` via ScrollConfig.maxDocuments (enforced by
+      //     ScrollApi's `.take`) and flag truncation.
+      //
+      //     `single.fields.nonEmpty` MIRRORS `SearchExecutor` (GatewayApi.scala:146): only a
+      //     no-LIMIT query with explicit projection fields takes the unbounded `scroll` branch —
+      //     the ONLY over-quota path. A no-LIMIT query with empty `fields` (aggregations / GROUP BY
+      //     / `SELECT *`) takes the `searchAsync` branch, which ES bounds by
+      //     `index.max_result_window` (≤10k ≤ every tier quota) → can never exceed, needs no cap,
+      //     and must NOT be re-routed to scroll (it would mishandle aggregation buckets). JOIN legs
+      //     (ResultCapContext.isSuppressed) also skip the cap so the join input is not truncated.
+      case (None, Some(max)) if single.fields.nonEmpty && !ResultCapContext.isSuppressed =>
+        logger.info(
+          s"ℹ️ No LIMIT on single-index scroll query; capping the stream at license quota ($max rows) and flagging truncation"
+        )
+        cappedScroll(single, max, client)
+
+      // (3) Explicit LIMIT within quota, OR unlimited quota (Enterprise), OR the bounded
+      //     searchAsync branch (no-LIMIT + empty fields / aggregations), OR a suppressed JOIN leg
+      //     → execute unchanged, no truncation flag.
+      case _ =>
+        client.dqlExecutor.execute(single)
+    }
+  }
+
+  /** Drive the single-index scroll bounded by `maxDocuments = max` and attach a
+    * [[ResultTruncation]] to the produced [[QueryStream]]. `client` is a full `ElasticClientApi`,
+    * which mixes `ScrollApi`, so `scroll(statement, config)` is directly available. The
+    * `searchAsync` branch is intentionally NOT used: it would issue a single `size = max` search,
+    * which Elasticsearch rejects when `max > index.max_result_window` (default 10k) — i.e. for Pro
+    * (1M). Scroll / PIT pages past `max_result_window` natively, serving any N up to the quota
+    * across ES 6/7/8/9.
+    */
+  protected def cappedScroll(
+    single: SingleSearch,
+    max: Int,
+    client: ElasticClientApi
+  )(implicit system: ActorSystem): Future[ElasticResult[QueryResult]] = {
+    implicit val context: ConversionContext = NativeContext
+    val source =
+      client.scroll(single, ScrollConfig(maxDocuments = Some(max.toLong)))
+    val warning =
+      s"Result capped to $max rows (license quota). " +
+      s"Add an explicit LIMIT <= $max, or upgrade for more rows."
+    val signal = ResultTruncation(
+      truncated = true,
+      limit = max.toLong,
+      totalRows = None, // capped at source — pre-cap total intentionally not scanned (OQ-4)
+      warning = warning
+    )
+    Future.successful(ElasticSuccess(QueryStream(source, truncation = Some(signal))))
   }
 }

--- a/core/src/main/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtension.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtension.scala
@@ -60,6 +60,15 @@ class CoreDqlExtension extends ExtensionSpi {
   protected var licenseManager: Option[LicenseManager] = None
   protected val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
+  /** Story P0.6 -- the cap-hit collector captured at `initialize`. It is the SAME per-strategy
+    * `TelemetryCollector` that `GatewayApi.run` increments for `queriesTotal`, so a `QueryResults`
+    * cap-hit recorded here rides the existing `InstancePing` delta to the license-server. Defaults
+    * to `Noop` until initialized (or if no strategy carries a real collector). The closed
+    * `EnforcedDqlExtension` (priority &lt; 100) extends this class and inherits the increment via
+    * the shared `capOrReject`, so the paid enforcement path counts cap-hits too.
+    */
+  protected var capHitCollector: TelemetryCollector = TelemetryCollector.Noop
+
   override def extensionId: String = "core-dql"
   override def extensionName: String = "Core DQL Quotas"
   override def version: String = "0.1.0"
@@ -70,6 +79,7 @@ class CoreDqlExtension extends ExtensionSpi {
   ): Either[String, Unit] = {
     logger.info("🔌 Initializing Core DQL extension")
     licenseManager = Some(licenseRefreshStrategy.licenseManager)
+    capHitCollector = licenseRefreshStrategy.telemetryCollector
     Right(())
   }
 
@@ -172,6 +182,9 @@ class CoreDqlExtension extends ExtensionSpi {
     (single.limit, quota.maxQueryResults) match {
       // (1) Explicit LIMIT over a finite quota → hard 402 (UNCHANGED).
       case (Some(l), Some(max)) if max < l.limit =>
+        // Story P0.6 — the meter bit: record a QueryResults cap-hit BEFORE building the 402
+        // (side-effect only; the reject itself is unchanged — AC 8).
+        capHitCollector.incrementCapHit(TelemetryCollector.CapHitKind.QueryResults)
         logger.warn(
           s"⚠️ Query result limit (${l.limit}) exceeds license quota ($max)"
         )
@@ -198,6 +211,12 @@ class CoreDqlExtension extends ExtensionSpi {
       //     and must NOT be re-routed to scroll (it would mishandle aggregation buckets). JOIN legs
       //     (ResultCapContext.isSuppressed) also skip the cap so the join input is not truncated.
       case (None, Some(max)) if single.fields.nonEmpty && !ResultCapContext.isSuppressed =>
+        // Story P0.6 (OQ-2) — the no-LIMIT truncation IS the meter biting (non-fatally): count it
+        // as a QueryResults cap-hit, the SAME kind as the explicit-LIMIT 402 above. The cap is
+        // suppressed for JOIN legs (the `!isSuppressed` guard), so a per-leg input truncation is
+        // never counted — only a genuine single-index result cap. (JOIN-output truncation is
+        // counted on the Joins axis downstream, not here — no double-count.)
+        capHitCollector.incrementCapHit(TelemetryCollector.CapHitKind.QueryResults)
         logger.info(
           s"ℹ️ No LIMIT on single-index scroll query; capping the stream at license quota ($max rows) and flagging truncation"
         )

--- a/core/src/main/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtension.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtension.scala
@@ -23,6 +23,7 @@ import app.softnetwork.elastic.client.scroll.ScrollConfig
 import app.softnetwork.elastic.licensing._
 import app.softnetwork.elastic.sql.query._
 import com.typesafe.config.Config
+import org.slf4j.Logger
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -57,8 +58,8 @@ import scala.concurrent.{ExecutionContext, Future}
 //format:on
 class CoreDqlExtension extends ExtensionSpi {
 
-  protected var licenseManager: Option[LicenseManager] = None
-  protected val logger = org.slf4j.LoggerFactory.getLogger(getClass)
+  private[this] var licenseManager: Option[LicenseManager] = None
+  private[this] val logger: Logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
   /** Story P0.6 -- the cap-hit collector captured at `initialize`. It is the SAME per-strategy
     * `TelemetryCollector` that `GatewayApi.run` increments for `queriesTotal`, so a `QueryResults`
@@ -67,7 +68,7 @@ class CoreDqlExtension extends ExtensionSpi {
     * `EnforcedDqlExtension` (priority &lt; 100) extends this class and inherits the increment via
     * the shared `capOrReject`, so the paid enforcement path counts cap-hits too.
     */
-  protected var capHitCollector: TelemetryCollector = TelemetryCollector.Noop
+  private[this] var capHitCollector: TelemetryCollector = TelemetryCollector.Noop
 
   override def extensionId: String = "core-dql"
   override def extensionName: String = "Core DQL Quotas"

--- a/core/src/main/scala/app/softnetwork/elastic/client/repl/StreamingReplExecutor.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/repl/StreamingReplExecutor.scala
@@ -62,7 +62,7 @@ class StreamingReplExecutor(gateway: ElasticClientApi)(implicit
         val executionTime = (System.nanoTime() - startTime).nanos
 
         elasticResult match {
-          case ElasticSuccess(QueryStream(source)) =>
+          case ElasticSuccess(QueryStream(source, _)) =>
             // Store stream context for later consumption
             activeStream = Some(StreamContext(source.map(_._1), sql, startTime))
             ExecutionSuccess(

--- a/core/src/main/scala/app/softnetwork/elastic/client/result/CsvFormatter.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/result/CsvFormatter.scala
@@ -23,7 +23,7 @@ object CsvFormatter {
   @tailrec
   def format(result: QueryResult): String = {
     result match {
-      case QueryRows(rows) if rows.nonEmpty =>
+      case QueryRows(rows, _) if rows.nonEmpty =>
         val columns = rows.head.keys.toSeq
         val header = columns.mkString(",")
         val body = rows
@@ -33,7 +33,7 @@ object CsvFormatter {
           .mkString("\n")
         s"$header\n$body"
 
-      case QueryStructured(response) if response.results.nonEmpty =>
+      case QueryStructured(response, _) if response.results.nonEmpty =>
         format(QueryRows(response.results))
 
       case _ =>

--- a/core/src/main/scala/app/softnetwork/elastic/client/result/JsonFormatter.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/result/JsonFormatter.scala
@@ -27,7 +27,7 @@ object JsonFormatter {
 
   def format(result: QueryResult, executionTime: Duration): String = {
     result match {
-      case QueryRows(rows) =>
+      case QueryRows(rows, _) =>
         val json = JObject(
           "rows"              -> JArray(rows.map(rowToJson).toList),
           "count"             -> JInt(rows.size),
@@ -35,7 +35,7 @@ object JsonFormatter {
         )
         pretty(render(json))
 
-      case QueryStructured(response) =>
+      case QueryStructured(response, _) =>
         val json = JObject(
           "rows"              -> JArray(response.results.map(rowToJson).toList),
           "count"             -> JInt(response.results.size),

--- a/core/src/main/scala/app/softnetwork/elastic/client/result/ResultRenderer.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/result/ResultRenderer.scala
@@ -48,10 +48,10 @@ object ResultRenderer {
       case EmptyResult =>
         renderEmpty()
 
-      case QueryRows(rows) =>
+      case QueryRows(rows, _) =>
         renderTable(rows, executionTime)
 
-      case QueryStructured(response) =>
+      case QueryStructured(response, _) =>
         renderTable(response.results, executionTime)
 
       case DmlResult(inserted, updated, deleted, rejected) =>
@@ -69,7 +69,7 @@ object ResultRenderer {
       case SQLResult(sql) =>
         renderSql(sql)
 
-      case QueryStream(_) =>
+      case QueryStream(_, _) =>
         renderStreamInfo()
 
       case StreamResult(estimatedSize, _) =>

--- a/core/src/main/scala/app/softnetwork/elastic/client/result/package.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/result/package.scala
@@ -393,17 +393,60 @@ package object result {
     def empty: QueryResult = EmptyResult
   }
 
+  /** Truncation metadata for a result that was capped at its source.
+    *
+    * Mirrors the JOIN path's `TruncationResult` (arrow `JoinLicenseGuard`) so single-index
+    * truncation surfaces through the identical driver channels: JDBC/ADBC `SQLWarning` SQLState
+    * `"01004"` and Flight schema metadata `x-result-truncated` / `x-result-total-rows` /
+    * `x-result-limit`.
+    *
+    * `totalRows = None` when the pre-cap total is unknown (the result was capped at the source and
+    * the stream never scanned past the limit — by design; see Story P0.5 OQ-4).
+    *
+    * @param truncated
+    *   whether the result was actually capped (rows available exceeded the limit)
+    * @param limit
+    *   the row-count cap that was applied (the licensed `maxQueryResults`)
+    * @param totalRows
+    *   the true pre-cap total when cheaply known (scroll first-response `hits.total`), else `None`
+    * @param warning
+    *   a human-readable, tier-aware message reusable verbatim as the `"01004"` `SQLWarning` text
+    */
+  case class ResultTruncation(
+    truncated: Boolean,
+    limit: Long,
+    totalRows: Option[Long],
+    warning: String
+  )
+
   // --------------------
   // DQL (SELECT)
   // --------------------
-  case class QueryRows(rows: Seq[ListMap[String, Any]]) extends QueryResult
 
-  case class QueryStream(
-    stream: Source[(ListMap[String, Any], ScrollMetrics), NotUsed]
+  /** A materialized set of result rows.
+    *
+    * Story P0.5: the additive, default-`None` `truncation` field carries the single-index result
+    * cap signal. Because the field has a default value, every `QueryRows(rows)` '''constructor'''
+    * call across core / arrow / jdbc keeps compiling unchanged. Positional '''pattern''' matches
+    * (`case QueryRows(rows)`) must add a trailing `_` (`case QueryRows(rows, _)`) — the compiler's
+    * synthetic extractor now binds both fields. (A custom 1-arg companion `unapply` was rejected:
+    * Scala 2.12 still prefers the synthetic 2-arg extractor, so it is not cross-version safe.)
+    */
+  case class QueryRows(
+    rows: Seq[ListMap[String, Any]],
+    truncation: Option[ResultTruncation] = None
   ) extends QueryResult
 
-  case class QueryStructured(response: ElasticResponse) extends QueryResult {
-    def asQueryRows: QueryRows = QueryRows(response.results)
+  case class QueryStream(
+    stream: Source[(ListMap[String, Any], ScrollMetrics), NotUsed],
+    truncation: Option[ResultTruncation] = None
+  ) extends QueryResult
+
+  case class QueryStructured(
+    response: ElasticResponse,
+    truncation: Option[ResultTruncation] = None
+  ) extends QueryResult {
+    def asQueryRows: QueryRows = QueryRows(response.results, truncation)
   }
 
   case class StreamResult(

--- a/core/src/test/scala/app/softnetwork/elastic/client/LicenseExecutorSpec.scala
+++ b/core/src/test/scala/app/softnetwork/elastic/client/LicenseExecutorSpec.scala
@@ -79,20 +79,18 @@ class LicenseExecutorSpec extends AnyFlatSpec with Matchers {
     row should contain key "platform"
     row("platform") shouldBe "PRODUCTION"
     row should contain key "max_materialized_views"
-    row("max_materialized_views") shouldBe "3"
+    row("max_materialized_views") shouldBe "1"
     row should contain key "max_clusters"
     row("max_clusters") shouldBe "1"
     row should contain key "max_result_rows"
     row("max_result_rows") shouldBe "10000"
-    row should contain key "max_concurrent_queries"
-    row("max_concurrent_queries") shouldBe "5"
     row should contain key "expires_at"
     row("expires_at") shouldBe "never"
     row("days_remaining") shouldBe -1L
     row should contain key "status"
     row("status") shouldBe "Active"
     row should contain key "max_joins"
-    row("max_joins") shouldBe "1"
+    row("max_joins") shouldBe "2"
   }
 
   it should "return strategy license info when strategy is configured" in {
@@ -117,7 +115,6 @@ class LicenseExecutorSpec extends AnyFlatSpec with Matchers {
     row("max_materialized_views") shouldBe "50"
     row("max_clusters") shouldBe "5"
     row("max_result_rows") shouldBe "1000000"
-    row("max_concurrent_queries") shouldBe "50"
     row("platform") shouldBe "PRODUCTION"
     row("expires_at") shouldBe "2026-12-31T23:59:59Z"
     row("days_remaining").asInstanceOf[Long] should be > 0L
@@ -202,7 +199,6 @@ class LicenseExecutorSpec extends AnyFlatSpec with Matchers {
       override def quotas: Quota = Quota(
         maxMaterializedViews = Some(25),
         maxQueryResults = Some(500000),
-        maxConcurrentQueries = Some(25),
         maxClusters = Some(2),
         maxJoins = Some(2)
       )
@@ -223,7 +219,6 @@ class LicenseExecutorSpec extends AnyFlatSpec with Matchers {
     row("max_materialized_views") shouldBe "25"
     row("max_clusters") shouldBe "2"
     row("max_result_rows") shouldBe "500000"
-    row("max_concurrent_queries") shouldBe "25"
     row("max_joins") shouldBe "2"
   }
 
@@ -235,7 +230,6 @@ class LicenseExecutorSpec extends AnyFlatSpec with Matchers {
       override def quotas: Quota = Quota(
         maxMaterializedViews = Some(5),
         maxQueryResults = Some(10000),
-        maxConcurrentQueries = Some(5),
         maxClusters = Some(1),
         maxJoins = Some(1)
       )
@@ -255,7 +249,6 @@ class LicenseExecutorSpec extends AnyFlatSpec with Matchers {
     row("max_materialized_views") shouldBe "5"
     row("max_clusters") shouldBe "1"
     row("max_result_rows") shouldBe "10000"
-    row("max_concurrent_queries") shouldBe "5"
     row("max_joins") shouldBe "1"
   }
 

--- a/core/src/test/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtensionSpec.scala
+++ b/core/src/test/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtensionSpec.scala
@@ -23,6 +23,7 @@ import app.softnetwork.elastic.client._
 import app.softnetwork.elastic.client.result._
 import app.softnetwork.elastic.client.scroll.{ScrollConfig, ScrollMetrics}
 import app.softnetwork.elastic.licensing._
+import app.softnetwork.elastic.licensing.metrics.MetricsApi
 import app.softnetwork.elastic.sql.parser.Parser
 import app.softnetwork.elastic.sql.query.{SearchStatement, SelectStatement, SingleSearch}
 import com.typesafe.config.ConfigFactory
@@ -63,11 +64,15 @@ class CoreDqlExtensionSpec extends AnyFlatSpec with Matchers {
       override def licenseType: LicenseType = tier
     }
 
-  private def strategy(mgr: LicenseManager): LicenseRefreshStrategy =
+  private def strategy(
+    mgr: LicenseManager,
+    collector: TelemetryCollector = TelemetryCollector.Noop
+  ): LicenseRefreshStrategy =
     new LicenseRefreshStrategy {
       override def initialize(): LicenseKey = LicenseKey.Community
       override def refresh(): Either[LicenseError, LicenseKey] = Left(RefreshNotSupported)
       override def licenseManager: LicenseManager = mgr
+      override def telemetryCollector: TelemetryCollector = collector
     }
 
   /** Records every statement forwarded to the scroll / searchAsync seam plus the scroll config, so
@@ -282,5 +287,79 @@ class CoreDqlExtensionSpec extends AnyFlatSpec with Matchers {
     client.scrolledStatement.get() shouldBe a[SingleSearch]
     client.scrolledConfig.get().maxDocuments shouldBe None
     truncationOf(res) shouldBe None
+  }
+
+  // ---- Story P0.6: QueryResults cap-hit recorded on BOTH reject branches ----
+
+  behavior of "CoreDqlExtension cap-hit instrumentation (P0.6)"
+
+  private def runWithCollector(
+    sql: String,
+    quota: Quota,
+    tier: LicenseType,
+    suppress: Boolean = false
+  ): (TelemetryCollector, ElasticResult[QueryResult]) = {
+    val parsed = Parser(sql) match {
+      case Right(s) => s
+      case Left(e)  => fail(s"parse failed: ${e.msg}")
+    }
+    val collector = new TelemetryCollector
+    val client = new RecordingClient()
+    val ext = new CoreDqlExtension()
+    ext.initialize(ConfigFactory.empty(), strategy(managerWithQuota(quota, tier), collector))
+    val res =
+      if (suppress)
+        ResultCapContext.suppressed(Await.result(ext.execute(parsed, client), 5.seconds))
+      else Await.result(ext.execute(parsed, client), 5.seconds)
+    (collector, res)
+  }
+
+  private def capHits(c: TelemetryCollector): Map[String, Long] =
+    c.collect(MetricsApi.Noop).capHitsByKind
+
+  it should "increment the QueryResults cap-hit on the explicit-LIMIT 402 branch" in {
+    val (collector, res) =
+      runWithCollector("SELECT a FROM idx LIMIT 20000", Quota.Community, LicenseType.Community)
+    res shouldBe a[ElasticFailure]
+    res.asInstanceOf[ElasticFailure].elasticError.statusCode shouldBe Some(402)
+    capHits(collector)("max_query_results") shouldBe 1L
+    // no other bucket bumped
+    capHits(collector)("max_joins") shouldBe 0L
+    capHits(collector)("max_clusters") shouldBe 0L
+    capHits(collector)("max_materialized_views") shouldBe 0L
+  }
+
+  it should "increment the QueryResults cap-hit on the P0.5 no-LIMIT truncation branch (OQ-2)" in {
+    val (collector, res) =
+      runWithCollector("SELECT a, b FROM idx", Quota.Community, LicenseType.Community)
+    res shouldBe a[ElasticSuccess[_]]
+    truncationOf(res).map(_.truncated) shouldBe Some(true)
+    capHits(collector)("max_query_results") shouldBe 1L
+  }
+
+  it should "NOT increment any cap-hit when an explicit LIMIT is within quota" in {
+    val (collector, res) =
+      runWithCollector("SELECT a FROM idx LIMIT 50", Quota.Community, LicenseType.Community)
+    res shouldBe a[ElasticSuccess[_]]
+    capHits(collector).values.toSet shouldBe Set(0L)
+  }
+
+  it should "NOT increment a cap-hit when a no-LIMIT query is a suppressed JOIN leg" in {
+    val (collector, res) =
+      runWithCollector(
+        "SELECT a, b FROM idx",
+        Quota.Community,
+        LicenseType.Community,
+        suppress = true
+      )
+    res shouldBe a[ElasticSuccess[_]]
+    capHits(collector).values.toSet shouldBe Set(0L)
+  }
+
+  it should "NOT increment a cap-hit for an unlimited (Enterprise) no-LIMIT query" in {
+    val (collector, res) =
+      runWithCollector("SELECT a, b FROM idx", Quota.Enterprise, LicenseType.Enterprise)
+    res shouldBe a[ElasticSuccess[_]]
+    capHits(collector).values.toSet shouldBe Set(0L)
   }
 }

--- a/core/src/test/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtensionSpec.scala
+++ b/core/src/test/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtensionSpec.scala
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client.extensions
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
+import app.softnetwork.elastic.client._
+import app.softnetwork.elastic.client.result._
+import app.softnetwork.elastic.client.scroll.{ScrollConfig, ScrollMetrics}
+import app.softnetwork.elastic.licensing._
+import app.softnetwork.elastic.sql.parser.Parser
+import app.softnetwork.elastic.sql.query.{SearchStatement, SelectStatement, SingleSearch}
+import com.typesafe.config.ConfigFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.collection.immutable.ListMap
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/** Unit tests for [[CoreDqlExtension]] — the Community-baseline single-index result cap (Story
+  * P0.5). No Docker / no Elasticsearch: a recording [[NopeClientApi]] captures the forwarded
+  * [[SearchStatement]] and the [[ScrollConfig]] so we assert the cap DECISION and the attached
+  * [[ResultTruncation]] directly.
+  *
+  * Seam (OQ-2 resolution): the production `CoreDqlExtension` drives `client.scroll(single, config)`
+  * for the no-LIMIT cap path and `client.dqlExecutor.execute(single)` (→ `SearchExecutor` →
+  * `scroll`/`searchAsync`) for the passthrough paths. The test client overrides BOTH `scroll` and
+  * `searchAsync` to record, so every branch is observable without a full ES stub or a `dqlExecutor`
+  * spy (which is a concrete `lazy val DqlRouterExecutor` and not cleanly mockable).
+  */
+class CoreDqlExtensionSpec extends AnyFlatSpec with Matchers {
+
+  implicit val system: ActorSystem = ActorSystem("core-dql-extension-test")
+
+  private val testLogger: Logger = LoggerFactory.getLogger(getClass)
+
+  // ---- license-manager + strategy stubs (mirror LicenseExecutorSpec) ----
+
+  private def managerWithQuota(q: Quota, tier: LicenseType): LicenseManager =
+    new LicenseManager {
+      override def validate(key: String): Either[LicenseError, LicenseKey] =
+        Left(InvalidLicense("test"))
+      override def hasFeature(feature: Feature): Boolean = true
+      override def quotas: Quota = q
+      override def licenseType: LicenseType = tier
+    }
+
+  private def strategy(mgr: LicenseManager): LicenseRefreshStrategy =
+    new LicenseRefreshStrategy {
+      override def initialize(): LicenseKey = LicenseKey.Community
+      override def refresh(): Either[LicenseError, LicenseKey] = Left(RefreshNotSupported)
+      override def licenseManager: LicenseManager = mgr
+    }
+
+  /** Records every statement forwarded to the scroll / searchAsync seam plus the scroll config, so
+    * tests can assert the cap decision (which path, what maxDocuments).
+    */
+  private class RecordingClient extends NopeClientApi {
+    override protected def logger: Logger = testLogger
+
+    val scrolledStatement = new AtomicReference[SearchStatement]()
+    val scrolledConfig = new AtomicReference[ScrollConfig]()
+    val searchedStatement = new AtomicReference[SearchStatement]()
+
+    override def scroll(
+      statement: SearchStatement,
+      config: ScrollConfig = ScrollConfig()
+    )(implicit
+      system: ActorSystem,
+      context: ConversionContext
+    ): Source[(ListMap[String, Any], ScrollMetrics), NotUsed] = {
+      scrolledStatement.set(statement)
+      scrolledConfig.set(config)
+      Source.empty[(ListMap[String, Any], ScrollMetrics)]
+    }
+
+    override def searchAsync(
+      statement: SearchStatement
+    )(implicit
+      ec: scala.concurrent.ExecutionContext,
+      context: ConversionContext
+    ): scala.concurrent.Future[ElasticResult[ElasticResponse]] = {
+      searchedStatement.set(statement)
+      scala.concurrent.Future.successful(
+        ElasticSuccess(
+          ElasticResponse(
+            sql = None,
+            query = "{}",
+            results = Seq(ListMap[String, Any]("ok" -> 1)),
+            fieldAliases = ListMap.empty,
+            aggregations = ListMap.empty
+          )
+        )
+      )
+    }
+  }
+
+  private def newExtension(quota: Quota, tier: LicenseType): CoreDqlExtension = {
+    val ext = new CoreDqlExtension()
+    ext.initialize(ConfigFactory.empty(), strategy(managerWithQuota(quota, tier)))
+    ext
+  }
+
+  private def run(
+    sql: String,
+    quota: Quota,
+    tier: LicenseType = LicenseType.Community
+  ): (RecordingClient, ElasticResult[QueryResult]) = {
+    val parsed = Parser(sql) match {
+      case Right(s) => s
+      case Left(e)  => fail(s"parse failed: ${e.msg}")
+    }
+    val client = new RecordingClient()
+    val ext = newExtension(quota, tier)
+    val res = Await.result(ext.execute(parsed, client), 5.seconds)
+    (client, res)
+  }
+
+  private def truncationOf(res: ElasticResult[QueryResult]): Option[ResultTruncation] =
+    res.asInstanceOf[ElasticSuccess[QueryResult]].value match {
+      case q: QueryRows       => q.truncation
+      case q: QueryStream     => q.truncation
+      case q: QueryStructured => q.truncation
+      case other              => fail(s"unexpected result variant: $other")
+    }
+
+  // ---- AC-6: routing verdict guard ----
+
+  behavior of "CoreDqlExtension routing"
+
+  it should "parse a single-index SELECT to a bare SingleSearch (not SelectStatement)" in {
+    Parser("SELECT a, b FROM idx") match {
+      case Right(_: SingleSearch) => succeed
+      case Right(_: SelectStatement) =>
+        fail("parser wrapped SELECT in SelectStatement — routing assumption broken")
+      case other => fail(s"unexpected parse result: $other")
+    }
+  }
+
+  // ---- AC-1 + AC-2: no-LIMIT on Community → capped scroll + truncation ----
+
+  behavior of "CoreDqlExtension no-LIMIT cap (Community)"
+
+  it should "drive a capped scroll (maxDocuments = quota) and flag truncation for a no-LIMIT single-index query" in {
+    val (client, res) = run("SELECT a, b FROM idx", Quota.Community)
+
+    res shouldBe a[ElasticSuccess[_]]
+
+    // AC-1: the scroll was driven bounded by maxDocuments = the Community quota.
+    client.scrolledStatement.get() shouldBe a[SingleSearch]
+    client.scrolledConfig.get().maxDocuments shouldBe Some(10000L)
+    // searchAsync must NOT be used for the over-quota path (would hit max_result_window on Pro).
+    client.searchedStatement.get() shouldBe null
+
+    // AC-2: truncation present and non-silent.
+    val trunc = truncationOf(res)
+    trunc.map(_.truncated) shouldBe Some(true)
+    trunc.map(_.limit) shouldBe Some(10000L)
+    trunc.flatMap(t => Some(t.warning)).getOrElse("") should not be empty
+  }
+
+  it should "cap a no-LIMIT query at the Pro quota (1,000,000) via scroll, never searchAsync" in {
+    val (client, res) = run("SELECT a, b FROM idx", Quota.Pro, LicenseType.Pro)
+
+    res shouldBe a[ElasticSuccess[_]]
+    client.scrolledConfig.get().maxDocuments shouldBe Some(1000000L)
+    client.searchedStatement.get() shouldBe null
+    truncationOf(res).map(_.limit) shouldBe Some(1000000L)
+  }
+
+  // ---- AC-3: explicit LIMIT within quota → untouched, no flag ----
+
+  behavior of "CoreDqlExtension explicit LIMIT within quota"
+
+  it should "forward an explicit LIMIT <= quota unchanged with no truncation flag" in {
+    val (client, res) = run("SELECT a FROM idx LIMIT 50", Quota.Community)
+
+    res shouldBe a[ElasticSuccess[_]]
+    // limit defined → SearchExecutor routes to searchAsync, not the capped scroll.
+    client.searchedStatement.get() match {
+      case s: SingleSearch => s.limit.map(_.limit) shouldBe Some(50)
+      case other           => fail(s"expected SingleSearch via searchAsync, got $other")
+    }
+    client.scrolledConfig.get() shouldBe null
+    truncationOf(res) shouldBe None
+  }
+
+  // ---- searchAsync-branch carve-out: no-LIMIT aggregation / empty-fields query is NOT capped ----
+
+  behavior of "CoreDqlExtension searchAsync-branch carve-out"
+
+  it should "NOT cap a no-LIMIT aggregation query (empty fields → searchAsync, bounded by max_result_window)" in {
+    // GROUP BY ⇒ SingleSearch.fields is empty ⇒ SearchExecutor routes to searchAsync, which ES
+    // bounds by index.max_result_window (≤10k ≤ quota). Capping it would mishandle aggregation
+    // buckets and re-route to scroll, so the cap MUST fall through to plain execution.
+    val (client, res) = run("SELECT category, count(*) FROM idx GROUP BY category", Quota.Community)
+
+    res shouldBe a[ElasticSuccess[_]]
+    // executed via searchAsync, NOT the capped scroll, and NOT truncation-flagged.
+    client.searchedStatement.get() shouldBe a[SingleSearch]
+    client.scrolledConfig.get() shouldBe null
+    truncationOf(res) shouldBe None
+  }
+
+  // ---- AC-4: explicit LIMIT over quota → 402 (intentional asymmetry) ----
+
+  behavior of "CoreDqlExtension explicit LIMIT over quota"
+
+  it should "reject an explicit LIMIT > quota with HTTP 402 (no truncation, no execution)" in {
+    val (client, res) = run("SELECT a FROM idx LIMIT 20000", Quota.Community)
+
+    res shouldBe a[ElasticFailure]
+    val err = res.asInstanceOf[ElasticFailure].elasticError
+    err.statusCode shouldBe Some(402)
+    err.operation shouldBe Some("license")
+    // never forwarded to any execution seam
+    client.scrolledStatement.get() shouldBe null
+    client.searchedStatement.get() shouldBe null
+  }
+
+  // ---- AC-5: Enterprise (unlimited) → uncapped ----
+
+  behavior of "CoreDqlExtension Enterprise unlimited"
+
+  it should "not cap a no-LIMIT query when maxQueryResults is None (Enterprise)" in {
+    val (client, res) = run("SELECT a, b FROM idx", Quota.Enterprise, LicenseType.Enterprise)
+
+    res shouldBe a[ElasticSuccess[_]]
+    // no-LIMIT + unlimited quota → plain passthrough scroll with the DEFAULT config (no cap).
+    client.scrolledStatement.get() shouldBe a[SingleSearch]
+    client.scrolledConfig.get().maxDocuments shouldBe None
+    truncationOf(res) shouldBe None
+  }
+
+  it should "not reject an arbitrarily large explicit LIMIT on Enterprise" in {
+    val (client, res) =
+      run("SELECT a FROM idx LIMIT 50000000", Quota.Enterprise, LicenseType.Enterprise)
+    res shouldBe a[ElasticSuccess[_]]
+    client.searchedStatement.get() match {
+      case s: SingleSearch => s.limit.map(_.limit) shouldBe Some(50000000)
+      case other           => fail(s"expected SingleSearch via searchAsync, got $other")
+    }
+  }
+
+  // ---- AC (join-leg carve-out): suppress flag bypasses the cap ----
+
+  behavior of "CoreDqlExtension join-leg suppression"
+
+  it should "NOT cap a no-LIMIT query when ResultCapContext is suppressed (a JOIN leg)" in {
+    val parsed = Parser("SELECT a, b FROM idx") match {
+      case Right(s) => s
+      case Left(e)  => fail(s"parse failed: ${e.msg}")
+    }
+    val client = new RecordingClient()
+    val ext = newExtension(Quota.Community, LicenseType.Community)
+
+    val res = ResultCapContext.suppressed {
+      Await.result(ext.execute(parsed, client), 5.seconds)
+    }
+
+    res shouldBe a[ElasticSuccess[_]]
+    // suppressed → falls through to the plain passthrough scroll (default config, no cap), and
+    // carries NO truncation flag, so the JOIN input is not silently truncated.
+    client.scrolledStatement.get() shouldBe a[SingleSearch]
+    client.scrolledConfig.get().maxDocuments shouldBe None
+    truncationOf(res) shouldBe None
+  }
+}

--- a/licensing/src/main/scala/app/softnetwork/elastic/licensing/TelemetryCollector.scala
+++ b/licensing/src/main/scala/app/softnetwork/elastic/licensing/TelemetryCollector.scala
@@ -38,6 +38,16 @@ import java.util.concurrent.atomic.AtomicLong
   * `Map.empty` default below applies only to the bare/no-op construction, never to a `collect()` /
   * `collectAndReset()` result. Story 15.2 reads `joinQueryCount` into the `InstancePing` proto
   * `join_query_count` field.
+  *
+  * Story P0.6 -- `capHitsByKind` is the per-quota-type cap-hit DELTA, with the SAME per-interval
+  * semantics as `joinQueryByRow` (NOT cumulative like `queriesTotal`): it counts how many times a
+  * license quota REJECTED an operation in the interval, keyed by the four quota types
+  * (`max_materialized_views`, `max_query_results`, `max_joins`, `max_clusters`). This is the launch
+  * "is the meter biting?" leading indicator (PRD §15.1 cap-hits). Like the JOIN buckets it ALWAYS
+  * carries all four keys on a COLLECTED snapshot (a zero is an explicit `0`, never an absent entry)
+  * so the wire shape stays stable for the daily ping; the `Map.empty` default applies only to the
+  * bare/no-op construction. Story P0.6 reads these into the `InstancePing` proto `capHitMax*`
+  * fields (14-17).
   */
 case class TelemetryData(
   queriesTotal: Long = 0,
@@ -48,7 +58,8 @@ case class TelemetryData(
   clusterVersion: Option[String] = None,
   aggregatedMetrics: AggregatedMetrics = AggregatedMetrics.empty,
   joinQueryCount: Long = 0,
-  joinQueryByRow: Map[String, Long] = Map.empty
+  joinQueryByRow: Map[String, Long] = Map.empty,
+  capHitsByKind: Map[String, Long] = Map.empty
 )
 
 /** Mutable telemetry collector with atomic counters.
@@ -70,6 +81,12 @@ class TelemetryCollector {
   private val _joinPassthrough = new AtomicLong(0L)
   private val _joinCrossCluster = new AtomicLong(0L)
   private val _joinCoordinator = new AtomicLong(0L)
+  // Story P0.6 -- per-interval cap-hit DELTA buckets, one per quota type. Same lock-free pattern as
+  // the JOIN buckets: independent AtomicLong so the increment never contends with collect/reset.
+  private val _capMv = new AtomicLong(0L)
+  private val _capResults = new AtomicLong(0L)
+  private val _capJoins = new AtomicLong(0L)
+  private val _capClusters = new AtomicLong(0L)
   private val clusterInfoLock = new AnyRef
   private var _mvsActive: Int = 0
   private var _clustersConnected: Int = 0
@@ -106,6 +123,36 @@ class TelemetryCollector {
     (p + x + c, Map("passthrough" -> p, "cross_cluster" -> x, "coordinator" -> c))
   }
 
+  /** Record one license cap-hit (a quota REJECTED an operation), attributed to its quota type
+    * (Story P0.6). Real-time, lock-free (AtomicLong); the four buckets are independent so the
+    * increment never contends with collect/collectAndReset. Called at each of the four reject sites
+    * (CoreDqlExtension / MaterializedViewExtension / JoinPlanner / JoinLicenseGuard), regardless of
+    * whether that reject surfaces as an HTTP 402, a `Left(String)`, or a startup exit -- this is a
+    * SEMANTIC cap-hit, not an HTTP-status filter (PRD §15.1 / P0.6 OQ-1).
+    */
+  def incrementCapHit(kind: TelemetryCollector.CapHitKind): Unit = {
+    val _ = (kind match {
+      case TelemetryCollector.CapHitKind.MaterializedViews => _capMv
+      case TelemetryCollector.CapHitKind.QueryResults      => _capResults
+      case TelemetryCollector.CapHitKind.Joins             => _capJoins
+      case TelemetryCollector.CapHitKind.Clusters          => _capClusters
+    }).incrementAndGet()
+  }
+
+  /** Snapshot+reset ONLY the cap-hit delta (read+zero with `getAndSet`). Used by the scheduled tick
+    * when `config.telemetryEnabled` is false (so the buckets still reset, mirroring AC 5a) and by
+    * the clean-shutdown flush (mirroring AC 5b / P0.6 OQ-8 -- the `maxClusters` cap-hit happens on
+    * a startup CrashLoop, so its delta MUST be flushed before `sys.exit`). ALWAYS returns all four
+    * keys (an explicit `0`, never an absent entry) so the wire shape stays stable for the daily
+    * ping, exactly like `collectAndResetJoinCounts`.
+    */
+  def collectAndResetCapHits(): Map[String, Long] = Map(
+    "max_materialized_views" -> _capMv.getAndSet(0L),
+    "max_query_results"      -> _capResults.getAndSet(0L),
+    "max_joins"              -> _capJoins.getAndSet(0L),
+    "max_clusters"           -> _capClusters.getAndSet(0L)
+  )
+
   def setMvsActive(count: Int): Unit = clusterInfoLock.synchronized { _mvsActive = count }
 
   def setClustersConnected(count: Int): Unit = clusterInfoLock.synchronized {
@@ -124,6 +171,14 @@ class TelemetryCollector {
 
   // --- Read methods (called by AutoRefreshStrategy.doScheduleRefresh) ---
 
+  /** Read-only snapshot of the cap-hit buckets (all four keys, NO reset). Used by `collect`. */
+  private def readCapHits(): Map[String, Long] = Map(
+    "max_materialized_views" -> _capMv.get(),
+    "max_query_results"      -> _capResults.get(),
+    "max_joins"              -> _capJoins.get(),
+    "max_clusters"           -> _capClusters.get()
+  )
+
   def collect(metrics: MetricsApi): TelemetryData = clusterInfoLock.synchronized {
     // JOIN buckets: read with .get() -- collect NEVER resets (interval read without flush).
     val p = _joinPassthrough.get()
@@ -138,7 +193,9 @@ class TelemetryCollector {
       clusterVersion = _clusterVersion,
       aggregatedMetrics = metrics.getAggregatedMetrics,
       joinQueryCount = p + x + c,
-      joinQueryByRow = Map("passthrough" -> p, "cross_cluster" -> x, "coordinator" -> c)
+      joinQueryByRow = Map("passthrough" -> p, "cross_cluster" -> x, "coordinator" -> c),
+      // Cap-hit buckets: read with .get() -- collect NEVER resets (interval read without flush).
+      capHitsByKind = readCapHits()
     )
   }
 
@@ -160,7 +217,9 @@ class TelemetryCollector {
       clusterVersion = _clusterVersion,
       aggregatedMetrics = metrics.collectAndResetAggregatedMetrics,
       joinQueryCount = p + x + c,
-      joinQueryByRow = Map("passthrough" -> p, "cross_cluster" -> x, "coordinator" -> c)
+      joinQueryByRow = Map("passthrough" -> p, "cross_cluster" -> x, "coordinator" -> c),
+      // Cap-hit buckets: read+zero with .getAndSet(0L) -- per-interval delta; this IS the flush.
+      capHitsByKind = collectAndResetCapHits()
     )
   }
 }
@@ -189,6 +248,37 @@ object TelemetryCollector {
     case object Coordinator extends JoinRow
   }
 
+  /** The license quota type a cap-hit is attributed to (Story P0.6). Each rejected operation
+    * increments exactly one bucket. The four types map 1:1 to the four enforced quotas; the `key`
+    * is the snake-case wire/column name carried to the license-server `instance_ping` cap-hit
+    * columns.
+    */
+  sealed trait CapHitKind { def key: String }
+  object CapHitKind {
+
+    /** `maxMaterializedViews` -- `MaterializedViewExtension` CREATE over quota (the quota-exceeded
+      * 402 branch ONLY; NOT the feature-absent path -- P0.6 OQ-7).
+      */
+    case object MaterializedViews extends CapHitKind { val key = "max_materialized_views" }
+
+    /** `maxQueryResults` -- `CoreDqlExtension` single-index result boundary: BOTH the
+      * explicit-LIMIT 402 reject AND the P0.5 no-LIMIT truncation/cappedScroll bite (P0.6 OQ-2).
+      */
+    case object QueryResults extends CapHitKind { val key = "max_query_results" }
+
+    /** `maxJoins` -- `JoinPlanner.plan()` cross-index JOIN-count reject (`Left(String)`, NOT a
+      * 402).
+      */
+    case object Joins extends CapHitKind { val key = "max_joins" }
+
+    /** `maxClusters` -- `JoinLicenseGuard` federation cluster-count reject (startup `Left`/exit or
+      * `checkClusterLimit` `Left(QuotaExceeded)`, NOT a 402).
+      */
+    case object Clusters extends CapHitKind { val key = "max_clusters" }
+
+    val values: Seq[CapHitKind] = Seq(MaterializedViews, QueryResults, Joins, Clusters)
+  }
+
   /** Default collector returning zero-valued data. Used when telemetry is disabled or no runtime
     * wires a real collector. Write methods are no-ops to prevent accidental mutation of the shared
     * singleton.
@@ -198,6 +288,9 @@ object TelemetryCollector {
     override def incrementJoin(row: JoinRow): Unit = ()
     override def collectAndResetJoinCounts(): (Long, Map[String, Long]) =
       (0L, Map("passthrough" -> 0L, "cross_cluster" -> 0L, "coordinator" -> 0L))
+    override def incrementCapHit(kind: CapHitKind): Unit = ()
+    override def collectAndResetCapHits(): Map[String, Long] =
+      CapHitKind.values.map(_.key -> 0L).toMap
     override def setMvsActive(count: Int): Unit = ()
     override def setClustersConnected(count: Int): Unit = ()
     override def setClusterInfo(

--- a/licensing/src/main/scala/app/softnetwork/elastic/licensing/package.scala
+++ b/licensing/src/main/scala/app/softnetwork/elastic/licensing/package.scala
@@ -83,8 +83,6 @@ package object licensing {
     case object MaterializedViews extends Feature
     case object JdbcDriver extends ProductType
     case object AdbcDriver extends ProductType // Story 15.2 (A11) -- replaces OdbcDriver
-    case object UnlimitedResults extends Feature
-    case object AdvancedAggregations extends Feature
     case object FlightSql extends ProductType
     case object Federation extends ProductType
     case object Repl extends ProductType // Story 15.2 (A11) -- NEW
@@ -92,34 +90,28 @@ package object licensing {
       MaterializedViews,
       JdbcDriver,
       AdbcDriver,
-      UnlimitedResults,
-      AdvancedAggregations,
       FlightSql,
       Federation,
       Repl
     )
 
     def fromString(s: String): Option[Feature] = s.trim.toLowerCase match {
-      case "materialized_views"    => Some(MaterializedViews)
-      case "jdbc_driver"           => Some(JdbcDriver)
-      case "adbc_driver"           => Some(AdbcDriver)
-      case "unlimited_results"     => Some(UnlimitedResults)
-      case "advanced_aggregations" => Some(AdvancedAggregations)
-      case "flight_sql"            => Some(FlightSql)
-      case "federation"            => Some(Federation)
-      case "repl"                  => Some(Repl)
-      case _                       => None
+      case "materialized_views" => Some(MaterializedViews)
+      case "jdbc_driver"        => Some(JdbcDriver)
+      case "adbc_driver"        => Some(AdbcDriver)
+      case "flight_sql"         => Some(FlightSql)
+      case "federation"         => Some(Federation)
+      case "repl"               => Some(Repl)
+      case _                    => None
     }
 
     def toSnakeCase(f: Feature): String = f match {
-      case MaterializedViews    => "materialized_views"
-      case JdbcDriver           => "jdbc_driver"
-      case AdbcDriver           => "adbc_driver"
-      case UnlimitedResults     => "unlimited_results"
-      case AdvancedAggregations => "advanced_aggregations"
-      case FlightSql            => "flight_sql"
-      case Federation           => "federation"
-      case Repl                 => "repl"
+      case MaterializedViews => "materialized_views"
+      case JdbcDriver        => "jdbc_driver"
+      case AdbcDriver        => "adbc_driver"
+      case FlightSql         => "flight_sql"
+      case Federation        => "federation"
+      case Repl              => "repl"
     }
   }
 
@@ -180,24 +172,21 @@ package object licensing {
   case class Quota(
     maxMaterializedViews: Option[Int], // None = unlimited
     maxQueryResults: Option[Int], // None = unlimited
-    maxConcurrentQueries: Option[Int],
     maxClusters: Option[Int] = Some(0), // None = unlimited
     maxJoins: Option[Int] = Some(0) // None = unlimited
   )
 
   object Quota {
     val Community: Quota = Quota(
-      maxMaterializedViews = Some(3),
+      maxMaterializedViews = Some(1), // ADR D6: 3 -> 1 (operationalization signal)
       maxQueryResults = Some(10000),
-      maxConcurrentQueries = Some(5),
       maxClusters = Some(1),
-      maxJoins = Some(1)
+      maxJoins = Some(2) // ADR D5: 1 -> 2 (3-table JOIN free-tier aha)
     )
 
     val Pro: Quota = Quota(
       maxMaterializedViews = Some(50),
       maxQueryResults = Some(1000000),
-      maxConcurrentQueries = Some(50),
       maxClusters = Some(5),
       maxJoins = Some(5)
     )
@@ -205,7 +194,6 @@ package object licensing {
     val Enterprise: Quota = Quota(
       maxMaterializedViews = None, // Unlimited
       maxQueryResults = None,
-      maxConcurrentQueries = None,
       maxClusters = None,
       maxJoins = None
     )

--- a/licensing/src/test/scala/app/softnetwork/elastic/licensing/FeatureFromStringSpec.scala
+++ b/licensing/src/test/scala/app/softnetwork/elastic/licensing/FeatureFromStringSpec.scala
@@ -33,14 +33,6 @@ class FeatureFromStringSpec extends AnyFlatSpec with Matchers {
     Feature.fromString("adbc_driver") shouldBe Some(Feature.AdbcDriver)
   }
 
-  it should "map unlimited_results" in {
-    Feature.fromString("unlimited_results") shouldBe Some(Feature.UnlimitedResults)
-  }
-
-  it should "map advanced_aggregations" in {
-    Feature.fromString("advanced_aggregations") shouldBe Some(Feature.AdvancedAggregations)
-  }
-
   it should "map flight_sql" in {
     Feature.fromString("flight_sql") shouldBe Some(Feature.FlightSql)
   }
@@ -55,6 +47,11 @@ class FeatureFromStringSpec extends AnyFlatSpec with Matchers {
 
   it should "return None for unknown string" in {
     Feature.fromString("warp_drive") shouldBe None
+  }
+
+  it should "return None for retired flag strings" in {
+    Feature.fromString("unlimited_results") shouldBe None
+    Feature.fromString("advanced_aggregations") shouldBe None
   }
 
   it should "be case-insensitive" in {

--- a/licensing/src/test/scala/app/softnetwork/elastic/licensing/FeatureSpec.scala
+++ b/licensing/src/test/scala/app/softnetwork/elastic/licensing/FeatureSpec.scala
@@ -29,8 +29,8 @@ class FeatureSpec extends AnyFlatSpec with Matchers {
     Feature.Federation shouldBe a[Feature]
   }
 
-  "Feature.values" should "contain all 8 features" in {
-    Feature.values should have size 8
+  "Feature.values" should "contain all 6 features" in {
+    Feature.values should have size 6
   }
 
   it should "contain FlightSql and Federation" in {
@@ -43,8 +43,6 @@ class FeatureSpec extends AnyFlatSpec with Matchers {
       Feature.MaterializedViews,
       Feature.JdbcDriver,
       Feature.AdbcDriver,
-      Feature.UnlimitedResults,
-      Feature.AdvancedAggregations,
       Feature.FlightSql,
       Feature.Federation,
       Feature.Repl

--- a/licensing/src/test/scala/app/softnetwork/elastic/licensing/LicenseKeySpec.scala
+++ b/licensing/src/test/scala/app/softnetwork/elastic/licensing/LicenseKeySpec.scala
@@ -50,12 +50,10 @@ class LicenseKeySpec extends AnyFlatSpec with Matchers {
       features = Feature.values.toSet,
       expiresAt = None
     )
-    key.features should have size 8
+    key.features should have size 6
     key.features should contain(Feature.MaterializedViews)
     key.features should contain(Feature.JdbcDriver)
     key.features should contain(Feature.AdbcDriver)
-    key.features should contain(Feature.UnlimitedResults)
-    key.features should contain(Feature.AdvancedAggregations)
     key.features should contain(Feature.FlightSql)
     key.features should contain(Feature.Federation)
     key.features should contain(Feature.Repl)

--- a/licensing/src/test/scala/app/softnetwork/elastic/licensing/LicenseManagerSpec.scala
+++ b/licensing/src/test/scala/app/softnetwork/elastic/licensing/LicenseManagerSpec.scala
@@ -47,14 +47,6 @@ class LicenseManagerSpec extends AnyFlatSpec with Matchers {
     manager.hasFeature(Feature.Repl) shouldBe true
   }
 
-  it should "not include UnlimitedResults" in {
-    manager.hasFeature(Feature.UnlimitedResults) shouldBe false
-  }
-
-  it should "not include AdvancedAggregations" in {
-    manager.hasFeature(Feature.AdvancedAggregations) shouldBe false
-  }
-
   it should "return Community quotas" in {
     manager.quotas shouldBe Quota.Community
   }

--- a/licensing/src/test/scala/app/softnetwork/elastic/licensing/LicenseUsageSpec.scala
+++ b/licensing/src/test/scala/app/softnetwork/elastic/licensing/LicenseUsageSpec.scala
@@ -48,19 +48,19 @@ class LicenseUsageSpec extends AnyFlatSpec with Matchers {
   }
 
   "checkQuota for MaterializedViews" should "return None when within quota" in {
-    val usage = LicenseUsage(totalMvsActive = 2)
+    val usage = LicenseUsage(totalMvsActive = 0)
     usage.checkQuota(Feature.MaterializedViews, Quota.Community) shouldBe None
   }
 
   it should "return None at exact quota boundary" in {
-    val usage = LicenseUsage(totalMvsActive = 3)
+    val usage = LicenseUsage(totalMvsActive = 1)
     usage.checkQuota(Feature.MaterializedViews, Quota.Community) shouldBe None
   }
 
   it should "detect exceeded maxMaterializedViews" in {
-    val usage = LicenseUsage(totalMvsActive = 4)
+    val usage = LicenseUsage(totalMvsActive = 2)
     usage.checkQuota(Feature.MaterializedViews, Quota.Community) shouldBe Some(
-      QuotaExceeded("maxMaterializedViews", 4, 3)
+      QuotaExceeded("maxMaterializedViews", 2, 1)
     )
   }
 
@@ -100,6 +100,5 @@ class LicenseUsageSpec extends AnyFlatSpec with Matchers {
     val usage = LicenseUsage(totalMvsActive = 100, totalFederatedClusters = 100)
     usage.checkQuota(Feature.JdbcDriver, Quota.Community) shouldBe None
     usage.checkQuota(Feature.FlightSql, Quota.Community) shouldBe None
-    usage.checkQuota(Feature.UnlimitedResults, Quota.Community) shouldBe None
   }
 }

--- a/licensing/src/test/scala/app/softnetwork/elastic/licensing/QuotaSpec.scala
+++ b/licensing/src/test/scala/app/softnetwork/elastic/licensing/QuotaSpec.scala
@@ -25,20 +25,16 @@ class QuotaSpec extends AnyFlatSpec with Matchers {
     Quota.Community.maxClusters shouldBe Some(1)
   }
 
-  it should "have maxJoins = Some(1)" in {
-    Quota.Community.maxJoins shouldBe Some(1)
+  it should "have maxJoins = Some(2)" in {
+    Quota.Community.maxJoins shouldBe Some(2)
   }
 
-  it should "have maxMaterializedViews = Some(3)" in {
-    Quota.Community.maxMaterializedViews shouldBe Some(3)
+  it should "have maxMaterializedViews = Some(1)" in {
+    Quota.Community.maxMaterializedViews shouldBe Some(1)
   }
 
   it should "have maxQueryResults = Some(10000)" in {
     Quota.Community.maxQueryResults shouldBe Some(10000)
-  }
-
-  it should "have maxConcurrentQueries = Some(5)" in {
-    Quota.Community.maxConcurrentQueries shouldBe Some(5)
   }
 
   "Quota.Pro" should "have maxClusters = Some(5)" in {
@@ -57,10 +53,6 @@ class QuotaSpec extends AnyFlatSpec with Matchers {
     Quota.Pro.maxQueryResults shouldBe Some(1000000)
   }
 
-  it should "have maxConcurrentQueries = Some(50)" in {
-    Quota.Pro.maxConcurrentQueries shouldBe Some(50)
-  }
-
   "Quota.Enterprise" should "have maxClusters = None (unlimited)" in {
     Quota.Enterprise.maxClusters shouldBe None
   }
@@ -77,15 +69,10 @@ class QuotaSpec extends AnyFlatSpec with Matchers {
     Quota.Enterprise.maxQueryResults shouldBe None
   }
 
-  it should "have maxConcurrentQueries = None (unlimited)" in {
-    Quota.Enterprise.maxConcurrentQueries shouldBe None
-  }
-
   "Quota default constructor" should "use maxClusters = Some(0)" in {
     val quota = Quota(
       maxMaterializedViews = Some(10),
-      maxQueryResults = Some(100),
-      maxConcurrentQueries = Some(1)
+      maxQueryResults = Some(100)
     )
     quota.maxClusters shouldBe Some(0)
     quota.maxJoins shouldBe Some(0)

--- a/licensing/src/test/scala/app/softnetwork/elastic/licensing/ResultLimitInvariantSpec.scala
+++ b/licensing/src/test/scala/app/softnetwork/elastic/licensing/ResultLimitInvariantSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.licensing
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** ADR D3 invariant: "unlimited results" has ONE source of truth —
+  * `Quota.maxQueryResults` — not a removed `UnlimitedResults` feature flag.
+  * Community = Some(10000), Pro = Some(1000000), Enterprise = None (unlimited).
+  */
+class ResultLimitInvariantSpec extends AnyFlatSpec with Matchers {
+
+  "Result-limit policy" should "be driven solely by Quota.maxQueryResults per tier" in {
+    Quota.Community.maxQueryResults shouldBe Some(10000)
+    Quota.Pro.maxQueryResults shouldBe Some(1000000)
+    Quota.Enterprise.maxQueryResults shouldBe None // unlimited
+  }
+
+  it should "treat Enterprise (maxQueryResults = None) as the unlimited case" in {
+    Quota.Enterprise.maxQueryResults.isEmpty shouldBe true
+  }
+
+  "The Feature enum" should "carry no result-limit flag" in {
+    // The retired UnlimitedResults / AdvancedAggregations flags must not exist
+    // under any (case-insensitive) spelling, and the catalog must stay at 6.
+    Feature.values should have size 6
+    Feature.values.map(Feature.toSnakeCase) should contain noneOf (
+      "unlimited_results",
+      "advanced_aggregations"
+    )
+    Feature.fromString("unlimited_results") shouldBe None
+    Feature.fromString("advanced_aggregations") shouldBe None
+  }
+
+  "Community manager" should "express the result cap via quota, not a feature" in {
+    val mgr = new CommunityLicenseManager
+    mgr.quotas.maxQueryResults shouldBe Some(10000)
+    // No flag encodes the limit:
+    Feature.values.foreach(f => mgr.hasFeature(f) shouldBe LicenseKey.Community.features.contains(f))
+  }
+}

--- a/licensing/src/test/scala/app/softnetwork/elastic/licensing/ResultLimitInvariantSpec.scala
+++ b/licensing/src/test/scala/app/softnetwork/elastic/licensing/ResultLimitInvariantSpec.scala
@@ -19,9 +19,9 @@ package app.softnetwork.elastic.licensing
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-/** ADR D3 invariant: "unlimited results" has ONE source of truth —
-  * `Quota.maxQueryResults` — not a removed `UnlimitedResults` feature flag.
-  * Community = Some(10000), Pro = Some(1000000), Enterprise = None (unlimited).
+/** ADR D3 invariant: "unlimited results" has ONE source of truth — `Quota.maxQueryResults` — not a
+  * removed `UnlimitedResults` feature flag. Community = Some(10000), Pro = Some(1000000),
+  * Enterprise = None (unlimited).
   */
 class ResultLimitInvariantSpec extends AnyFlatSpec with Matchers {
 
@@ -51,6 +51,8 @@ class ResultLimitInvariantSpec extends AnyFlatSpec with Matchers {
     val mgr = new CommunityLicenseManager
     mgr.quotas.maxQueryResults shouldBe Some(10000)
     // No flag encodes the limit:
-    Feature.values.foreach(f => mgr.hasFeature(f) shouldBe LicenseKey.Community.features.contains(f))
+    Feature.values.foreach(f =>
+      mgr.hasFeature(f) shouldBe LicenseKey.Community.features.contains(f)
+    )
   }
 }

--- a/licensing/src/test/scala/app/softnetwork/elastic/licensing/TelemetryCollectorSpec.scala
+++ b/licensing/src/test/scala/app/softnetwork/elastic/licensing/TelemetryCollectorSpec.scala
@@ -238,4 +238,115 @@ class TelemetryCollectorSpec extends AnyFlatSpec with Matchers {
     total shouldBe 0
     byRow shouldBe Map("passthrough" -> 0L, "cross_cluster" -> 0L, "coordinator" -> 0L)
   }
+
+  // --- Story P0.6: cap-hit counter ---
+
+  private val allCapKeys =
+    Set("max_materialized_views", "max_query_results", "max_joins", "max_clusters")
+
+  "TelemetryCollector" should "increment ONLY the bucket for the given cap-hit kind" in {
+    val collector = new TelemetryCollector
+    collector.incrementCapHit(TelemetryCollector.CapHitKind.MaterializedViews)
+    collector.incrementCapHit(TelemetryCollector.CapHitKind.QueryResults)
+    collector.incrementCapHit(TelemetryCollector.CapHitKind.QueryResults)
+    collector.incrementCapHit(TelemetryCollector.CapHitKind.Joins)
+    collector.incrementCapHit(TelemetryCollector.CapHitKind.Clusters)
+    collector.incrementCapHit(TelemetryCollector.CapHitKind.Clusters)
+    collector.incrementCapHit(TelemetryCollector.CapHitKind.Clusters)
+    val data = collector.collect(noop)
+    data.capHitsByKind("max_materialized_views") shouldBe 1
+    data.capHitsByKind("max_query_results") shouldBe 2
+    data.capHitsByKind("max_joins") shouldBe 1
+    data.capHitsByKind("max_clusters") shouldBe 3
+  }
+
+  it should "ALWAYS carry all four cap-hit keys even when their buckets are 0" in {
+    val collector = new TelemetryCollector
+    val data = collector.collect(noop)
+    data.capHitsByKind.keySet shouldBe allCapKeys
+    data.capHitsByKind.values.toSet shouldBe Set(0L)
+    // and the same on a reset read
+    val reset = collector.collectAndReset(noop)
+    reset.capHitsByKind.keySet shouldBe allCapKeys
+    reset.capHitsByKind.values.toSet shouldBe Set(0L)
+  }
+
+  it should "NOT reset the cap-hit counters on collect (interval read without flush)" in {
+    val collector = new TelemetryCollector
+    collector.incrementCapHit(TelemetryCollector.CapHitKind.Joins)
+    collector.collect(noop).capHitsByKind("max_joins") shouldBe 1
+    collector.collect(noop).capHitsByKind("max_joins") shouldBe 1 // still 1 -- collect never resets
+  }
+
+  it should "reset the cap-hit counters on collectAndReset (per-interval delta; shutdown flush)" in {
+    val collector = new TelemetryCollector
+    collector.incrementCapHit(TelemetryCollector.CapHitKind.Clusters)
+    collector.collectAndReset(noop).capHitsByKind("max_clusters") shouldBe 1
+    // delta reset after the interval
+    collector.collectAndReset(noop).capHitsByKind("max_clusters") shouldBe 0
+  }
+
+  it should "snapshot+reset only the cap-hit delta via collectAndResetCapHits (all 4 keys)" in {
+    val collector = new TelemetryCollector
+    collector.incrementCapHit(TelemetryCollector.CapHitKind.MaterializedViews)
+    collector.incrementCapHit(TelemetryCollector.CapHitKind.Clusters)
+    val first = collector.collectAndResetCapHits()
+    first shouldBe Map(
+      "max_materialized_views" -> 1L,
+      "max_query_results"      -> 0L,
+      "max_joins"              -> 0L,
+      "max_clusters"           -> 1L
+    )
+    // reset: a second snapshot returns zeros, all 4 keys present
+    val second = collector.collectAndResetCapHits()
+    second shouldBe Map(
+      "max_materialized_views" -> 0L,
+      "max_query_results"      -> 0L,
+      "max_joins"              -> 0L,
+      "max_clusters"           -> 0L
+    )
+    // the cap-hit flush does NOT affect the JOIN buckets or queriesTotal
+    collector.incrementQueries()
+    collector.collect(noop).queriesTotal shouldBe 1
+    collector.collect(noop).joinQueryCount shouldBe 0
+  }
+
+  it should "increment the cap-hit counters concurrently without loss" in {
+    val collector = new TelemetryCollector
+    val threads = (1 to 10).map { _ =>
+      new Thread(() => {
+        (1 to 1000).foreach { _ =>
+          collector.incrementCapHit(TelemetryCollector.CapHitKind.QueryResults)
+        }
+      })
+    }
+    threads.foreach(_.start())
+    threads.foreach(_.join())
+    collector.collect(noop).capHitsByKind("max_query_results") shouldBe 10000
+  }
+
+  it should "expose exactly the four CapHitKind values with their snake-case keys" in {
+    TelemetryCollector.CapHitKind.values should have size 4
+    TelemetryCollector.CapHitKind.values.map(_.key).toSet shouldBe allCapKeys
+    TelemetryCollector.CapHitKind.MaterializedViews.key shouldBe "max_materialized_views"
+    TelemetryCollector.CapHitKind.QueryResults.key shouldBe "max_query_results"
+    TelemetryCollector.CapHitKind.Joins.key shouldBe "max_joins"
+    TelemetryCollector.CapHitKind.Clusters.key shouldBe "max_clusters"
+  }
+
+  "TelemetryCollector.Noop" should "no-op incrementCapHit and zero-out collectAndResetCapHits" in {
+    TelemetryCollector.Noop.incrementCapHit(TelemetryCollector.CapHitKind.Joins)
+    TelemetryCollector.Noop.collect(noop).capHitsByKind shouldBe Map(
+      "max_materialized_views" -> 0L,
+      "max_query_results"      -> 0L,
+      "max_joins"              -> 0L,
+      "max_clusters"           -> 0L
+    )
+    TelemetryCollector.Noop.collectAndResetCapHits() shouldBe Map(
+      "max_materialized_views" -> 0L,
+      "max_query_results"      -> 0L,
+      "max_joins"              -> 0L,
+      "max_clusters"           -> 0L
+    )
+  }
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -44,7 +44,7 @@ object Versions {
 
   val testContainers = "2.0.2"
 
-  val genericPersistence = "0.8.0"
+  val genericPersistence = "0.9.0"
 
   val gson = "2.8.9"
 

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/GatewayIntegrationTestKit.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/GatewayIntegrationTestKit.scala
@@ -117,7 +117,7 @@ trait GatewayIntegrationTestKit extends AnyFlatSpecLike with Matchers with Scala
     }
     res.isSuccess shouldBe true
     res.toOption.get match {
-      case QueryStream(stream) =>
+      case QueryStream(stream, _) =>
         val sink =
           Sink.fold[Seq[ListMap[String, Any]], (ListMap[String, Any], ScrollMetrics)](Seq.empty) {
             case (acc, (row, _)) =>
@@ -133,7 +133,7 @@ trait GatewayIntegrationTestKit extends AnyFlatSpecLike with Matchers with Scala
         } else {
           log.info(s"Rows: $results")
         }
-      case QueryStructured(response) =>
+      case QueryStructured(response, _) =>
         renderResults(startTime, res)
         val results =
           response.results.map(normalizeRow)
@@ -213,7 +213,7 @@ trait GatewayIntegrationTestKit extends AnyFlatSpecLike with Matchers with Scala
     renderResults(startTime, res)
     res.isSuccess shouldBe true
     res.toOption.get match {
-      case QueryStream(stream) =>
+      case QueryStream(stream, _) =>
         val sink =
           Sink.fold[Seq[ListMap[String, Any]], (ListMap[String, Any], ScrollMetrics)](Seq.empty) {
             case (acc, (row, _)) => acc :+ normalizeRow(row)
@@ -221,7 +221,7 @@ trait GatewayIntegrationTestKit extends AnyFlatSpecLike with Matchers with Scala
         stream.runWith(sink).futureValue
       case q: QueryRows =>
         q.rows.map(normalizeRow)
-      case QueryStructured(response) =>
+      case QueryStructured(response, _) =>
         response.results.map(normalizeRow)
       case other =>
         fail(s"Unexpected QueryResult type for SELECT: $other")

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/repl/ReplGatewayIntegrationSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/repl/ReplGatewayIntegrationSpec.scala
@@ -1259,7 +1259,7 @@ trait ReplGatewayIntegrationSpec extends ReplIntegrationTestKit {
 
     val watcherStatus = executeSync("SHOW WATCHER STATUS my_watcher_interval")
     watcherStatus match {
-      case ExecutionSuccess(QueryRows(rows), _) =>
+      case ExecutionSuccess(QueryRows(rows, _), _) =>
         rows.size shouldBe 1
         val row = rows.head
         log.info(s"Watcher Status: $row")
@@ -1272,7 +1272,7 @@ trait ReplGatewayIntegrationSpec extends ReplIntegrationTestKit {
     if (supportsQueryWatchers) {
       val watchers = executeSync("SHOW WATCHERS")
       watchers match {
-        case ExecutionSuccess(QueryRows(rows), _) =>
+        case ExecutionSuccess(QueryRows(rows, _), _) =>
           rows.find(row => row.get("id").contains("my_watcher_interval")) match {
             case Some(row) =>
               row.get("is_healthy") shouldBe Some(true)
@@ -1365,7 +1365,7 @@ trait ReplGatewayIntegrationSpec extends ReplIntegrationTestKit {
     val executePolicy = "EXECUTE ENRICH POLICY my_policy"
     val result = executeSync(executePolicy)
     result match {
-      case ExecutionSuccess(QueryRows(rows), _) =>
+      case ExecutionSuccess(QueryRows(rows, _), _) =>
         rows.size shouldBe 1
         val row = rows.head
         log.info(s"Policy Execution Result: $row")

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/repl/ReplGatewayIntegrationSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/repl/ReplGatewayIntegrationSpec.scala
@@ -1440,7 +1440,6 @@ trait ReplGatewayIntegrationSpec extends ReplIntegrationTestKit {
     row("license_type") shouldBe "Community"
     row should contain key "max_materialized_views"
     row should contain key "max_result_rows"
-    row should contain key "max_concurrent_queries"
     row should contain key "max_clusters"
     row should contain key "expires_at"
     row("expires_at") shouldBe "never"

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/repl/ReplIntegrationTestKit.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/repl/ReplIntegrationTestKit.scala
@@ -156,7 +156,7 @@ trait ReplIntegrationTestKit
 
     val success = res.asInstanceOf[ExecutionSuccess]
     success.result match {
-      case QueryStream(stream) =>
+      case QueryStream(stream, _) =>
         val sink = Sink.fold[Seq[Map[String, Any]], (Map[String, Any], ScrollMetrics)](Seq.empty) {
           case (acc, (row, _)) => acc :+ normalizeRow(row)
         }
@@ -170,7 +170,7 @@ trait ReplIntegrationTestKit
           log.info(s"Rows: $results")
         }
 
-      case QueryStructured(response) =>
+      case QueryStructured(response, _) =>
         val results = response.results.map(normalizeRow)
         if (rows.nonEmpty) {
           results.size shouldBe rows.size


### PR DESCRIPTION
## Release R1 — v0.20.0

Finalizes the **R1** release line by merging `release-r1` into `main`. Version is bumped to **0.20.0**.

### Highlights — Pricing Repackaging & Quota Cleanup (Phase 0, elasticsql slice)

The open-core reprice now rests on an **enforced, truthful, measurable** quota model:

- **P0.1 + P0.2 — Quota model + dead-flag removal** (`8fcfb77`): removed `maxConcurrentQueries`; Community `maxJoins` 1→2 and `maxMaterializedViews` 3→1; deleted the `AdvancedAggregations` / `UnlimitedResults` feature flags (result-limit policy is now driven solely by `maxQueryResults`). `SHOW LICENSE` no longer lists concurrent queries.
- **P0.5 — `maxQueryResults` enforcement** (`eb1d367`): the advertised result cap is now actually enforced on the no-`LIMIT` single-index path via the license-agnostic `ScrollConfig.maxDocuments` mechanism + an additive `ResultTruncation` signal. The cap is **suppressed for JOIN legs** (`ResultCapContext`) so cross-index joins are never silently truncated; `CoreDqlExtension` is the OSS Community baseline while the un-forkable enforcement decision lives in the closed `EnforcedDqlExtension` (softclient4es-extensions).
- **P0.6 — Cap-hit funnel instrumentation** (`7d0b5e5`): semantic `TelemetryCollector.incrementCapHit(kind)` at the result-cap reject sites, riding the existing `InstancePing` telemetry to the license-server.

### Supporting changes

- `genericPersistence` → 0.9.0 (`4442e02`)
- `CoreDqlExtension` field visibility tightened to `private` (`9b167eb`)
- Version → 0.20.0 (`dcd2059`)

### Sibling repos (separate PRs, for the full R1 cut)

The cross-repo Phase 0 slices land in their own repos: **softclient4es-extensions** (P0.3 propagation + P0.5 `EnforcedDqlExtension` + P0.6 MV cap-hit), **softclient4es-license-server** (P0.3 + P0.6 cap-hit ingestion + Grafana), **softclient4es-arrow** (P0.4 boundary tests + P0.5 join-leg suppression + P0.6 joins/clusters cap-hit).

### Not in this release (follow-up)

- **Phase 1** — P1.1 reprice/Stripe, P1.2 pricing page, P1.3 marketing/docs reconciliation (config/portal/docs only; no engine code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
