### PR TITLE
docs: add cross-index JOINs to DQL Version Compatibility matrix (MD twin)

### DIFF
--- a/documentation/sql/dql_statements.md
+++ b/documentation/sql/dql_statements.md
@@ -841,6 +841,7 @@ Notes:
 | Basic SELECT                   | ✔   | ✔   | ✔   | ✔   |
 | Nested fields                  | ✔   | ✔   | ✔   | ✔   |
 | UNION ALL                      | ✔   | ✔   | ✔   | ✔   |
+| Cross-index JOINs              | ✔   | ✔   | ✔   | ✔   |
 | JOIN UNNEST                    | ✔   | ✔   | ✔   | ✔   |
 | Aggregations                   | ✔   | ✔   | ✔   | ✔   |
 | Parent-level nested array aggs | ✔   | ✔   | ✔   | ✔   |


### PR DESCRIPTION
One-commit follow-up to #153: the MD twin sync (`documentation/sql/dql_statements.md` Version Compatibility table gains the Cross-index JOINs row) was pushed to the branch a few minutes after #153 merged, so it missed the train into #152.

Mirrors softclient4es-web PR SOFTNETWORK-APP/softclient4es-web#26 (same row in `sql/dql.mdx` and `architecture/es-versions.mdx`), per the dual MD+MDX docs-sync rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)