### PR TITLE
Story 17.4: BI-tool integration index (bi_tools.md) — elasticsql MD mirror

### DIFF
--- a/documentation/client/README.md
+++ b/documentation/client/README.md
@@ -23,4 +23,5 @@ Welcome to the Client Engine Documentation. Navigate through the sections below:
 - [REPL Client](repl.md)
 - [Arrow Flight SQL](arrow_flight_sql.md)
 - [ADBC Driver](adbc_driver.md)
+- [BI Tool Integration](bi_tools.md) — DBeaver, Superset, Grafana, Tableau, Power BI, Metabase (full guides on the website)
 - [Telemetry & Privacy](telemetry.md)

--- a/documentation/client/bi_tools.md
+++ b/documentation/client/bi_tools.md
@@ -1,0 +1,22 @@
+# BI Tool Integration
+
+SoftClient4ES connects to common BI and SQL tools through the **JDBC driver** (`jdbc:elastic://host:port`, driver class `app.softnetwork.elastic.jdbc.ElasticDriver`) or the **Arrow Flight SQL** server (`grpc://host:32010`).
+
+Full, step-by-step guides — connect, browse your indices, and run a cross-index JOIN — live on the website. This page is an index; the website carries the screenshots and per-tool detail.
+
+## Tested vs Compatible
+
+**Tested** tools are exercised against SoftClient4ES. **Compatible** tools speak a working protocol but have not been through formal regression (best-effort).
+
+| Tool | Tier | Path | Guide |
+|---|---|---|---|
+| Apache Superset | Tested (dedicated dialect) | Arrow Flight SQL | https://softclient4es.dev/integrations/superset/ |
+| DBeaver | Tested | JDBC or Arrow Flight SQL | https://softclient4es.dev/integrations/dbeaver/ |
+| Grafana | Tested (via Arrow Flight SQL) | Arrow Flight SQL | https://softclient4es.dev/integrations/grafana/ |
+| Tableau | Compatible (not formally tested) | JDBC | https://softclient4es.dev/integrations/tableau/ |
+| Power BI | Compatible (not formally tested) | JDBC | https://softclient4es.dev/integrations/power-bi/ |
+| Metabase | Compatible (not formally tested) | JDBC | https://softclient4es.dev/integrations/metabase/ |
+
+## Honest-gap note
+
+Every tool runs the R1 superpower — a **cross-index JOIN** that Elasticsearch can't do — best through explicit `JOIN … ON …` SQL. Some BI tools auto-generate nested subqueries (Tableau live connections, Power BI DirectQuery relationships, the Metabase GUI Question builder); subqueries and CTEs are not in R1 yet. Use Extract / Import / Native-SQL mode with explicit JOINs as the workaround. Full BI-tool subquery / CTE support is coming in R2a. See the website's Known Limitations page for the full picture.

--- a/documentation/client/bi_tools.md
+++ b/documentation/client/bi_tools.md
@@ -19,4 +19,4 @@ Full, step-by-step guides — connect, browse your indices, and run a cross-inde
 
 ## Honest-gap note
 
-Every tool runs the R1 superpower — a **cross-index JOIN** that Elasticsearch can't do — best through explicit `JOIN … ON …` SQL. Some BI tools auto-generate nested subqueries (Tableau live connections, Power BI DirectQuery relationships, the Metabase GUI Question builder); subqueries and CTEs are not in R1 yet. Use Extract / Import / Native-SQL mode with explicit JOINs as the workaround. Full BI-tool subquery / CTE support is coming in R2a. See the website's Known Limitations page for the full picture.
+Every tool runs the superpower of this release — a **cross-index JOIN** that Elasticsearch can't do — best through explicit `JOIN … ON …` SQL. Some BI tools auto-generate nested subqueries (Tableau live connections, Power BI DirectQuery relationships, the Metabase GUI Question builder); subqueries and CTEs are not in this release yet. Use Extract / Import / Native-SQL mode with explicit JOINs as the workaround. Full BI-tool subquery / CTE support is coming in the next release (Quarter 4 2026). See the website's Known Limitations page for the full picture.


### PR DESCRIPTION
Epic 17 — R1 Documentation & Marketing · Story 17.4 (Layer 1; deps 17.1, 17.6). Closes #142.

## What

The full BI-tool integration guides are **web-only** (A2 carve-out — no `documentation/` MD twin, consistent with how 15.6/17.6/17.3 handled web-only surfaces). The elasticsql side carries an **abridged index pointer only**, NOT six per-tool MD files.

- CREATE `documentation/client/bi_tools.md` — one-screen stub: Tested-vs-Compatible tier table (Tested = DBeaver/Superset/Grafana via dedicated dialect / Arrow Flight SQL; Compatible = Tableau/Power BI/Metabase) + per-tool website deep links (`https://softclient4es.dev/integrations/<tool>/`, each resolves) + honest-gap note.
- UPDATE `documentation/client/README.md` — `[BI Tool Integration](bi_tools.md)` index line after ADBC Driver.

## Notes

- Stub chosen over a bare README line (OQ-2 option b, "preferred for accuracy") because a generic "BI guides" label must NOT point at the single `/integrations/jdbc/` page (no BI-index route exists on the site).
- Full per-tool content (connect/browse/JOIN/screenshot) lives on the website.

Sibling PR (canonical web content): SOFTNETWORK-APP/softclient4es-web#19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)