### PR TITLE
fix(build): plain cli fails all queries on JDK 18+ — discard classless resolver-SPI registration (#171)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -321,6 +321,14 @@ def cliProject(esVersion: String, ss: Def.SettingsDefinition*): Project = {
       ),
 
       assembly / assemblyMergeStrategy := {
+        // Issue #171: dnsjava (transitive via hadoop-client -> hadoop-common) registers
+        // org.xbill.DNS.spi.DnsjavaInetAddressResolverProvider, but the provider class only
+        // exists under META-INF/versions/18/ (multi-release jar), which the META-INF discard
+        // rule below drops. Keeping the classless registration breaks ALL name resolution on
+        // JDK 18+ (JEP 418 consults the InetAddressResolver SPI on first lookup), so the
+        // service entry must be discarded along with the class.
+        case PathList("META-INF", "services", "java.net.spi.InetAddressResolverProvider") =>
+          MergeStrategy.discard
         case PathList("META-INF", "services", _ @_*) => MergeStrategy.concat
         case PathList("META-INF", _ @_*) => MergeStrategy.discard
         case "reference.conf"            => MergeStrategy.concat


### PR DESCRIPTION
Closes #171.

## Root cause

`dnsjava` (transitive: `dnsjava:dnsjava:3.6.1` ← `org.apache.hadoop:hadoop-common:3.4.2` ← `org.apache.hadoop:hadoop-client:3.4.2` ← `softclient4es-core`) ships `META-INF/services/java.net.spi.InetAddressResolverProvider` registering `org.xbill.DNS.spi.DnsjavaInetAddressResolverProvider`.

dnsjava 3.6.x is a **multi-release jar**: that provider class exists only under `META-INF/versions/18/`. The cli assembly merge strategy keeps every `META-INF/services/*` entry (`MergeStrategy.concat`) but discards everything else under `META-INF/` — including the versioned class directories. The plain cli assemblies therefore ship the SPI **registration without its class**.

On JDK 18+ (JEP 418), the `InetAddressResolver` SPI is consulted on the first name resolution: the JVM tries to load the registered provider, fails with `ServiceConfigurationError`/`ClassNotFoundException`, and **every query fails** (reproduced on JDK 21 with the published 0.20.1 assemblies, found while validating PR #170). JDK 11/17 never consult the SPI, which is why this went unnoticed.

## Fix

Add a more specific case *before* the services-concat line in the shared `cliProject` merge strategy (covers **all** cli assemblies — es6/7/8/9):

```scala
case PathList("META-INF", "services", "java.net.spi.InetAddressResolverProvider") =>
  MergeStrategy.discard
```

The class isn't shipped, so the registration must not be either — the JVM then falls back to the built-in resolver.

## Evidence

**Before** (assembly built from `main` @ 12e60dd5, same 0.20.1 layout as the published jar):

```
$ unzip -l softclient4es8-cli-0.20.1-assembly.jar | grep InetAddressResolverProvider
      53  META-INF/services/java.net.spi.InetAddressResolverProvider
$ unzip -p softclient4es8-cli-0.20.1-assembly.jar META-INF/services/java.net.spi.InetAddressResolverProvider
org.xbill.DNS.spi.DnsjavaInetAddressResolverProvider
```

…while `org/xbill/DNS/spi/` in the same jar contains only `DNSJavaNameService` and `DNSJavaNameServiceDescriptor` — **no** `DnsjavaInetAddressResolverProvider` class (confirming the classless registration).

**After** (assembly rebuilt with the fix): the `META-INF/services/java.net.spi.InetAddressResolverProvider` entry is gone; all other service registrations (ExtensionSpi, ElasticClientSpi, Lucene codecs, jackson, slf4j, JLine providers, …) are intact.

## Smoke tests (ES 8.18.3 single-node Docker, port 9271)

- **JDK 21 (zulu 21.0.3)**: `java -jar softclient4es8-cli-0.20.1-assembly.jar -p 9271 -c "SHOW TABLES"` → `✅ No rows returned (250ms)`, metrics `Success Rate: 100.0%`, zero `InetAddressResolver` errors. Connecting to localhost proves the built-in resolver is used.
- **Default JDK 11 (zulu 11.0.23)**: same command → `✅ No rows returned (244ms)`, `Success Rate: 100.0%` — no regression.

## Versioning

No version bump — stays 0.20.1 and rides the 0.20.2 line via the epic PRs.

Refs #169 and PR #170 (where the bug was found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
