### PR TITLE
Story 17.1 — Cross-Index JOIN doc (Markdown twin)

### DIFF
--- a/documentation/sql/README.md
+++ b/documentation/sql/README.md
@@ -17,6 +17,7 @@ Welcome to the SQL Engine Documentation. Navigate through the sections below:
 - [DDL Support](ddl_statements.md)
 - [DML Support](dml_statements.md)
 - [DQL Support](dql_statements.md)
+- [Cross-Index JOIN](joins.md)
 - [Materialized Views](materialized_views.md)
 - [Telemetry & Privacy](../client/telemetry.md)
 - [Telemetry & Privacy](telemetry.md)

--- a/documentation/sql/diagrams/join-row1.svg
+++ b/documentation/sql/diagrams/join-row1.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="360" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#333"/>
+    </marker>
+  </defs>
+
+  <!-- SQL input -->
+  <text x="320" y="28" font-family="Arial" font-size="13" text-anchor="middle" fill="#333">SQL: SELECT ... FROM emp e JOIN dept d ON e.dept_id = d.dept_id</text>
+  <line x1="320" y1="36" x2="320" y2="60" stroke="#333" marker-end="url(#arrow)"/>
+
+  <!-- Engine box -->
+  <rect x="190" y="64" width="260" height="56" rx="6" fill="#f0f0f0" stroke="#333"/>
+  <text x="320" y="88" font-family="Arial" font-size="13" text-anchor="middle">Driver / sidecar / REPL</text>
+  <text x="320" y="106" font-family="Arial" font-size="12" text-anchor="middle">(embedded DuckDB engine)</text>
+
+  <!-- sub-query arrows -->
+  <line x1="250" y1="120" x2="160" y2="190" stroke="#333" marker-end="url(#arrow)"/>
+  <text x="150" y="160" font-family="Arial" font-size="11" text-anchor="middle">sub-query e</text>
+  <line x1="390" y1="120" x2="480" y2="190" stroke="#333" marker-end="url(#arrow)"/>
+  <text x="490" y="160" font-family="Arial" font-size="11" text-anchor="middle">sub-query d</text>
+
+  <!-- one cluster grouping -->
+  <rect x="80" y="194" width="480" height="96" rx="8" fill="none" stroke="#333" stroke-dasharray="5,4"/>
+  <text x="320" y="214" font-family="Arial" font-size="12" text-anchor="middle" fill="#333">one cluster</text>
+
+  <!-- ES index boxes -->
+  <rect x="110" y="224" width="160" height="52" rx="6" fill="#f0f0f0" stroke="#333"/>
+  <text x="190" y="255" font-family="Arial" font-size="13" text-anchor="middle">ES index: emp</text>
+  <rect x="370" y="224" width="160" height="52" rx="6" fill="#f0f0f0" stroke="#333"/>
+  <text x="450" y="255" font-family="Arial" font-size="13" text-anchor="middle">ES index: dept</text>
+
+  <!-- results back into join -->
+  <line x1="190" y1="276" x2="290" y2="312" stroke="#333" marker-end="url(#arrow)"/>
+  <line x1="450" y1="276" x2="350" y2="312" stroke="#333" marker-end="url(#arrow)"/>
+
+  <!-- joined in DuckDB -->
+  <rect x="210" y="314" width="220" height="34" rx="6" fill="#f0f0f0" stroke="#333"/>
+  <text x="320" y="336" font-family="Arial" font-size="13" text-anchor="middle">joined in DuckDB</text>
+
+  <!-- rows to client -->
+  <line x1="430" y1="331" x2="540" y2="331" stroke="#333" marker-end="url(#arrow)"/>
+  <text x="585" y="335" font-family="Arial" font-size="12" text-anchor="middle">rows to client</text>
+</svg>

--- a/documentation/sql/diagrams/join-row1.svg
+++ b/documentation/sql/diagrams/join-row1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" font-family="'Inter','Segoe UI',system-ui,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="490" viewBox="0 0 640 490" font-family="'Inter','Segoe UI',system-ui,sans-serif">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#1e293b"/></linearGradient>
     <linearGradient id="engine" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#7c3aed"/><stop offset="100%" stop-color="#a78bfa"/></linearGradient>
@@ -8,34 +8,45 @@
     <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6 Z" fill="#94a3b8"/></marker>
   </defs>
 
-  <rect width="640" height="360" rx="16" fill="url(#bg)"/>
+  <rect width="640" height="490" rx="16" fill="url(#bg)"/>
 
-  <text x="320" y="30" font-size="13" text-anchor="middle" fill="#cbd5e1" font-family="'JetBrains Mono','Courier New',monospace">SELECT … FROM emp e JOIN dept d ON e.dept_id = d.dept_id</text>
-  <line x1="320" y1="38" x2="320" y2="60" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <!-- terminal header with the SQL query -->
+  <rect x="40" y="16" width="560" height="120" rx="10" fill="#0d1117" stroke="#30363d"/>
+  <circle cx="60" cy="35" r="5.5" fill="#ff5f56"/>
+  <circle cx="78" cy="35" r="5.5" fill="#ffbd2e"/>
+  <circle cx="96" cy="35" r="5.5" fill="#27c93f"/>
+  <text x="582" y="39" text-anchor="end" font-size="11" fill="#8b949e">Row 1 · same-cluster JOIN</text>
+  <line x1="40" y1="52" x2="600" y2="52" stroke="#30363d" stroke-width="1"/>
+  <text x="58" y="78" xml:space="preserve" font-family="'JetBrains Mono','SF Mono','Courier New',monospace" font-size="13"><tspan fill="#79c0ff">SELECT</tspan><tspan fill="#e6edf3"> e.name, e.salary, d.dept_name</tspan></text>
+  <text x="58" y="99" xml:space="preserve" font-family="'JetBrains Mono','SF Mono','Courier New',monospace" font-size="13"><tspan fill="#79c0ff">FROM</tspan><tspan fill="#e6edf3"> emp e</tspan></text>
+  <text x="58" y="120" xml:space="preserve" font-family="'JetBrains Mono','SF Mono','Courier New',monospace" font-size="13"><tspan fill="#79c0ff">JOIN</tspan><tspan fill="#e6edf3"> dept d </tspan><tspan fill="#79c0ff">ON</tspan><tspan fill="#e6edf3"> e.dept_id = d.dept_id;</tspan></text>
 
-  <rect x="190" y="64" width="260" height="56" rx="10" fill="url(#engine)" filter="url(#shadow)"/>
-  <text x="320" y="89" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">Driver / sidecar / REPL</text>
-  <text x="320" y="107" font-size="11" text-anchor="middle" fill="#ede9fe">embedded DuckDB engine</text>
+  <!-- flow diagram -->
+  <g transform="translate(0,120)">
+    <rect x="190" y="64" width="260" height="56" rx="10" fill="url(#engine)" filter="url(#shadow)"/>
+    <text x="320" y="89" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">Driver / sidecar / REPL</text>
+    <text x="320" y="107" font-size="11" text-anchor="middle" fill="#ede9fe">embedded DuckDB engine</text>
 
-  <line x1="250" y1="120" x2="172" y2="188" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
-  <text x="150" y="160" font-size="11" text-anchor="middle" fill="#cbd5e1">sub-query e</text>
-  <line x1="390" y1="120" x2="468" y2="188" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
-  <text x="490" y="160" font-size="11" text-anchor="middle" fill="#cbd5e1">sub-query d</text>
+    <line x1="250" y1="120" x2="172" y2="188" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+    <text x="150" y="160" font-size="11" text-anchor="middle" fill="#cbd5e1">sub-query e</text>
+    <line x1="390" y1="120" x2="468" y2="188" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+    <text x="490" y="160" font-size="11" text-anchor="middle" fill="#cbd5e1">sub-query d</text>
 
-  <rect x="80" y="194" width="480" height="96" rx="10" fill="none" stroke="#334155" stroke-width="1.5" stroke-dasharray="6,4"/>
-  <text x="320" y="213" font-size="11" font-weight="600" text-anchor="middle" fill="#64748b">one Elasticsearch cluster</text>
+    <rect x="80" y="194" width="480" height="96" rx="10" fill="none" stroke="#334155" stroke-width="1.5" stroke-dasharray="6,4"/>
+    <text x="320" y="213" font-size="11" font-weight="600" text-anchor="middle" fill="#64748b">one Elasticsearch cluster</text>
 
-  <rect x="110" y="224" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
-  <text x="190" y="255" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">ES index: emp</text>
-  <rect x="370" y="224" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
-  <text x="450" y="255" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">ES index: dept</text>
+    <rect x="110" y="224" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
+    <text x="190" y="255" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">ES index: emp</text>
+    <rect x="370" y="224" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
+    <text x="450" y="255" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">ES index: dept</text>
 
-  <line x1="190" y1="276" x2="290" y2="310" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <line x1="450" y1="276" x2="350" y2="310" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="190" y1="276" x2="290" y2="310" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="450" y1="276" x2="350" y2="310" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <rect x="210" y="314" width="220" height="34" rx="10" fill="url(#join)" filter="url(#shadow)"/>
-  <text x="320" y="336" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">joined in DuckDB</text>
+    <rect x="210" y="314" width="220" height="34" rx="10" fill="url(#join)" filter="url(#shadow)"/>
+    <text x="320" y="336" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">joined in DuckDB</text>
 
-  <line x1="430" y1="331" x2="538" y2="331" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="585" y="335" font-size="11" text-anchor="middle" fill="#cbd5e1">rows to client</text>
+    <line x1="430" y1="331" x2="538" y2="331" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <text x="585" y="335" font-size="11" text-anchor="middle" fill="#cbd5e1">rows to client</text>
+  </g>
 </svg>

--- a/documentation/sql/diagrams/join-row1.svg
+++ b/documentation/sql/diagrams/join-row1.svg
@@ -1,44 +1,41 @@
-<svg width="640" height="360" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" font-family="'Inter','Segoe UI',system-ui,sans-serif">
   <defs>
-    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#333"/>
-    </marker>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#1e293b"/></linearGradient>
+    <linearGradient id="engine" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#7c3aed"/><stop offset="100%" stop-color="#a78bfa"/></linearGradient>
+    <linearGradient id="es" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#059669"/><stop offset="100%" stop-color="#10b981"/></linearGradient>
+    <linearGradient id="join" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#2563eb"/><stop offset="100%" stop-color="#3b82f6"/></linearGradient>
+    <filter id="shadow" x="-6%" y="-8%" width="112%" height="120%"><feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.35"/></filter>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6 Z" fill="#94a3b8"/></marker>
   </defs>
 
-  <!-- SQL input -->
-  <text x="320" y="28" font-family="Arial" font-size="13" text-anchor="middle" fill="#333">SQL: SELECT ... FROM emp e JOIN dept d ON e.dept_id = d.dept_id</text>
-  <line x1="320" y1="36" x2="320" y2="60" stroke="#333" marker-end="url(#arrow)"/>
+  <rect width="640" height="360" rx="16" fill="url(#bg)"/>
 
