### PR TITLE
fix(build): es6 cli crashes on first use — add explicit log4j-api (#168)

### DIFF
--- a/project/SoftClient4es.scala
+++ b/project/SoftClient4es.scala
@@ -68,7 +68,18 @@ trait SoftClient4es {
       case 6 =>
         Seq(
           "com.sksamuel.elastic4s" %% "elastic4s-core" % Versions.elastic64s exclude ("org.elasticsearch", "elasticsearch") exclude ("org.slf4j", "slf4j-api"),
-          "com.sksamuel.elastic4s" %% "elastic4s-http" % Versions.elastic64s exclude ("org.elasticsearch", "elasticsearch")
+          "com.sksamuel.elastic4s" %% "elastic4s-http" % Versions.elastic64s exclude ("org.elasticsearch", "elasticsearch"),
+          // Same story as ES7 below (issue #168): ES6's elastic4s-http pulls
+          // elasticsearch-rest-high-level-client 6.8.x, whose <clinit> hard-references
+          // org.apache.logging.log4j.LogManager (log4j-api), while excludeSlf4jAndLog4j strips
+          // every org.apache.logging.log4j artifact from the closure. Without this explicit
+          // re-add the published softclient4es6-rest-client — and therefore the plain es6 REPL —
+          // crashes on the first ES call with
+          //   NoClassDefFoundError: org/apache/logging/log4j/LogManager.
+          // Versions.log4j (2.17.1) matches the log4j the ES 6.8.23 server bundles; only the
+          // log4j-api surface is needed client-side (no provider required — log4j-api falls
+          // back to its no-op/SimpleLogger provider, which is fine for the cli).
+          "org.apache.logging.log4j" % "log4j-api" % Versions.log4j
         )
       case 7 =>
         Seq(
@@ -80,7 +91,8 @@ trait SoftClient4es {
           // the es7 JDBC driver and the arrow es7 sidecar — crash on the first ES call with
           //   NoClassDefFoundError: org/apache/logging/log4j/LogManager.
           // Versions.log4j (2.17.1) matches the log4j-core ES 7.17 bundles, keeping the pair
-          // aligned. (ES6 RHLC needs no log4j; ES8/9 use the new Java client.)
+          // aligned. (ES6's RHLC has the same LogManager hard reference — handled above, see
+          // issue #168; ES8/9 use the new Java client.)
           "org.apache.logging.log4j" % "log4j-api" % Versions.log4j
         )
       case 8 =>


### PR DESCRIPTION
Closes #168.

## Root cause

The global `excludeSlf4jAndLog4j` rules in `project/SoftClient4es.scala` strip **every** `org.apache.logging.log4j` artifact from the published dependency closure, while ES6's `RestHighLevelClient` `<clinit>` hard-references `org.apache.logging.log4j.LogManager` (log4j-api). As a result the published `softclient4es6-rest-client` — and therefore the plain es6 cli 0.20.1 — crashed on first use with:

```
NoClassDefFoundError: org/apache/logging/log4j/LogManager
```

es7 already carried an explicit `log4j-api` re-add for the exact same reason; es6 did not (the es7 comment even claimed "ES6 RHLC needs no log4j" — disproved by REPL.4's bundle E2E smoke on ES 6.8.23).

## Fix

Mirror es7's explicit dependency in `elastic4sDependencies(6)`:

- `"org.apache.logging.log4j" % "log4j-api" % Versions.log4j` (2.17.1 — matches the log4j ES 6.8.23 bundles; only the API surface is needed client-side, log4j-api's SimpleLogger fallback is fine for the cli)
- Corrected the stale es7 comment to point at the es6 case and issue #168.

## Verification

- `sbt es6cli/assembly` — assembly jar now contains `org/apache/logging/log4j/LogManager.class`
- Live smoke against docker `elasticsearch:6.8.23` (single node, green): `java -jar softclient4es6-cli-0.20.1-assembly.jar -p 9268 -c "SHOW TABLES"` and a `SELECT name, age FROM people` after indexing a doc — both succeed, no `NoClassDefFoundError` (log4j-api falls back to SimpleLogger with a benign StatusLogger notice)
- `sbt "+ es6rest/compile" "+ es6jest/compile" scalafmtCheck` — all green (Scala 2.12 + 2.13)

## Notes

- No version bump here: this rides the **0.20.2** line — the 0.20.2-SNAPSHOT bump arrives via the epic #169 PRs. See #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
