### PR TITLE
chore: gitignore blogs/ and linkedin/ (local-only marketing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ testkit/target*
 _bmad*
 docker/data
 .claude
+blogs/
+linkedin/


### PR DESCRIPTION
Adds `blogs/` and `linkedin/` to `.gitignore` on `release-r1`.

Blog posts and LinkedIn snippets/assets are **local-only** working material and must never be committed to this public repo. `release-r1` previously ignored neither (only `main` ignored `blogs/`), which is how a dev run accidentally committed them into a draft PR (since closed). This makes the rule enforceable on `release-r1` and any branch cut from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)