### PR TITLE
P1.3 Marketing reconciliation — README + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,21 +386,36 @@ SoftClient4ES uses a dual-license model:
 - **Core** (SQL engine, REPL client, Scala library) — **Apache License 2.0** (open source)
 - **JDBC Driver**, **Arrow Flight SQL**, **ADBC Driver**, and **Materialized Views** — **Elastic License 2.0** (free to use, not open source)
 
-### Feature Matrix
+### Editions & pricing
 
-| Feature                                                            | Community | Pro     | Enterprise |
-|--------------------------------------------------------------------|-----------|---------|------------|
-| Full SQL DDL (CREATE, ALTER, DROP TABLE)                           | Yes       | Yes     | Yes        |
-| Full SQL DML (INSERT, UPDATE, DELETE, COPY INTO)                   | Yes       | Yes     | Yes        |
-| Full SQL DQL (SELECT, JOIN UNNEST, aggregations, window functions) | Yes       | Yes     | Yes        |
-| Pipelines, Watchers, Enrich Policies                               | Yes       | Yes     | Yes        |
-| Interactive REPL client                                            | Yes       | Yes     | Yes        |
-| Scala library (Akka Streams)                                       | Yes       | Yes     | Yes        |
-| Elasticsearch 6, 7, 8, 9 support                                   | Yes       | Yes     | Yes        |
-| JDBC driver (DBeaver, Tableau, etc.)                               | Yes       | Yes     | Yes        |
-| Arrow Flight SQL server + ADBC driver                              | Yes       | Yes     | Yes        |
-| Materialized Views (CREATE, REFRESH, DESCRIBE)                     | Max 3     | Limited | Unlimited  |
-| Priority support                                                   | -         | -       | Yes        |
+Every tier has **every feature** — including all client drivers. You pay for
+**scale**, metered by quotas, not for unlocking capabilities.
+
+The two things Elasticsearch cannot do natively — and that DIY can't either —
+are available on **every** tier:
+
+- **Query-time cross-index JOIN** — on every surface (REPL, JDBC, ADBC,
+  Arrow Flight SQL, Federation). JOIN *depth* is metered.
+- **Persisted Materialized Views** — pre-joined / pre-aggregated indices.
+
+| | **Community** | **Pro** | **Enterprise** |
+|---|---|---|---|
+| **Price** | Free | **€129/mo** · €1,290/yr | **from €12,000/year** |
+| Full SQL (DDL · DML · DQL · window functions) | Yes | Yes | Yes |
+| Client drivers — JDBC · ADBC · REPL | **Free** | Free | Free |
+| Arrow Flight SQL server | Yes | Yes | Yes |
+| Cross-index JOINs per query | **2** | 5 | Unlimited |
+| Federation (cross-cluster) | **1 cluster** | up to 5 clusters | Unlimited |
+| Materialized Views | **1** | 50 | Unlimited |
+| Max query results | 10,000 | 1,000,000 | Unlimited |
+| ES 6 / 7 / 8 / 9 support | Yes | Yes | Yes |
+| Support | Community | Email / 48h | Priority / 4h SLA |
+| SSO · air-gapped licensing · custom quotas | — | — | Yes |
+
+> Single-cluster cross-index JOINs and one Materialized View are **free** in
+> Community — taste both superpowers, then scale up by cluster count, JOIN
+> depth, and MV volume. See the
+> [pricing page](https://softclient4es.dev/licensing/) for details.
 
 ### Elasticsearch License Requirements
 

--- a/documentation/sql/dql_statements.md
+++ b/documentation/sql/dql_statements.md
@@ -1461,7 +1461,6 @@ Returns the current license type, quota values, expiration date, and grace statu
 | `max_materialized_views` | Maximum number of materialized views allowed, or "unlimited" |
 | `max_clusters` | Maximum number of federated clusters allowed, or "unlimited" |
 | `max_result_rows` | Maximum rows returned per query, or "unlimited" |
-| `max_concurrent_queries` | Maximum concurrent queries allowed, or "unlimited" |
 | `max_joins` | Maximum number of JOIN operations allowed per query, or "unlimited" |
 | `expires_at` | License expiration timestamp, or "never" for Community |
 | `days_remaining` | Days until expiration, or -1 for Community (no expiry) |
@@ -1473,9 +1472,9 @@ Returns the current license type, quota values, expiration date, and grace statu
 SHOW LICENSE;
 ```
 
-| license_type | trial | platform | max_materialized_views | max_clusters | max_result_rows | max_concurrent_queries | max_joins | expires_at | days_remaining | status |
-|---|---|---|---|---|---|---|---|---|---|---|
-| Community | false | PRODUCTION | 3 | 1 | 10000 | 5 | 1 | never | -1 | Active |
+| license_type | trial | platform | max_materialized_views | max_clusters | max_result_rows | max_joins | expires_at | days_remaining | status |
+|---|---|---|---|---|---|---|---|---|---|
+| Community | false | PRODUCTION | 1 | 1 | 10000 | 2 | never | -1 | Active |
 📊 1 row(s) (1ms)
 
 ---

--- a/documentation/sql/materialized_views.md
+++ b/documentation/sql/materialized_views.md
@@ -474,7 +474,7 @@ DROP MATERIALIZED VIEW IF EXISTS orders_with_customers_mv;
 |---------------------------------------------|----------------------------------------------------------------------|
 | **UNNEST JOIN**                             | Not supported in materialized views                                  |
 | **`RIGHT JOIN` / `FULL OUTER JOIN`**        | Not supported (see below). Use `LEFT JOIN` with swapped table order. |
-| **Quota limits**                            | Community edition: max 3 views. Pro: limited. Enterprise: unlimited  |
+| **Quota limits**                            | Community: 1 view · Pro: 50 · Enterprise: unlimited                 |
 | **Watcher dependency (ES license)**         | Automatic enrich policy re-execution relies on Elasticsearch Watchers, which require an Elasticsearch Platinum or Enterprise license (see below) |
 | **Eventual consistency**                    | Data is eventually consistent based on refresh frequency and delay   |
 | **Join cardinality**                        | JOINs use enrich policies which match on a single field              |


### PR DESCRIPTION
Reconcile elasticsql public marketing + reference docs to the post-Phase-0 enforced open-core model (one source of truth: code = marketing = docs).

## Changes (markdown-only — no Scala, no build)
- **README.md** — replaced the `### Feature Matrix` block with an **Editions & pricing** quota-as-meter table:
  - Community Free / Pro **€129/mo · €1,290/yr** / Enterprise **from €12,000/year**
  - All client drivers (JDBC · ADBC · REPL) **free in every tier**
  - Cross-index JOINs 2/5/∞ · Federation 1/5/∞ clusters · Materialized Views 1/50/∞ · Max results 10k/1M/∞
  - Two ES-impossible superpowers (query-time cross-index JOIN + persisted MVs) stated distinctly
  - "Materialized Views … Max 3" removed
- **documentation/sql/materialized_views.md** — quota line → "Community: 1 view · Pro: 50 · Enterprise: unlimited" (dual-docs mirror of the web MV page)
- **documentation/sql/dql_statements.md** — drift (c): dropped the `max_concurrent_queries` row from the SHOW LICENSE column table + example output (P0.1 removed it from SHOW LICENSE), and corrected stale Community example values (max_materialized_views 3→1, max_joins 1→2). Mirrors the same removal in web `dql.mdx`.

## Verification (grep gates, all pass)
- No "Max 3" / "max 3 views"; no stale prices (€459/$499/4,990/4,590); no `maxConcurrentQueries` / `max_concurrent_queries` / AdvancedAggregations / UnlimitedResults; no "source-available".
- "129" and "12,000" present in README. Numbers match enforced `Quota` after Phase 0 (P0.1).

Closes #133
Closes #132 (epic capstone in this repo)

Sibling PRs: P1.1 #94 (license-server reprice), P1.2 (portal), web P1.3 (SOFTNETWORK-APP/softclient4es-web).