### PR TITLE
docs: fix install script URLs (scripts/ path 404s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Get started in seconds with the interactive SQL client:
 
 **Linux / macOS:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/SOFTNETWORK-APP/SoftClient4ES/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/SOFTNETWORK-APP/SoftClient4ES/main/install.sh | bash
 ```
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/SOFTNETWORK-APP/SoftClient4ES/main/scripts/install.ps1 | iex
+irm https://raw.githubusercontent.com/SOFTNETWORK-APP/SoftClient4ES/main/install.ps1 | iex
 ```
 
 ### Connect and Query


### PR DESCRIPTION
The Quick Start curl/irm commands point to `main/scripts/install.sh` and `main/scripts/install.ps1` — a `scripts/` directory that has never existed in the repository (verified with `git log --all --full-history -- scripts/`). Both URLs return 404, so the documented one-liner install fails.

The actual files live at the repository root: [install.sh](https://github.com/SOFTNETWORK-APP/SoftClient4ES/blob/main/install.sh) / [install.ps1](https://github.com/SOFTNETWORK-APP/SoftClient4ES/blob/main/install.ps1). This PR points the README at them.

Verified while investigating: the CLI artifact resolves publicly on JFrog (`softclient4es8-cli_2.13` up to **0.20.0**), and the REPL sources are in `core` (`client/Cli.scala`, `client/repl/*`) — the `es{N}/cli` sbt projects are assembly-only wrappers with no committed sources, which is why no `cli/` directories appear on GitHub.

Blocking for the launch post scheduled Tue Jul 28, which links this install one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)