-  <!-- Engine box -->
-  <rect x="190" y="64" width="260" height="56" rx="6" fill="#f0f0f0" stroke="#333"/>
-  <text x="320" y="88" font-family="Arial" font-size="13" text-anchor="middle">Driver / sidecar / REPL</text>
-  <text x="320" y="106" font-family="Arial" font-size="12" text-anchor="middle">(embedded DuckDB engine)</text>
+  <text x="320" y="30" font-size="13" text-anchor="middle" fill="#cbd5e1" font-family="'JetBrains Mono','Courier New',monospace">SELECT … FROM emp e JOIN dept d ON e.dept_id = d.dept_id</text>
+  <line x1="320" y1="38" x2="320" y2="60" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- sub-query arrows -->
-  <line x1="250" y1="120" x2="160" y2="190" stroke="#333" marker-end="url(#arrow)"/>
-  <text x="150" y="160" font-family="Arial" font-size="11" text-anchor="middle">sub-query e</text>
-  <line x1="390" y1="120" x2="480" y2="190" stroke="#333" marker-end="url(#arrow)"/>
-  <text x="490" y="160" font-family="Arial" font-size="11" text-anchor="middle">sub-query d</text>
+  <rect x="190" y="64" width="260" height="56" rx="10" fill="url(#engine)" filter="url(#shadow)"/>
+  <text x="320" y="89" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">Driver / sidecar / REPL</text>
+  <text x="320" y="107" font-size="11" text-anchor="middle" fill="#ede9fe">embedded DuckDB engine</text>
 
-  <!-- one cluster grouping -->
-  <rect x="80" y="194" width="480" height="96" rx="8" fill="none" stroke="#333" stroke-dasharray="5,4"/>
-  <text x="320" y="214" font-family="Arial" font-size="12" text-anchor="middle" fill="#333">one cluster</text>
+  <line x1="250" y1="120" x2="172" y2="188" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+  <text x="150" y="160" font-size="11" text-anchor="middle" fill="#cbd5e1">sub-query e</text>
+  <line x1="390" y1="120" x2="468" y2="188" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+  <text x="490" y="160" font-size="11" text-anchor="middle" fill="#cbd5e1">sub-query d</text>
 
-  <!-- ES index boxes -->
-  <rect x="110" y="224" width="160" height="52" rx="6" fill="#f0f0f0" stroke="#333"/>
-  <text x="190" y="255" font-family="Arial" font-size="13" text-anchor="middle">ES index: emp</text>
-  <rect x="370" y="224" width="160" height="52" rx="6" fill="#f0f0f0" stroke="#333"/>
-  <text x="450" y="255" font-family="Arial" font-size="13" text-anchor="middle">ES index: dept</text>
+  <rect x="80" y="194" width="480" height="96" rx="10" fill="none" stroke="#334155" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <text x="320" y="213" font-size="11" font-weight="600" text-anchor="middle" fill="#64748b">one Elasticsearch cluster</text>
 
-  <!-- results back into join -->
-  <line x1="190" y1="276" x2="290" y2="312" stroke="#333" marker-end="url(#arrow)"/>
-  <line x1="450" y1="276" x2="350" y2="312" stroke="#333" marker-end="url(#arrow)"/>
+  <rect x="110" y="224" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
+  <text x="190" y="255" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">ES index: emp</text>
+  <rect x="370" y="224" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
+  <text x="450" y="255" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">ES index: dept</text>
 
-  <!-- joined in DuckDB -->
-  <rect x="210" y="314" width="220" height="34" rx="6" fill="#f0f0f0" stroke="#333"/>
-  <text x="320" y="336" font-family="Arial" font-size="13" text-anchor="middle">joined in DuckDB</text>
+  <line x1="190" y1="276" x2="290" y2="310" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="450" y1="276" x2="350" y2="310" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- rows to client -->
-  <line x1="430" y1="331" x2="540" y2="331" stroke="#333" marker-end="url(#arrow)"/>
-  <text x="585" y="335" font-family="Arial" font-size="12" text-anchor="middle">rows to client</text>
+  <rect x="210" y="314" width="220" height="34" rx="10" fill="url(#join)" filter="url(#shadow)"/>
+  <text x="320" y="336" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">joined in DuckDB</text>
+
+  <line x1="430" y1="331" x2="538" y2="331" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="585" y="335" font-size="11" text-anchor="middle" fill="#cbd5e1">rows to client</text>
 </svg>

--- a/documentation/sql/diagrams/join-row2.svg
+++ b/documentation/sql/diagrams/join-row2.svg
@@ -10,6 +10,12 @@
 
   <rect width="620" height="300" rx="16" fill="url(#bg)"/>
 
+  <!-- connectors (drawn BEHIND the boxes; heads stop in the gap outside each box) -->
+  <line x1="260" y1="70" x2="150" y2="190" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <line x1="185" y1="205" x2="300" y2="82" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+  <line x1="390" y1="70" x2="480" y2="190" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
+
+  <!-- boxes (on top, cover any connector tail) -->
   <rect x="200" y="20" width="220" height="54" rx="10" fill="url(#coord)" filter="url(#shadow)"/>
   <text x="310" y="52" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">Federation coordinator</text>
 
@@ -21,12 +27,8 @@
   <text x="480" y="225" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">prod_eu sidecar</text>
   <text x="480" y="242" font-size="10" text-anchor="middle" fill="#fed7aa">target</text>
 
-  <line x1="250" y1="74" x2="152" y2="198" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
-  <text x="118" y="138" font-size="11" fill="#cbd5e1">1. run source SELECT</text>
-
-  <line x1="172" y1="198" x2="288" y2="76" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
-  <text x="246" y="152" font-size="11" fill="#cbd5e1">2. Arrow stream</text>
-
-  <line x1="372" y1="64" x2="470" y2="198" stroke="#f97316" stroke-width="1.8" marker-end="url(#arrow)"/>
-  <text x="430" y="138" font-size="11" fill="#fdba74">3. bulk-load conveyor</text>
+  <!-- labels -->
+  <text x="116" y="138" font-size="11" fill="#cbd5e1">1. run source SELECT</text>
+  <text x="248" y="152" font-size="11" fill="#cbd5e1">2. Arrow stream</text>
+  <text x="424" y="138" font-size="11" fill="#cbd5e1">3. bulk-load conveyor</text>
 </svg>

--- a/documentation/sql/diagrams/join-row2.svg
+++ b/documentation/sql/diagrams/join-row2.svg
@@ -1,32 +1,32 @@
-<svg width="620" height="300" viewBox="0 0 620 300" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="300" viewBox="0 0 620 300" font-family="'Inter','Segoe UI',system-ui,sans-serif">
   <defs>
-    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#333"/>
-    </marker>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#1e293b"/></linearGradient>
+    <linearGradient id="coord" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0891b2"/><stop offset="100%" stop-color="#06b6d4"/></linearGradient>
+    <linearGradient id="es" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#059669"/><stop offset="100%" stop-color="#10b981"/></linearGradient>
+    <linearGradient id="target" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#ea580c"/><stop offset="100%" stop-color="#f97316"/></linearGradient>
+    <filter id="shadow" x="-6%" y="-8%" width="112%" height="120%"><feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.35"/></filter>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6 Z" fill="#94a3b8"/></marker>
   </defs>
 
-  <!-- coordinator -->
-  <rect x="200" y="20" width="220" height="50" rx="6" fill="#f0f0f0" stroke="#333"/>
-  <text x="310" y="50" font-family="Arial" font-size="14" text-anchor="middle">Federation coordinator</text>
+  <rect width="620" height="300" rx="16" fill="url(#bg)"/>
 
-  <!-- source sidecar -->
-  <rect x="40" y="200" width="200" height="50" rx="6" fill="#f0f0f0" stroke="#333"/>
-  <text x="140" y="230" font-family="Arial" font-size="14" text-anchor="middle">prod_us sidecar</text>
+  <rect x="200" y="20" width="220" height="54" rx="10" fill="url(#coord)" filter="url(#shadow)"/>
+  <text x="310" y="52" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">Federation coordinator</text>
 
-  <!-- target sidecar -->
-  <rect x="380" y="200" width="220" height="50" rx="6" fill="#f0f0f0" stroke="#333"/>
-  <text x="490" y="225" font-family="Arial" font-size="13" text-anchor="middle">prod_eu sidecar</text>
-  <text x="490" y="241" font-family="Arial" font-size="11" text-anchor="middle">(target)</text>
+  <rect x="40" y="200" width="200" height="54" rx="10" fill="url(#es)" filter="url(#shadow)"/>
+  <text x="140" y="225" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">prod_us sidecar</text>
+  <text x="140" y="242" font-size="10" text-anchor="middle" fill="#d1fae5">source</text>
 
-  <!-- 1. run source SELECT -->
-  <line x1="250" y1="70" x2="150" y2="200" stroke="#333" marker-end="url(#arrow)"/>
-  <text x="120" y="135" font-family="Arial" font-size="11">1. run source SELECT</text>
+  <rect x="380" y="200" width="200" height="54" rx="10" fill="url(#target)" filter="url(#shadow)"/>
+  <text x="480" y="225" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">prod_eu sidecar</text>
+  <text x="480" y="242" font-size="10" text-anchor="middle" fill="#fed7aa">target</text>
 
-  <!-- 2. Arrow stream -->
-  <line x1="170" y1="200" x2="290" y2="70" stroke="#333" marker-end="url(#arrow)"/>
-  <text x="245" y="150" font-family="Arial" font-size="11">2. Arrow stream</text>
+  <line x1="250" y1="74" x2="152" y2="198" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <text x="118" y="138" font-size="11" fill="#cbd5e1">1. run source SELECT</text>
 
-  <!-- 3. bulk-load conveyor -->
-  <line x1="370" y1="60" x2="470" y2="200" stroke="#333" marker-end="url(#arrow)"/>
-  <text x="430" y="135" font-family="Arial" font-size="11">3. bulk-load conveyor</text>
+  <line x1="172" y1="198" x2="288" y2="76" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+  <text x="246" y="152" font-size="11" fill="#cbd5e1">2. Arrow stream</text>
+
+  <line x1="372" y1="64" x2="470" y2="198" stroke="#f97316" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <text x="430" y="138" font-size="11" fill="#fdba74">3. bulk-load conveyor</text>
 </svg>

--- a/documentation/sql/diagrams/join-row2.svg
+++ b/documentation/sql/diagrams/join-row2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="620" height="300" viewBox="0 0 620 300" font-family="'Inter','Segoe UI',system-ui,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="450" viewBox="0 0 620 450" font-family="'Inter','Segoe UI',system-ui,sans-serif">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#1e293b"/></linearGradient>
     <linearGradient id="coord" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0891b2"/><stop offset="100%" stop-color="#06b6d4"/></linearGradient>
