### PR TITLE
fix(installer): drop unreferenced STDOUT appender from the generated logback.xml (#177)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -430,11 +430,11 @@ function Create-LogbackConfig {
         <appender-ref ref="FILE" />
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%date{HH:mm:ss.SSS} %-5level %logger{20} - %msg%n</pattern>
-        </encoder>
-    </appender>
+    <!-- File-only by design: the REPL owns stdout. An appender that no
+         <appender-ref> points at is reported as unreferenced, and that single
+         WARN makes logback dump its entire status log to stdout on every
+         launch. Reference any new appender from <root> or a <logger>, or
+         leave it out. -->
 
     <logger name="app.softnetwork.elastic" level="INFO" />
     <logger name="org.apache.http" level="WARN" />

--- a/install.sh
+++ b/install.sh
@@ -1121,11 +1121,11 @@ create_logback_config() {
         <appender-ref ref="FILE" />
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%date{HH:mm:ss.SSS} %-5level %logger{20} - %msg%n</pattern>
-        </encoder>
-    </appender>
+    <!-- File-only by design: the REPL owns stdout. An appender that no
+         <appender-ref> points at is reported as unreferenced, and that single
+         WARN makes logback dump its entire status log to stdout on every
+         launch. Reference any new appender from <root> or a <logger>, or
+         leave it out. -->
 
     <logger name="app.softnetwork.elastic" level="INFO" />
     <logger name="org.apache.http" level="WARN" />


### PR DESCRIPTION
Closes #177.

## What was wrong

Both installers generated a `conf/logback.xml` declaring a `ConsoleAppender` named `STDOUT` that no logger referenced. Logback flags that with a single WARN — `Appender named [STDOUT] not referenced. Skipping further processing.` — and because a WARN occurred during configuration it then prints its **entire status log to stdout** on every REPL and every `-c` batch launch.

Root cause verified in logback 1.5.32 bytecode, not inferred: `AppenderModelHandler` calls `ModelInterpretationContext.hasDependers(name)` and `addWarn(...)` when nothing points at the appender; `LogbackServiceProvider.initialize()` then calls `StatusPrinter.printInCaseOfErrorsOrWarnings(ctx)`, which dumps the whole status list when the max level is WARN or above. `StatusPrinter2` writes to `System.out`, so this is not merely cosmetic — it corrupts piped `-c` output.

## The fix

Remove the `STDOUT` appender from both generated templates. Console logging is off by design (records go to `logs/` via `ASYNC` → `FILE`), and because the appender was unreferenced from the start **no log record ever reached it** — so this changes the status spam only, never log routing. An XML comment replaces it recording the constraint, so the appender is not reintroduced.

## Verification

| Check | Result |
|---|---|
| Status lines on launch (real 0.20.2 bundle, live ES) | 36 → **0**, zero WARN/ERROR |
| `logs/softclient4es.log` still written | yes — `FILE` appender still active |
| Both embedded templates parse (ElementTree) | valid; appenders `[FILE, ASYNC]`, refs `[FILE, ASYNC]`, unreferenced `[]` |
| The two payloads stayed in sync | byte-identical, `sha256 c0f78390db1284d4…` |
| Payload is ASCII-only | yes — deliberate: PowerShell 5.1 reads BOM-less scripts as ANSI, so a non-ASCII char in the here-string would be mangled into the generated XML on Windows |
| Heredoc / here-string integrity | no `$`, backtick, quote, bare `EOF` line, or line starting with `'@` in the new text |
| Other copies of the template / other `ref="STDOUT"` | none in the repo |
| Whitespace | `git diff --check` clean |

## Notes for reviewers

- **Existing installs are not repaired automatically.** `create_logback_config` / `Create-LogbackConfig` run unconditionally and overwrite, so re-running the installer fixes an install in place; users who do not re-run keep the broken `conf/logback.xml`. Worth a line in release notes.
- **No `NopStatusListener` was added, deliberately.** Now that nothing logs to the console, the status dump is the last diagnostic channel if the `FILE` appender itself fails (e.g. `logs/` not writable). Silencing it globally would hide that; the fix removes the *cause* of the spurious WARN instead.
- Referencing an appender from any `<logger>` is sufficient, not just `<root>` — confirmed via `ModelClassToModelHandlerLinker`, which registers `AppenderRefDependencyAnalyser` for `LoggerModel` as well as `RootLoggerModel`. The comment says so.

## Out of scope, found while reviewing

`install.ps1` is far from a clone of `install.sh` and the gap is filed separately as #179: both Windows launchers use `java -jar`, which ignores `lib/` — directly contradicting `install.sh:1028`'s "`java -jar` would ignore the classpath entirely — do not switch back" — and the Windows script has no bundle, licence-extraction, AppCDS or `--no-extensions` support at all.