@@ -8,27 +8,39 @@
     <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6 Z" fill="#94a3b8"/></marker>
   </defs>
 
-  <rect width="620" height="300" rx="16" fill="url(#bg)"/>
+  <rect width="620" height="450" rx="16" fill="url(#bg)"/>
 
-  <!-- connectors (drawn BEHIND the boxes; heads stop in the gap outside each box) -->
-  <line x1="260" y1="70" x2="150" y2="190" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
-  <line x1="185" y1="205" x2="300" y2="82" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
-  <line x1="390" y1="70" x2="480" y2="190" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <!-- terminal header with the SQL query -->
+  <rect x="30" y="16" width="560" height="140" rx="10" fill="#0d1117" stroke="#30363d"/>
+  <circle cx="50" cy="35" r="5.5" fill="#ff5f56"/>
+  <circle cx="68" cy="35" r="5.5" fill="#ffbd2e"/>
+  <circle cx="86" cy="35" r="5.5" fill="#27c93f"/>
+  <text x="572" y="39" text-anchor="end" font-size="11" fill="#8b949e">Row 2 · cross-cluster conveyor</text>
+  <line x1="30" y1="52" x2="590" y2="52" stroke="#30363d" stroke-width="1"/>
+  <text x="48" y="78" xml:space="preserve" font-family="'JetBrains Mono','SF Mono','Courier New',monospace" font-size="13"><tspan fill="#79c0ff">INSERT INTO</tspan><tspan fill="#e6edf3"> </tspan><tspan fill="#7ee787">`prod_eu`</tspan><tspan fill="#e6edf3">.dest</tspan></text>
+  <text x="48" y="99" xml:space="preserve" font-family="'JetBrains Mono','SF Mono','Courier New',monospace" font-size="13"><tspan fill="#79c0ff">SELECT</tspan><tspan fill="#e6edf3"> o.id, c.name</tspan></text>
+  <text x="48" y="120" xml:space="preserve" font-family="'JetBrains Mono','SF Mono','Courier New',monospace" font-size="13"><tspan fill="#79c0ff">FROM</tspan><tspan fill="#e6edf3"> </tspan><tspan fill="#7ee787">`prod_us`</tspan><tspan fill="#e6edf3">.orders o</tspan></text>
+  <text x="48" y="141" xml:space="preserve" font-family="'JetBrains Mono','SF Mono','Courier New',monospace" font-size="13"><tspan fill="#79c0ff">JOIN</tspan><tspan fill="#e6edf3"> </tspan><tspan fill="#7ee787">`prod_us`</tspan><tspan fill="#e6edf3">.customers c </tspan><tspan fill="#79c0ff">ON</tspan><tspan fill="#e6edf3"> o.id = c.id;</tspan></text>
 
-  <!-- boxes (on top, cover any connector tail) -->
-  <rect x="200" y="20" width="220" height="54" rx="10" fill="url(#coord)" filter="url(#shadow)"/>
-  <text x="310" y="52" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">Federation coordinator</text>
+  <!-- flow diagram -->
+  <g transform="translate(0,170)">
+    <line x1="260" y1="70" x2="150" y2="190" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
+    <line x1="185" y1="205" x2="300" y2="82" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+    <line x1="390" y1="70" x2="480" y2="190" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
 
-  <rect x="40" y="200" width="200" height="54" rx="10" fill="url(#es)" filter="url(#shadow)"/>
-  <text x="140" y="225" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">prod_us sidecar</text>
-  <text x="140" y="242" font-size="10" text-anchor="middle" fill="#d1fae5">source</text>
+    <rect x="200" y="20" width="220" height="54" rx="10" fill="url(#coord)" filter="url(#shadow)"/>
+    <text x="310" y="52" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">Federation coordinator</text>
 
-  <rect x="380" y="200" width="200" height="54" rx="10" fill="url(#target)" filter="url(#shadow)"/>
-  <text x="480" y="225" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">prod_eu sidecar</text>
-  <text x="480" y="242" font-size="10" text-anchor="middle" fill="#fed7aa">target</text>
+    <rect x="40" y="200" width="200" height="54" rx="10" fill="url(#es)" filter="url(#shadow)"/>
+    <text x="140" y="225" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">prod_us sidecar</text>
+    <text x="140" y="242" font-size="10" text-anchor="middle" fill="#d1fae5">source</text>
 
-  <!-- labels -->
-  <text x="116" y="138" font-size="11" fill="#cbd5e1">1. run source SELECT</text>
-  <text x="248" y="152" font-size="11" fill="#cbd5e1">2. Arrow stream</text>
-  <text x="424" y="138" font-size="11" fill="#cbd5e1">3. bulk-load conveyor</text>
+    <rect x="380" y="200" width="200" height="54" rx="10" fill="url(#target)" filter="url(#shadow)"/>
+    <text x="480" y="225" font-size="13" font-weight="700" text-anchor="middle" fill="#fff">prod_eu sidecar</text>
+    <text x="480" y="242" font-size="10" text-anchor="middle" fill="#fed7aa">target</text>
+
+    <text x="116" y="138" font-size="11" fill="#cbd5e1">1. run source SELECT</text>
+    <text x="248" y="152" font-size="11" fill="#cbd5e1">2. Arrow stream</text>
+    <text x="424" y="138" font-size="11" fill="#cbd5e1">3. bulk-load conveyor</text>
+  </g>
 </svg>

--- a/documentation/sql/diagrams/join-row2.svg
+++ b/documentation/sql/diagrams/join-row2.svg
@@ -1,0 +1,32 @@
+<svg width="620" height="300" viewBox="0 0 620 300" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#333"/>
+    </marker>
+  </defs>
+
+  <!-- coordinator -->
+  <rect x="200" y="20" width="220" height="50" rx="6" fill="#f0f0f0" stroke="#333"/>
+  <text x="310" y="50" font-family="Arial" font-size="14" text-anchor="middle">Federation coordinator</text>
+
+  <!-- source sidecar -->
+  <rect x="40" y="200" width="200" height="50" rx="6" fill="#f0f0f0" stroke="#333"/>
+  <text x="140" y="230" font-family="Arial" font-size="14" text-anchor="middle">prod_us sidecar</text>
+
+  <!-- target sidecar -->
+  <rect x="380" y="200" width="220" height="50" rx="6" fill="#f0f0f0" stroke="#333"/>
+  <text x="490" y="225" font-family="Arial" font-size="13" text-anchor="middle">prod_eu sidecar</text>
+  <text x="490" y="241" font-family="Arial" font-size="11" text-anchor="middle">(target)</text>
+
+  <!-- 1. run source SELECT -->
+  <line x1="250" y1="70" x2="150" y2="200" stroke="#333" marker-end="url(#arrow)"/>
+  <text x="120" y="135" font-family="Arial" font-size="11">1. run source SELECT</text>
+
+  <!-- 2. Arrow stream -->
+  <line x1="170" y1="200" x2="290" y2="70" stroke="#333" marker-end="url(#arrow)"/>
+  <text x="245" y="150" font-family="Arial" font-size="11">2. Arrow stream</text>
+
+  <!-- 3. bulk-load conveyor -->
+  <line x1="370" y1="60" x2="470" y2="200" stroke="#333" marker-end="url(#arrow)"/>
+  <text x="430" y="135" font-family="Arial" font-size="11">3. bulk-load conveyor</text>
+</svg>

--- a/documentation/sql/diagrams/join-row3.svg
+++ b/documentation/sql/diagrams/join-row3.svg
@@ -1,39 +1,36 @@
-<svg width="640" height="380" viewBox="0 0 640 380" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="380" viewBox="0 0 640 380" font-family="'Inter','Segoe UI',system-ui,sans-serif">
   <defs>
-    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#333"/>
-    </marker>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#1e293b"/></linearGradient>
+    <linearGradient id="coord" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0891b2"/><stop offset="100%" stop-color="#06b6d4"/></linearGradient>
+    <linearGradient id="es" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#059669"/><stop offset="100%" stop-color="#10b981"/></linearGradient>
+    <linearGradient id="join" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#2563eb"/><stop offset="100%" stop-color="#3b82f6"/></linearGradient>
+    <linearGradient id="target" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#ea580c"/><stop offset="100%" stop-color="#f97316"/></linearGradient>
+    <filter id="shadow" x="-6%" y="-8%" width="112%" height="120%"><feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.35"/></filter>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6 Z" fill="#94a3b8"/></marker>
   </defs>
 
-  <!-- source 1 -->
-  <rect x="40" y="40" width="160" height="50" rx="6" fill="#f0f0f0" stroke="#333"/>
-  <text x="120" y="70" font-family="Arial" font-size="14" text-anchor="middle">prod_us</text>
+  <rect width="640" height="380" rx="16" fill="url(#bg)"/>
 
-  <!-- source 2 -->
-  <rect x="40" y="180" width="160" height="50" rx="6" fill="#f0f0f0" stroke="#333"/>
-  <text x="120" y="210" font-family="Arial" font-size="14" text-anchor="middle">prod_fr</text>
+  <rect x="40" y="40" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
+  <text x="120" y="71" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">prod_us</text>
+  <rect x="40" y="180" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
+  <text x="120" y="211" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">prod_fr</text>
 
-  <!-- coordinator -->
-  <rect x="300" y="70" width="300" height="90" rx="6" fill="#f0f0f0" stroke="#333"/>
-  <text x="450" y="105" font-family="Arial" font-size="14" text-anchor="middle">Federation coordinator</text>
-  <text x="450" y="126" font-family="Arial" font-size="12" text-anchor="middle">Parquet scratch +</text>
-  <text x="450" y="143" font-family="Arial" font-size="12" text-anchor="middle">per-query DuckDB view</text>
+  <rect x="300" y="66" width="300" height="98" rx="10" fill="url(#coord)" filter="url(#shadow)"/>
+  <text x="450" y="100" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">Federation coordinator</text>
+  <text x="450" y="123" font-size="11" text-anchor="middle" fill="#cffafe">Parquet scratch +</text>
+  <text x="450" y="140" font-size="11" text-anchor="middle" fill="#cffafe">per-query DuckDB view</text>
 
-  <!-- leg 1 -->
-  <line x1="200" y1="62" x2="298" y2="92" stroke="#333" marker-end="url(#arrow)"/>
-  <text x="245" y="62" font-family="Arial" font-size="11" text-anchor="middle">leg 1</text>
+  <line x1="200" y1="62" x2="298" y2="92" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+  <text x="245" y="60" font-size="11" text-anchor="middle" fill="#cbd5e1">leg 1</text>
+  <line x1="200" y1="206" x2="298" y2="140" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+  <text x="245" y="192" font-size="11" text-anchor="middle" fill="#cbd5e1">leg 2</text>
 
-  <!-- leg 2 -->
-  <line x1="200" y1="206" x2="298" y2="140" stroke="#333" marker-end="url(#arrow)"/>
-  <text x="245" y="190" font-family="Arial" font-size="11" text-anchor="middle">leg 2</text>
+  <line x1="450" y1="164" x2="450" y2="244" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <rect x="320" y="248" width="260" height="44" rx="10" fill="url(#join)" filter="url(#shadow)"/>
+  <text x="450" y="275" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">coordinator-local JOIN</text>
 
-  <!-- coordinator-local JOIN -->
-  <line x1="450" y1="160" x2="450" y2="244" stroke="#333" marker-end="url(#arrow)"/>
-  <rect x="320" y="248" width="260" height="44" rx="6" fill="#f0f0f0" stroke="#333"/>
-  <text x="450" y="275" font-family="Arial" font-size="14" text-anchor="middle">coordinator-local JOIN</text>
-
-  <!-- target -->
-  <line x1="450" y1="292" x2="450" y2="318" stroke="#333" marker-end="url(#arrow)"/>
-  <rect x="320" y="322" width="260" height="44" rx="6" fill="#f0f0f0" stroke="#333"/>
-  <text x="450" y="349" font-family="Arial" font-size="14" text-anchor="middle">prod_eu (target)</text>
+  <line x1="450" y1="292" x2="450" y2="318" stroke="#f97316" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <rect x="320" y="322" width="260" height="44" rx="10" fill="url(#target)" filter="url(#shadow)"/>
+  <text x="450" y="349" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">prod_eu (target)</text>
 </svg>

--- a/documentation/sql/diagrams/join-row3.svg
+++ b/documentation/sql/diagrams/join-row3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="640" height="380" viewBox="0 0 640 380" font-family="'Inter','Segoe UI',system-ui,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="560" viewBox="0 0 640 560" font-family="'Inter','Segoe UI',system-ui,sans-serif">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#1e293b"/></linearGradient>
     <linearGradient id="coord" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0891b2"/><stop offset="100%" stop-color="#06b6d4"/></linearGradient>
@@ -9,32 +9,44 @@
     <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6 Z" fill="#94a3b8"/></marker>
   </defs>
 
-  <rect width="640" height="380" rx="16" fill="url(#bg)"/>
+  <rect width="640" height="560" rx="16" fill="url(#bg)"/>
 
-  <!-- connectors (drawn BEHIND the boxes; heads stop in the gap outside each box) -->
-  <line x1="195" y1="66" x2="292" y2="96" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
-  <line x1="195" y1="206" x2="292" y2="140" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
-  <line x1="450" y1="160" x2="450" y2="240" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
-  <line x1="450" y1="288" x2="450" y2="314" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <!-- terminal header with the SQL query -->
+  <rect x="40" y="16" width="560" height="140" rx="10" fill="#0d1117" stroke="#30363d"/>
+  <circle cx="60" cy="35" r="5.5" fill="#ff5f56"/>
+  <circle cx="78" cy="35" r="5.5" fill="#ffbd2e"/>
+  <circle cx="96" cy="35" r="5.5" fill="#27c93f"/>
+  <text x="582" y="39" text-anchor="end" font-size="11" fill="#8b949e">Row 3 · multi-source coordinator</text>
+  <line x1="40" y1="52" x2="600" y2="52" stroke="#30363d" stroke-width="1"/>
+  <text x="58" y="78" xml:space="preserve" font-family="'JetBrains Mono','SF Mono','Courier New',monospace" font-size="13"><tspan fill="#79c0ff">INSERT INTO</tspan><tspan fill="#e6edf3"> </tspan><tspan fill="#7ee787">`prod_eu`</tspan><tspan fill="#e6edf3">.dest</tspan></text>
+  <text x="58" y="99" xml:space="preserve" font-family="'JetBrains Mono','SF Mono','Courier New',monospace" font-size="13"><tspan fill="#79c0ff">SELECT</tspan><tspan fill="#e6edf3"> o.id, c.name</tspan></text>
+  <text x="58" y="120" xml:space="preserve" font-family="'JetBrains Mono','SF Mono','Courier New',monospace" font-size="13"><tspan fill="#79c0ff">FROM</tspan><tspan fill="#e6edf3"> </tspan><tspan fill="#7ee787">`prod_us`</tspan><tspan fill="#e6edf3">.orders o</tspan></text>
+  <text x="58" y="141" xml:space="preserve" font-family="'JetBrains Mono','SF Mono','Courier New',monospace" font-size="13"><tspan fill="#79c0ff">JOIN</tspan><tspan fill="#e6edf3"> </tspan><tspan fill="#7ee787">`prod_fr`</tspan><tspan fill="#e6edf3">.customers c </tspan><tspan fill="#79c0ff">ON</tspan><tspan fill="#e6edf3"> o.id = c.id;</tspan></text>
 
-  <!-- boxes (on top, cover any connector tail) -->
-  <rect x="40" y="40" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
-  <text x="120" y="71" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">prod_us</text>
-  <rect x="40" y="180" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
-  <text x="120" y="211" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">prod_fr</text>
+  <!-- flow diagram -->
+  <g transform="translate(0,170)">
+    <line x1="195" y1="66" x2="292" y2="96" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+    <line x1="195" y1="206" x2="292" y2="140" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+    <line x1="450" y1="160" x2="450" y2="240" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
+    <line x1="450" y1="288" x2="450" y2="314" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
 
-  <rect x="300" y="66" width="300" height="98" rx="10" fill="url(#coord)" filter="url(#shadow)"/>
-  <text x="450" y="100" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">Federation coordinator</text>
-  <text x="450" y="123" font-size="11" text-anchor="middle" fill="#cffafe">Parquet scratch +</text>
-  <text x="450" y="140" font-size="11" text-anchor="middle" fill="#cffafe">per-query DuckDB view</text>
+    <rect x="40" y="40" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
+    <text x="120" y="71" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">prod_us</text>
+    <rect x="40" y="180" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
+    <text x="120" y="211" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">prod_fr</text>
 
-  <rect x="320" y="248" width="260" height="44" rx="10" fill="url(#join)" filter="url(#shadow)"/>
-  <text x="450" y="275" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">coordinator-local JOIN</text>
+    <rect x="300" y="66" width="300" height="98" rx="10" fill="url(#coord)" filter="url(#shadow)"/>
+    <text x="450" y="100" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">Federation coordinator</text>
+    <text x="450" y="123" font-size="11" text-anchor="middle" fill="#cffafe">Parquet scratch +</text>
+    <text x="450" y="140" font-size="11" text-anchor="middle" fill="#cffafe">per-query DuckDB view</text>
 
-  <rect x="320" y="322" width="260" height="44" rx="10" fill="url(#target)" filter="url(#shadow)"/>
-  <text x="450" y="349" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">prod_eu (target)</text>
+    <rect x="320" y="248" width="260" height="44" rx="10" fill="url(#join)" filter="url(#shadow)"/>
+    <text x="450" y="275" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">coordinator-local JOIN</text>
 
-  <!-- labels -->
-  <text x="248" y="60" font-size="11" text-anchor="middle" fill="#cbd5e1">leg 1</text>
-  <text x="250" y="190" font-size="11" text-anchor="middle" fill="#cbd5e1">leg 2</text>
+    <rect x="320" y="322" width="260" height="44" rx="10" fill="url(#target)" filter="url(#shadow)"/>
+    <text x="450" y="349" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">prod_eu (target)</text>
+
+    <text x="248" y="60" font-size="11" text-anchor="middle" fill="#cbd5e1">leg 1</text>
+    <text x="250" y="190" font-size="11" text-anchor="middle" fill="#cbd5e1">leg 2</text>
+  </g>
 </svg>

--- a/documentation/sql/diagrams/join-row3.svg
+++ b/documentation/sql/diagrams/join-row3.svg
@@ -1,0 +1,39 @@
+<svg width="640" height="380" viewBox="0 0 640 380" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#333"/>
+    </marker>
+  </defs>
+
+  <!-- source 1 -->
+  <rect x="40" y="40" width="160" height="50" rx="6" fill="#f0f0f0" stroke="#333"/>
+  <text x="120" y="70" font-family="Arial" font-size="14" text-anchor="middle">prod_us</text>
+
+  <!-- source 2 -->
+  <rect x="40" y="180" width="160" height="50" rx="6" fill="#f0f0f0" stroke="#333"/>
+  <text x="120" y="210" font-family="Arial" font-size="14" text-anchor="middle">prod_fr</text>
+
+  <!-- coordinator -->
+  <rect x="300" y="70" width="300" height="90" rx="6" fill="#f0f0f0" stroke="#333"/>
+  <text x="450" y="105" font-family="Arial" font-size="14" text-anchor="middle">Federation coordinator</text>
+  <text x="450" y="126" font-family="Arial" font-size="12" text-anchor="middle">Parquet scratch +</text>
+  <text x="450" y="143" font-family="Arial" font-size="12" text-anchor="middle">per-query DuckDB view</text>
+
+  <!-- leg 1 -->
+  <line x1="200" y1="62" x2="298" y2="92" stroke="#333" marker-end="url(#arrow)"/>
+  <text x="245" y="62" font-family="Arial" font-size="11" text-anchor="middle">leg 1</text>
+
+  <!-- leg 2 -->
+  <line x1="200" y1="206" x2="298" y2="140" stroke="#333" marker-end="url(#arrow)"/>
+  <text x="245" y="190" font-family="Arial" font-size="11" text-anchor="middle">leg 2</text>
+
+  <!-- coordinator-local JOIN -->
+  <line x1="450" y1="160" x2="450" y2="244" stroke="#333" marker-end="url(#arrow)"/>
+  <rect x="320" y="248" width="260" height="44" rx="6" fill="#f0f0f0" stroke="#333"/>
+  <text x="450" y="275" font-family="Arial" font-size="14" text-anchor="middle">coordinator-local JOIN</text>
+
+  <!-- target -->
+  <line x1="450" y1="292" x2="450" y2="318" stroke="#333" marker-end="url(#arrow)"/>
+  <rect x="320" y="322" width="260" height="44" rx="6" fill="#f0f0f0" stroke="#333"/>
+  <text x="450" y="349" font-family="Arial" font-size="14" text-anchor="middle">prod_eu (target)</text>
+</svg>

--- a/documentation/sql/diagrams/join-row3.svg
+++ b/documentation/sql/diagrams/join-row3.svg
@@ -11,6 +11,13 @@
 
   <rect width="640" height="380" rx="16" fill="url(#bg)"/>
 
+  <!-- connectors (drawn BEHIND the boxes; heads stop in the gap outside each box) -->
+  <line x1="195" y1="66" x2="292" y2="96" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+  <line x1="195" y1="206" x2="292" y2="140" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+  <line x1="450" y1="160" x2="450" y2="240" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <line x1="450" y1="288" x2="450" y2="314" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
+
+  <!-- boxes (on top, cover any connector tail) -->
   <rect x="40" y="40" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
   <text x="120" y="71" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">prod_us</text>
   <rect x="40" y="180" width="160" height="52" rx="10" fill="url(#es)" filter="url(#shadow)"/>
@@ -21,16 +28,13 @@
   <text x="450" y="123" font-size="11" text-anchor="middle" fill="#cffafe">Parquet scratch +</text>
   <text x="450" y="140" font-size="11" text-anchor="middle" fill="#cffafe">per-query DuckDB view</text>
 
-  <line x1="200" y1="62" x2="298" y2="92" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
-  <text x="245" y="60" font-size="11" text-anchor="middle" fill="#cbd5e1">leg 1</text>
-  <line x1="200" y1="206" x2="298" y2="140" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
-  <text x="245" y="192" font-size="11" text-anchor="middle" fill="#cbd5e1">leg 2</text>
-
-  <line x1="450" y1="164" x2="450" y2="244" stroke="#94a3b8" stroke-width="1.6" marker-end="url(#arrow)"/>
   <rect x="320" y="248" width="260" height="44" rx="10" fill="url(#join)" filter="url(#shadow)"/>
   <text x="450" y="275" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">coordinator-local JOIN</text>
 
-  <line x1="450" y1="292" x2="450" y2="318" stroke="#f97316" stroke-width="1.8" marker-end="url(#arrow)"/>
   <rect x="320" y="322" width="260" height="44" rx="10" fill="url(#target)" filter="url(#shadow)"/>
   <text x="450" y="349" font-size="14" font-weight="700" text-anchor="middle" fill="#fff">prod_eu (target)</text>
+
+  <!-- labels -->
+  <text x="248" y="60" font-size="11" text-anchor="middle" fill="#cbd5e1">leg 1</text>
+  <text x="250" y="190" font-size="11" text-anchor="middle" fill="#cbd5e1">leg 2</text>
 </svg>

--- a/documentation/sql/dql_statements.md
+++ b/documentation/sql/dql_statements.md
@@ -12,7 +12,8 @@ DQL supports:
 - `SELECT` with expressions, aliases, nested fields, STRUCT and ARRAY<STRUCT>
 - `WHERE`, `GROUP BY`, `HAVING`, `ORDER BY`, `LIMIT`, `OFFSET`
 - `UNION ALL`
-- `JOIN UNNEST` on `ARRAY<STRUCT>`
+- cross-index JOINs (`INNER` / `LEFT` / `RIGHT` / `FULL OUTER`) across indices and clusters — see [Cross-Index JOIN](joins.md)
+- `JOIN UNNEST` on `ARRAY<STRUCT>` (the single-index nested form, handled natively inside one index)
 - aggregations, parent-level aggregations on nested arrays
 - window functions with `OVER`
 - rich function support (numeric, string, date/time, geo, conditional, type conversion)
@@ -854,7 +855,7 @@ Notes:
 
 Even though the DQL engine is powerful, some SQL features are not (yet) supported:
 
-- Traditional SQL joins are supported only through the use of Materialized Views (only `JOIN UNNEST` on `ARRAY<STRUCT>` is available natively)
+- Cross-index JOINs (`INNER` / `LEFT` / `RIGHT` / `FULL OUTER`) are supported across indices and clusters — see [Cross-Index JOIN](joins.md). `JOIN UNNEST` on `ARRAY<STRUCT>` is the single-index nested form, handled natively inside one index.
 - No correlated subqueries
 - No arbitrary subqueries in `SELECT` or `WHERE` (except `INSERT ... AS SELECT` in DML)
 - No `GROUPING SETS`, `CUBE`, `ROLLUP`

--- a/documentation/sql/joins.md
+++ b/documentation/sql/joins.md
@@ -29,9 +29,9 @@ Cross-index JOIN ships in three shapes ("rows"). Pick by where your data lives:
 
 **One sentence to decide:** same cluster → **Row 1**; copy results between two clusters → **Row 2**; join across two or more clusters → **Row 3**.
 
-The rule the engine actually applies: `QueryRouter.routeWriteWithJoin` counts the **distinct source catalogs** in the rewritten `FROM` / `JOIN` clauses versus the target catalog. Same (or no) catalog → Row 1; exactly one source catalog different from the target → Row 2; two or more source catalogs → Row 3.
+The rule the engine actually applies: it counts the **distinct source catalogs** in the rewritten `FROM` / `JOIN` clauses versus the target catalog. Same (or no) catalog → Row 1; exactly one source catalog different from the target → Row 2; two or more source catalogs → Row 3.
 
-> **What does NOT work yet:** Cross-index JOINs are first-class in R1, but two things are intentionally **not** here yet: arbitrary **subqueries / CTEs** in a JOIN query land in **R2a**, and **heterogeneous Row-3 sources** (joining ES with Postgres, MySQL, Snowflake, …) land in **R2b** — R1 Row 3 is multi-**Elasticsearch** only. See Known limitations (_pending 17.6_) for the full list.
+> **What does NOT work yet:** Cross-index JOINs are first-class in this release, but two things are intentionally **not** here yet: arbitrary **subqueries / CTEs** in a JOIN query land in **the next release (Quarter 4 2026)**, and **heterogeneous Row-3 sources** (joining ES with Postgres, MySQL, Snowflake, …) land in **the upcoming release (Quarter 1 2027)** — this release's Row 3 is multi-**Elasticsearch** only. See [Known limitations](known_limitations.md) for the full list.
 
 ---
 
@@ -39,21 +39,9 @@ The rule the engine actually applies: `QueryRouter.routeWriteWithJoin` counts th
 
 A Row-1 JOIN reaches two or more indices in **one** Elasticsearch cluster. Each table in the query becomes its own ES sub-query (with any single-table `WHERE` pushed down into it); the cross-index JOIN itself is executed in-process by an embedded **DuckDB** engine inside the driver, sidecar, or REPL. The first JOIN on a fresh process warms up the DuckDB native library once.
 
-```
-        SQL: SELECT ... FROM emp e JOIN dept d ON e.dept_id = d.dept_id
-                                  │
-                    ┌─────────────┴─────────────┐
-                    │   Driver / sidecar / REPL  │
-                    │   (embedded DuckDB engine) │
-                    └─────────────┬─────────────┘
-              sub-query e │                 │ sub-query d
-                          ▼                 ▼
-                   ┌────────────┐    ┌────────────┐
-                   │  ES index  │    │  ES index  │   ← one cluster
-                   │    emp     │    │    dept    │
-                   └────────────┘    └────────────┘
-                          └────► joined in DuckDB ◄────┘ → rows to client
-```
+![Row 1 — same-cluster passthrough](diagrams/join-row1.svg)
+
+*Row 1 — same-cluster passthrough: the embedded DuckDB engine fans each table out to its own ES sub-query in one cluster, then joins the results in-process before returning rows to the client.*
 
 All examples below are transcribed verbatim from the SoftClient4ES JDBC integration test suite.
 They run against two fixtures: **`jdbc_join_emp`** (`emp_id`, `dept_id`, `name`, `salary` — 6 rows: Alice/1/1/6000, Bob/2/1/4000, Carol/3/1/8000, Dave/4/2/5500, Eve/5/2/3000, Orphan/6/**99**/4500) and **`jdbc_join_dept`** (`dept_id`, `dept_name` — Engineering=1, Marketing=2, Empty=9). The orphan employee (`dept_id`=99) and the empty department (`dept_id`=9) surface the outer-join NULLs.
@@ -207,17 +195,9 @@ WHERE e.salary > ?;   -- bind 3500.0 → more rows; bind 6500.0 → fewer (Carol
 
 A Row-2 operation has its **target** in a different cluster from its **source**. The Federation coordinator runs the source SELECT on the source cluster's sidecar, receives the result as an Arrow stream, and **conveyors** it to the target sidecar for a bulk-load. (The JOIN in 2a/2b is itself single-source — both source tables are in `prod_us` — but the *target* `prod_eu` is a different cluster, and that is what makes it Row 2. A plain catalog-to-catalog `INSERT … SELECT *` with no JOIN is also a Row-2 conveyor.)
 
-```
-   ┌──────────────────────────┐
-   │  Federation coordinator  │
-   └───┬──────────────────▲───┘
-   1.  │ run source SELECT │  2. Arrow stream
-       ▼                   │
-   ┌────────────────────┐  │        ┌────────────────────┐
-   │  prod_us  sidecar  │──┘        │  prod_eu  sidecar  │  ← target
-   └────────────────────┘           └─────────▲──────────┘
-            └──────── 3. bulk-load conveyor ───┘
-```
+![Row 2 — cross-cluster conveyor](diagrams/join-row2.svg)
+
+*Row 2 — cross-cluster conveyor: the coordinator runs the source SELECT on `prod_us`, receives the result as an Arrow stream, and bulk-loads it onto the `prod_eu` target sidecar.*
 
 Cross-cluster references use **backtick-quoted catalog prefixes** — the catalog name is the Federation `servers.<name>` alias, which Federation strips before forwarding each leg's SELECT to its source cluster.
 
@@ -247,23 +227,11 @@ JOIN `prod_us`.customers c ON o.id = c.id;
 
 A Row-3 JOIN reaches **two or more source clusters**. The coordinator stages each leg to Parquet scratch on disk and exposes it as a per-query DuckDB view (named `q_<UUID>` for isolation), then runs the JOIN **coordinator-local**.
 
-> **R1 = multi-Elasticsearch only:** in R1, Row 3 joins across **multiple Elasticsearch clusters**. Joining Elasticsearch against heterogeneous sources (Postgres, MySQL, Snowflake, …) is **coming in R2b** — it is not promised for R1.
+> **Multi-Elasticsearch only in this release:** in this release, Row 3 joins across **multiple Elasticsearch clusters**. Joining Elasticsearch against heterogeneous sources (Postgres, MySQL, Snowflake, …) is **coming in the upcoming release (Quarter 1 2027)** — it is not promised for this release.
 
-```
-   ┌──────────────┐   leg 1   ┌──────────────────────────┐
-   │  prod_us     │──────────▶│  Federation coordinator  │
-   └──────────────┘           │                          │
-   ┌──────────────┐   leg 2   │  Parquet scratch + a     │
-   │  prod_fr     │──────────▶│  per-query DuckDB view   │
-   └──────────────┘           └────────────┬─────────────┘
-                                            ▼
-                                 coordinator-local JOIN
-                                            │
-                                            ▼
-                              ┌──────────────────────────┐
-                              │  prod_eu  (target)        │
-                              └──────────────────────────┘
-```
+![Row 3 — multi-source coordinator](diagrams/join-row3.svg)
+
+*Row 3 — multi-source coordinator: each source leg (`prod_us`, `prod_fr`) is staged to Parquet scratch and exposed as a per-query DuckDB view; the JOIN runs coordinator-local before landing on the `prod_eu` target.*
 
 **Multi-source SELECT JOIN** (read; the headline three-cluster query — two source catalogs, joined coordinator-local):
 
@@ -274,7 +242,7 @@ JOIN `prod_eu`.customers c ON o.id = c.id;
 -- two source catalogs (prod_us, prod_eu) → coordinator-local join
 ```
 
-This is the SRE wedge: **correlate logs, metrics, and traces across regional ES clusters in one SQL query.** (The full SRE story lives in the Federation operator guide (_pending 16.6/17.2 merge_) and the `three-region` example topology.)
+This is the SRE wedge: **correlate logs, metrics, and traces across regional ES clusters in one SQL query.** (The full SRE story lives in the [Federation operator guide](../client/federation_operator_guide.md) and the `three-region` example topology.)
 
 **Multi-source INSERT-with-JOIN** (sources `prod_us` + `prod_fr`, target `prod_eu`):
 
@@ -298,12 +266,12 @@ JOIN `prod_fr`.customers c ON o.customer_id = c.id;
 
 ## Performance characteristics
 
-What to expect per row, qualitatively. (Hard latency and throughput numbers belong to the R1.1 Arrow benchmark — link forward, don't pre-empt.)
+What to expect per row, qualitatively. (Hard latency and throughput numbers belong to a follow-up release's Arrow benchmark — link forward, don't pre-empt.)
 
 - **Row 1** — lowest latency of the three rows; the JOIN is in-process DuckDB over ES sub-query results, so the dominant cost is the ES sub-queries plus the cross product. The first JOIN on a fresh process pays a one-time DuckDB native-library warm-up.
 - **Row 2** — adds a network hop (coordinator → source SELECT) plus a bulk-load conveyor to the target; throughput is bound by the Arrow stream and target ingest, not by JSON — data crosses the wire as Arrow RecordBatches.
 - **Row 3** — adds per-leg Parquet staging on the coordinator before the DuckDB join; cost scales with the **largest** leg plus the join cardinality.
-- **Arrow wire format** — for **Flight SQL** and **ADBC** clients specifically, results stream as Arrow RecordBatches (zero JSON on the wire). The JDBC driver surfaces JOIN rows via an in-process Arrow result set and the REPL renders to a console, so the clean zero-JSON-wire property is a Flight-SQL/ADBC trait, not a blanket one. The value here is interoperability and SQL completeness; the full zero-copy speed story is the R1.1 benchmark.
+- **Arrow wire format** — for **Flight SQL** and **ADBC** clients specifically, results stream as Arrow RecordBatches (zero JSON on the wire). The JDBC driver surfaces JOIN rows via an in-process Arrow result set and the REPL renders to a console, so the clean zero-JSON-wire property is a Flight-SQL/ADBC trait, not a blanket one. The value here is interoperability and SQL completeness; the full zero-copy speed story is a follow-up release's benchmark.
 
 ### Row truncation at the result cap
 
@@ -316,7 +284,7 @@ The **joined output** is capped at the tier's `maxQueryResults` (Community 10,00
 Every tier **has every feature.** The meter gates *scale*, not an on/off switch.
 
 - **`maxJoins` — JOIN depth per query.** A 2-table JOIN counts as **1** JOIN, a 3-table JOIN as **2**, a 4-table JOIN as **3**. Community **2** (up to a 3-table JOIN), Pro **5** (up to a 6-table JOIN), Enterprise **∞**. `UNNEST` does **not** count toward `maxJoins`.
-- **`maxClusters` — cross-cluster reach.** Community **1**, Pro **5**, Enterprise **∞**. Single-cluster Federation is free — the **meter**, not a feature flag, is the paywall. **ES-only at R1** (phrased "across N ES clusters").
+- **`maxClusters` — cross-cluster reach.** Community **1**, Pro **5**, Enterprise **∞**. Single-cluster Federation is free — the **meter**, not a feature flag, is the paywall. **ES-only in this release** (phrased "across N ES clusters").
 - **`maxMaterializedViews` — persisted views.** Community **1**, Pro **50**, Enterprise **∞**.
 
 **Community has Federation.** It is capped at 1 cluster — the quota *is* the paywall, not a feature gate. One sidecar / one cluster boots free; a second cluster makes the Federation sidecar fail to start by design.
@@ -357,23 +325,23 @@ For the full price matrix and editions, see the licensing & pricing page on the 
 
 ## What does NOT work yet
 
-- **Arbitrary subqueries and CTEs** inside a JOIN query — coming in **R2a**.
-- **Heterogeneous Row-3 sources** (joining Elasticsearch with Postgres, MySQL, Snowflake, …) — coming in **R2b**; R1 Row 3 is multi-Elasticsearch only.
+- **Arbitrary subqueries and CTEs** inside a JOIN query — coming in **the next release (Quarter 4 2026)**.
+- **Heterogeneous Row-3 sources** (joining Elasticsearch with Postgres, MySQL, Snowflake, …) — coming in **the upcoming release (Quarter 1 2027)**; this release's Row 3 is multi-Elasticsearch only.
 
-Full list: Known limitations (_pending 17.6_).
+Full list: [Known limitations](known_limitations.md).
 
 ## Try it in 5 minutes
 
-- JDBC quickstart — single-cluster JOIN from any JDBC tool.
-- ADBC quickstart (_pending 17.3_) — in-process Arrow.
-- Arrow Flight SQL quickstart — columnar streaming.
-- Federation operator guide (_pending 16.6/17.2 merge_) — cross-cluster (Rows 2 & 3) with the Helm chart.
-- Example topologies live in the [`softclient4es-helm`](https://github.com/SOFTNETWORK-APP/softclient4es-helm) repo: `softclient4es-federation/examples/single-cluster/` and `.../three-region/`. (_pending Epic-16 topologies_)
+- [JDBC quickstart](../client/jdbc.md) — single-cluster JOIN from any JDBC tool.
+- [ADBC quickstart](../client/adbc_driver.md) — in-process Arrow.
+- [Arrow Flight SQL quickstart](../client/arrow_flight_sql.md) — columnar streaming.
+- [Federation operator guide](../client/federation_operator_guide.md) — cross-cluster (Rows 2 & 3) with the Helm chart.
+- Example topologies live in the [`softclient4es-helm`](https://github.com/SOFTNETWORK-APP/softclient4es-helm) repo: `softclient4es-federation/examples/single-cluster/` and `.../three-region/`.
 
 ## See also
 
 - [Materialized Views](materialized_views.md) — superpower #2: persisted, pre-joined data.
 - [DQL Support](dql_statements.md) — non-JOIN SELECT and `JOIN UNNEST` detail.
 - Licensing & pricing — the full edition / quota matrix (on the website).
-- Known limitations (_pending 17.6_).
-- Federation operator guide (_pending 16.6/17.2 merge_).
+- [Known limitations](known_limitations.md).
+- [Federation operator guide](../client/federation_operator_guide.md).

--- a/documentation/sql/joins.md
+++ b/documentation/sql/joins.md
@@ -55,8 +55,7 @@ A Row-1 JOIN reaches two or more indices in **one** Elasticsearch cluster. Each 
                           └────► joined in DuckDB ◄────┘ → rows to client
 ```
 
-All examples below are transcribed verbatim from the JDBC integration suite
-`softclient4es-jdbc/testkit/src/main/scala/app/softnetwork/elastic/jdbc/JdbcIntegrationSpec.scala`.
+All examples below are transcribed verbatim from the SoftClient4ES JDBC integration test suite.
 They run against two fixtures: **`jdbc_join_emp`** (`emp_id`, `dept_id`, `name`, `salary` — 6 rows: Alice/1/1/6000, Bob/2/1/4000, Carol/3/1/8000, Dave/4/2/5500, Eve/5/2/3000, Orphan/6/**99**/4500) and **`jdbc_join_dept`** (`dept_id`, `dept_name` — Engineering=1, Marketing=2, Empty=9). The orphan employee (`dept_id`=99) and the empty department (`dept_id`=9) surface the outer-join NULLs.
 
 A few examples use a separate small fixture **`jdbc_test`** (`id`, `name`, `value` — a 3-column table, **not** the employees table; it has no `salary`/`dept_id`).
@@ -222,8 +221,7 @@ A Row-2 operation has its **target** in a different cluster from its **source**.
 
 Cross-cluster references use **backtick-quoted catalog prefixes** — the catalog name is the Federation `servers.<name>` alias, which Federation strips before forwarding each leg's SELECT to its source cluster.
 
-Examples are transcribed from
-`softclient4es-arrow/federation/src/test/scala/app/softnetwork/elastic/arrow/federation/FederationJoinE2ESpec.scala`.
+Examples are transcribed from the SoftClient4ES Federation integration test suite.
 
 **Cross-cluster INSERT-with-JOIN** — the source SELECT runs on `prod_us`, conveyed to `prod_eu`:
 

--- a/documentation/sql/joins.md
+++ b/documentation/sql/joins.md
@@ -1,0 +1,381 @@
+# Cross-Index JOIN
+
+**Stop ETL'ing Elasticsearch into your warehouse just to JOIN it.**
+
+Elasticsearch has no native cross-index JOIN — and a stock JDBC driver on top of ES can't add one either. SoftClient4ES gives you two things Elasticsearch can't do on its own:
+
+1. **Query-time cross-index JOIN** — `INNER` / `LEFT` / `RIGHT` / `FULL OUTER` joins across indices (and across clusters), at query time, on **every** surface: the REPL, the JDBC driver, the ADBC driver, the Arrow Flight SQL sidecar, and Federation. The drivers are the **free delivery channel**; the JOIN *depth* is metered.
+2. **Persisted [Materialized Views](materialized_views.md)** — the other superpower: denormalize cross-index data once into a queryable view. (That has its own page; this page is about query-time JOINs.)
+
+## The JOIN ladder
+
+Three meters gate how far a JOIN can reach. Think of them as rungs:
+
+- **Query-time depth — `maxJoins`** — how many cross-index JOINs a single query may contain.
+- **Cross-cluster reach — `maxClusters`** — how many Elasticsearch clusters a Federation deployment may span.
+- **Persisted — `maxMaterializedViews`** — how many denormalized views you may keep materialized.
+
+Every tier *has* every feature. The meters gate **scale**, not on/off switches — see [Licensing & the meters](#licensing--the-meters).
+
+## Which row do I need?
+
+Cross-index JOIN ships in three shapes ("rows"). Pick by where your data lives:
+
+| Row | Name | What it does | Engine | Surfaces |
+|---|---|---|---|---|
+| **Row 1** | Passthrough / same-cluster | Cross-index JOIN of 2+ indices in **one** ES cluster | Each leg is an ES sub-query; the JOIN runs in-process in embedded **DuckDB** | REPL, JDBC, ADBC, Flight SQL sidecar |
+| **Row 2** | Cross-cluster conveyor | JOIN / INSERT / CTAS where **source and target live in different clusters** | Coordinator runs the source SELECT and conveyors the Arrow stream to the target sidecar for bulk-load | Federation |
+| **Row 3** | Multi-source coordinator | JOIN across **2+ source clusters** | Coordinator stages each leg to Parquet scratch + a per-query DuckDB view, joins coordinator-local | Federation |
+
+**One sentence to decide:** same cluster → **Row 1**; copy results between two clusters → **Row 2**; join across two or more clusters → **Row 3**.
+
+The rule the engine actually applies: `QueryRouter.routeWriteWithJoin` counts the **distinct source catalogs** in the rewritten `FROM` / `JOIN` clauses versus the target catalog. Same (or no) catalog → Row 1; exactly one source catalog different from the target → Row 2; two or more source catalogs → Row 3.
+
+> **What does NOT work yet:** Cross-index JOINs are first-class in R1, but two things are intentionally **not** here yet: arbitrary **subqueries / CTEs** in a JOIN query land in **R2a**, and **heterogeneous Row-3 sources** (joining ES with Postgres, MySQL, Snowflake, …) land in **R2b** — R1 Row 3 is multi-**Elasticsearch** only. See Known limitations (_pending 17.6_) for the full list.
+
+---
+
+## Row 1 — same-cluster passthrough
+
+A Row-1 JOIN reaches two or more indices in **one** Elasticsearch cluster. Each table in the query becomes its own ES sub-query (with any single-table `WHERE` pushed down into it); the cross-index JOIN itself is executed in-process by an embedded **DuckDB** engine inside the driver, sidecar, or REPL. The first JOIN on a fresh process warms up the DuckDB native library once.
+
+```
+        SQL: SELECT ... FROM emp e JOIN dept d ON e.dept_id = d.dept_id
+                                  │
+                    ┌─────────────┴─────────────┐
+                    │   Driver / sidecar / REPL  │
+                    │   (embedded DuckDB engine) │
+                    └─────────────┬─────────────┘
+              sub-query e │                 │ sub-query d
+                          ▼                 ▼
+                   ┌────────────┐    ┌────────────┐
+                   │  ES index  │    │  ES index  │   ← one cluster
+                   │    emp     │    │    dept    │
+                   └────────────┘    └────────────┘
+                          └────► joined in DuckDB ◄────┘ → rows to client
+```
+
+All examples below are transcribed verbatim from the JDBC integration suite
+`softclient4es-jdbc/testkit/src/main/scala/app/softnetwork/elastic/jdbc/JdbcIntegrationSpec.scala`.
+They run against two fixtures: **`jdbc_join_emp`** (`emp_id`, `dept_id`, `name`, `salary` — 6 rows: Alice/1/1/6000, Bob/2/1/4000, Carol/3/1/8000, Dave/4/2/5500, Eve/5/2/3000, Orphan/6/**99**/4500) and **`jdbc_join_dept`** (`dept_id`, `dept_name` — Engineering=1, Marketing=2, Empty=9). The orphan employee (`dept_id`=99) and the empty department (`dept_id`=9) surface the outer-join NULLs.
+
+A few examples use a separate small fixture **`jdbc_test`** (`id`, `name`, `value` — a 3-column table, **not** the employees table; it has no `salary`/`dept_id`).
+
+### SELECT — INNER / LEFT / RIGHT / FULL OUTER
+
+**INNER JOIN** (the canonical first example):
+
+```sql
+SELECT e.name, e.salary, d.dept_name
+FROM jdbc_join_emp e
+JOIN jdbc_join_dept d ON e.dept_id = d.dept_id;
+-- 5 rows (orphan employee with dept_id=99 dropped by the INNER JOIN)
+```
+
+**LEFT JOIN** with NULLs — unmatched left rows surface NULL on the right (this one uses the `jdbc_test` fixture):
+
+```sql
+SELECT t.id, t.name, d.dept_name
+FROM jdbc_test t
+LEFT JOIN jdbc_join_dept d ON t.id = d.dept_id
+ORDER BY t.id ASC;
+-- only ids 1→Engineering and 2→Marketing match; the rest get NULL dept_name
+```
+
+**RIGHT OUTER** and **FULL OUTER**:
+
+```sql
+-- RIGHT OUTER: dept side fully preserved; empty dept 9 → NULL e.name
+SELECT e.name, d.dept_name
+FROM jdbc_join_emp e
+RIGHT OUTER JOIN jdbc_join_dept d ON e.dept_id = d.dept_id
+ORDER BY d.dept_name ASC;
+
+-- FULL OUTER: NULLs on both sides (empty dept 9 → NULL name; orphan emp dept 99 → NULL dept_name)
+SELECT e.name, d.dept_name
+FROM jdbc_join_emp e
+FULL OUTER JOIN jdbc_join_dept d ON e.dept_id = d.dept_id;
+```
+
+### Predicate pushdown
+
+Each single-table `WHERE` predicate is pushed into its own ES sub-query before the JOIN, so a filtered JOIN returns strictly fewer rows:
+
+```sql
+SELECT e.name, e.salary, d.dept_name
+FROM jdbc_join_emp e
+JOIN jdbc_join_dept d ON e.dept_id = d.dept_id
+WHERE e.salary > 5000 AND d.dept_name = 'Engineering';
+```
+
+### GROUP BY / HAVING / ORDER BY
+
+Aggregation runs in DuckDB after the JOIN:
+
+```sql
+SELECT d.dept_name, COUNT(*) AS cnt
+FROM jdbc_join_emp e
+JOIN jdbc_join_dept d ON e.dept_id = d.dept_id
+GROUP BY d.dept_name
+HAVING COUNT(*) > 1
+ORDER BY COUNT(*) DESC;
+-- Engineering (3), Marketing (2) survive HAVING
+```
+
+> **Two ORDER BY gotchas:** the JOIN planner has two ordering restrictions — you cannot `ORDER BY` a **SELECT alias** (use `ORDER BY COUNT(*)`, not `ORDER BY cnt`), and you cannot `ORDER BY` a column that exists on **both** sides of the JOIN (order by a column unique to one side, e.g. `d.dept_name`, not the shared join key `d.dept_id`).
+
+### ORDER BY … LIMIT (top-N)
+
+```sql
+SELECT e.name, e.salary, d.dept_name
+FROM jdbc_join_emp e
+JOIN jdbc_join_dept d ON e.dept_id = d.dept_id
+ORDER BY e.salary DESC LIMIT 3;
+-- 8000 / 6000 / 5500
+```
+
+### UNNEST + cross-index JOIN
+
+Elasticsearch handles `JOIN UNNEST` on an `ARRAY<STRUCT>` natively inside the sub-query; the cross-index JOIN to the dimension runs in DuckDB. `UNNEST` does **not** count toward `maxJoins`:
+
+```sql
+SELECT o.id, oi.product, oi.quantity, d.dept_name
+FROM jdbc_join_order_items o
+JOIN UNNEST(o.items) AS oi
+JOIN jdbc_join_dept d ON o.customer_id = d.dept_id;
+-- one row per nested item; the UNNESTed nested fields (product, quantity) populate
+```
+
+### INSERT … SELECT … JOIN
+
+Write the joined output into a target index (Row-1 write; orphan dropped → 5 rows):
+
+```sql
+INSERT INTO jdbc_row1_insert_join_target
+SELECT e.name, e.salary, d.dept_name
+FROM jdbc_join_emp e
+JOIN jdbc_join_dept d ON e.dept_id = d.dept_id;
+```
+
+### CREATE TABLE … AS SELECT … JOIN (CTAS)
+
+```sql
+CREATE TABLE jdbc_row1_ctas_join_target AS
+SELECT e.name, e.salary, d.dept_name
+FROM jdbc_join_emp e
+JOIN jdbc_join_dept d ON e.dept_id = d.dept_id;
+```
+
+### CREATE OR REPLACE TABLE … AS
+
+Real REPLACE — drops then recreates, so re-running a narrower query shrinks the table:
+
+```sql
+CREATE OR REPLACE TABLE jdbc_row1_replace_ctas_target AS
+SELECT e.name, e.salary, d.dept_name
+FROM jdbc_join_emp e
+JOIN jdbc_join_dept d ON e.dept_id = d.dept_id;
+```
+
+### INSERT … ON CONFLICT (col) DO UPDATE (upsert)
+
+Idempotent upsert — a stable SHA-1 `_id` is derived from the conflict column, so re-running merges rather than duplicating (count stays 5, not 10):
+
+```sql
+INSERT INTO jdbc_row1_insert_join_upsert_target
+SELECT e.emp_id, e.name, e.salary, d.dept_name
+FROM jdbc_join_emp e
+JOIN jdbc_join_dept d ON e.dept_id = d.dept_id
+ON CONFLICT (emp_id) DO UPDATE;
+```
+
+> **Two ON CONFLICT forms are rejected:** **CTAS + ON CONFLICT** and **INSERT + ON CONFLICT DO NOTHING** are rejected at the boundary — Elasticsearch has no native skip-on-conflict with stable ids. Use `INSERT … ON CONFLICT (col) DO UPDATE` for upserts.
+
+### Prepared statement through a JOIN
+
+A bound parameter is substituted into the sub-query **before** planning, so the same `PreparedStatement` returns different rows for different bindings:
+
+```sql
+SELECT e.name, d.dept_name
+FROM jdbc_join_emp e
+JOIN jdbc_join_dept d ON e.dept_id = d.dept_id
+WHERE e.salary > ?;   -- bind 3500.0 → more rows; bind 6500.0 → fewer (Carol = 8000 survives)
+```
+
+---
+
+## Row 2 — cross-cluster conveyor
+
+A Row-2 operation has its **target** in a different cluster from its **source**. The Federation coordinator runs the source SELECT on the source cluster's sidecar, receives the result as an Arrow stream, and **conveyors** it to the target sidecar for a bulk-load. (The JOIN in 2a/2b is itself single-source — both source tables are in `prod_us` — but the *target* `prod_eu` is a different cluster, and that is what makes it Row 2. A plain catalog-to-catalog `INSERT … SELECT *` with no JOIN is also a Row-2 conveyor.)
+
+```
+   ┌──────────────────────────┐
+   │  Federation coordinator  │
+   └───┬──────────────────▲───┘
+   1.  │ run source SELECT │  2. Arrow stream
+       ▼                   │
+   ┌────────────────────┐  │        ┌────────────────────┐
+   │  prod_us  sidecar  │──┘        │  prod_eu  sidecar  │  ← target
+   └────────────────────┘           └─────────▲──────────┘
+            └──────── 3. bulk-load conveyor ───┘
+```
+
+Cross-cluster references use **backtick-quoted catalog prefixes** — the catalog name is the Federation `servers.<name>` alias, which Federation strips before forwarding each leg's SELECT to its source cluster.
+
+Examples are transcribed from
+`softclient4es-arrow/federation/src/test/scala/app/softnetwork/elastic/arrow/federation/FederationJoinE2ESpec.scala`.
+
+**Cross-cluster INSERT-with-JOIN** — the source SELECT runs on `prod_us`, conveyed to `prod_eu`:
+
+```sql
+INSERT INTO `prod_eu`.dest
+SELECT o.id, c.name
+FROM `prod_us`.orders o
+JOIN `prod_us`.customers c ON o.id = c.id;
+```
+
+**Cross-cluster CTAS-with-JOIN** — the target DDL is inferred from the source FlightInfo schema, then conveyed:
+
+```sql
+CREATE TABLE `prod_eu`.dest AS
+SELECT o.id, c.name
+FROM `prod_us`.orders o
+JOIN `prod_us`.customers c ON o.id = c.id;
+```
+
+---
+
+## Row 3 — multi-source coordinator
+
+A Row-3 JOIN reaches **two or more source clusters**. The coordinator stages each leg to Parquet scratch on disk and exposes it as a per-query DuckDB view (named `q_<UUID>` for isolation), then runs the JOIN **coordinator-local**.
+
+> **R1 = multi-Elasticsearch only:** in R1, Row 3 joins across **multiple Elasticsearch clusters**. Joining Elasticsearch against heterogeneous sources (Postgres, MySQL, Snowflake, …) is **coming in R2b** — it is not promised for R1.
+
+```
+   ┌──────────────┐   leg 1   ┌──────────────────────────┐
+   │  prod_us     │──────────▶│  Federation coordinator  │
+   └──────────────┘           │                          │
+   ┌──────────────┐   leg 2   │  Parquet scratch + a     │
+   │  prod_fr     │──────────▶│  per-query DuckDB view   │
+   └──────────────┘           └────────────┬─────────────┘
+                                            ▼
+                                 coordinator-local JOIN
+                                            │
+                                            ▼
+                              ┌──────────────────────────┐
+                              │  prod_eu  (target)        │
+                              └──────────────────────────┘
+```
+
+**Multi-source SELECT JOIN** (read; the headline three-cluster query — two source catalogs, joined coordinator-local):
+
+```sql
+SELECT o.id, c.name
+FROM `prod_us`.orders o
+JOIN `prod_eu`.customers c ON o.id = c.id;
+-- two source catalogs (prod_us, prod_eu) → coordinator-local join
+```
+
+This is the SRE wedge: **correlate logs, metrics, and traces across regional ES clusters in one SQL query.** (The full SRE story lives in the Federation operator guide (_pending 16.6/17.2 merge_) and the `three-region` example topology.)
+
+**Multi-source INSERT-with-JOIN** (sources `prod_us` + `prod_fr`, target `prod_eu`):
+
+```sql
+INSERT INTO `prod_eu`.dest
+SELECT o.id, c.name
+FROM `prod_us`.orders o
+JOIN `prod_fr`.customers c ON o.customer_id = c.id;
+```
+
+**Multi-source CREATE OR REPLACE TABLE … AS:**
+
+```sql
+CREATE OR REPLACE TABLE `prod_eu`.dest AS
+SELECT o.id, c.name
+FROM `prod_us`.orders o
+JOIN `prod_fr`.customers c ON o.customer_id = c.id;
+```
+
+---
+
+## Performance characteristics
+
+What to expect per row, qualitatively. (Hard latency and throughput numbers belong to the R1.1 Arrow benchmark — link forward, don't pre-empt.)
+
+- **Row 1** — lowest latency of the three rows; the JOIN is in-process DuckDB over ES sub-query results, so the dominant cost is the ES sub-queries plus the cross product. The first JOIN on a fresh process pays a one-time DuckDB native-library warm-up.
+- **Row 2** — adds a network hop (coordinator → source SELECT) plus a bulk-load conveyor to the target; throughput is bound by the Arrow stream and target ingest, not by JSON — data crosses the wire as Arrow RecordBatches.
+- **Row 3** — adds per-leg Parquet staging on the coordinator before the DuckDB join; cost scales with the **largest** leg plus the join cardinality.
+- **Arrow wire format** — for **Flight SQL** and **ADBC** clients specifically, results stream as Arrow RecordBatches (zero JSON on the wire). The JDBC driver surfaces JOIN rows via an in-process Arrow result set and the REPL renders to a console, so the clean zero-JSON-wire property is a Flight-SQL/ADBC trait, not a blanket one. The value here is interoperability and SQL completeness; the full zero-copy speed story is the R1.1 benchmark.
+
+### Row truncation at the result cap
+
+The **joined output** is capped at the tier's `maxQueryResults` (Community 10,000). Over-cap results are **truncated with a warning** — never silently dropped: JDBC and ADBC raise `SQLWarning 01004` (`Result truncated to N rows`), and Flight SQL emits an `x-result-truncated` header.
+
+> **Join inputs are never capped:** the result cap applies to the **joined output only**, never to a JOIN leg. Capping a leg would truncate a JOIN input and produce **silently wrong** results. So a wide Community join can hit the 10,000-row output cap even though none of its inputs were truncated.
+
+## Licensing & the meters
+
+Every tier **has every feature.** The meter gates *scale*, not an on/off switch.
+
+- **`maxJoins` — JOIN depth per query.** A 2-table JOIN counts as **1** JOIN, a 3-table JOIN as **2**, a 4-table JOIN as **3**. Community **2** (up to a 3-table JOIN), Pro **5** (up to a 6-table JOIN), Enterprise **∞**. `UNNEST` does **not** count toward `maxJoins`.
+- **`maxClusters` — cross-cluster reach.** Community **1**, Pro **5**, Enterprise **∞**. Single-cluster Federation is free — the **meter**, not a feature flag, is the paywall. **ES-only at R1** (phrased "across N ES clusters").
+- **`maxMaterializedViews` — persisted views.** Community **1**, Pro **50**, Enterprise **∞**.
+
+**Community has Federation.** It is capped at 1 cluster — the quota *is* the paywall, not a feature gate. One sidecar / one cluster boots free; a second cluster makes the Federation sidecar fail to start by design.
+
+The same meters, in source-of-truth order (MV / results / clusters / joins):
+
+| Tier | `maxMaterializedViews` | `maxQueryResults` | `maxClusters` | `maxJoins` |
+|---|---|---|---|---|
+| Community | 1 | 10,000 | 1 | 2 |
+| Pro | 50 | 1,000,000 | 5 | 5 |
+| Enterprise | ∞ | ∞ | ∞ | ∞ |
+
+### What happens at each cap (verified)
+
+- **`maxJoins` exceeded** → the planner rejects the query. A 4-table query (3 cross-index JOINs) under Community is rejected with a message that names the count, the limit, the next tier, and the upgrade URL:
+
+```sql
+-- 4 tables = 3 cross-index JOINs → exceeds Community maxJoins=2 → rejected
+SELECT t.id, d.dept_name, r.region_name, m.team_name
+FROM jdbc_test t
+JOIN jdbc_join_dept d   ON t.id = d.dept_id
+JOIN jdbc_join_region r ON t.id = r.region_id
+JOIN jdbc_join_team m   ON t.id = m.team_id;
+-- Error: "Query contains 3 cross-index JOINs ... maximum of 2 ... Upgrade to Pro ...
+--         See: https://portal.softclient4es.com/pricing"
+```
+
+  The same query runs unchanged on Pro or Enterprise (higher / no cap).
+
+- **`maxClusters` exceeded** → the Federation sidecar **fails to start** (by design — a CrashLoop) rather than silently dropping a cluster.
+- **`maxQueryResults` exceeded** → **truncate-with-warning** on the no-`LIMIT` path (`SQLWarning 01004` / Flight `x-result-truncated`), or an HTTP 402 on an explicit `LIMIT` over quota.
+
+The JOIN engine ships in the Elastic-License extensions — **free to use** (not "source-available").
+
+For the full price matrix and editions, see the licensing & pricing page on the website.
+
+---
+
+## What does NOT work yet
+
+- **Arbitrary subqueries and CTEs** inside a JOIN query — coming in **R2a**.
+- **Heterogeneous Row-3 sources** (joining Elasticsearch with Postgres, MySQL, Snowflake, …) — coming in **R2b**; R1 Row 3 is multi-Elasticsearch only.
+
+Full list: Known limitations (_pending 17.6_).
+
+## Try it in 5 minutes
+
+- JDBC quickstart — single-cluster JOIN from any JDBC tool.
+- ADBC quickstart (_pending 17.3_) — in-process Arrow.
+- Arrow Flight SQL quickstart — columnar streaming.
+- Federation operator guide (_pending 16.6/17.2 merge_) — cross-cluster (Rows 2 & 3) with the Helm chart.
+- Example topologies live in the [`softclient4es-helm`](https://github.com/SOFTNETWORK-APP/softclient4es-helm) repo: `softclient4es-federation/examples/single-cluster/` and `.../three-region/`. (_pending Epic-16 topologies_)
+
+## See also
+
+- [Materialized Views](materialized_views.md) — superpower #2: persisted, pre-joined data.
+- [DQL Support](dql_statements.md) — non-JOIN SELECT and `JOIN UNNEST` detail.
+- Licensing & pricing — the full edition / quota matrix (on the website).
+- Known limitations (_pending 17.6_).
+- Federation operator guide (_pending 16.6/17.2 merge_).


### PR DESCRIPTION
Epic 17 (R1 Documentation & Marketing), Layer 0 — in-repo Markdown twin of the canonical website JOIN doc (`SOFTNETWORK-APP/softclient4es-web#12`).

Closes #135.

## What
- **NEW** `documentation/sql/joins.md` — `# Cross-Index JOIN` page: same content as the canonical MDX, plain GitHub Markdown, all three diagrams as fenced ASCII. Worked SQL transcribed **verbatim** from the JDBC tests (`softclient4es-jdbc` `JdbcIntegrationSpec.scala`) and federation tests (`softclient4es-arrow` `FederationJoinE2ESpec.scala`).
- **UPDATE** `documentation/sql/README.md` — `- [Cross-Index JOIN](joins.md)` added after DQL Support.
- **UPDATE** `documentation/sql/dql_statements.md` — stale JOIN-limitation copy reconciled in two places (the top "What is supported" list and the `## Limitations` "joins only via Materialized Views" bullet), both pointing at the new page.

## Verification
- Pure Markdown (no Scala touched) — no build needed.
- Dual-docs parity verified against the canonical MDX: identical worked SQL (18 SQL examples each), identical quota table (MV/results/clusters/joins order), and the 1m Community-reject example (4-table / 3-JOIN, "maximum of 2") byte-aligned in both files.
- Quotas locked: Community 1/10,000/1/2, Pro 50/1,000,000/5/5, Enterprise ∞. Community HAS Federation (1 cluster). ELv2 = "free to use", never "source-available".

## Pending cross-links (Epic-17-close launch gate)
Links to not-yet-merged targets are marked `pending` (17.6 known-limitations, 17.3 ADBC, 17.2/16.6 federation guide, Epic-16 topologies). AC15 close-out gate strips every `pending` before R1.

Sibling PR: `SOFTNETWORK-APP/softclient4es-web#12` (canonical MDX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
