### PR TITLE
fix(installer): bring install.ps1 to parity with install.sh — Windows launchers ignored lib/ via java -jar (#179)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -9,6 +9,7 @@ param(
     [string]$Version = "latest",
     [string]$ScalaVersion = "2.13",
     [switch]$ListVersions,
+    [switch]$NoExtensions,
     [switch]$Help
 )
 
@@ -37,20 +38,32 @@ Usage: .\install.ps1 [OPTIONS]
 Options:
   -Target <dir>       Installation directory (default: $env:USERPROFILE\softclient4es)
   -EsVersion <ver>    Elasticsearch major version: 6, 7, 8, 9 (default: 8)
-  -Version <ver>      SoftClient4ES version (default: latest)
+  -Version <ver>      SoftClient4ES version (default: latest). By default this is
+                      a version of the -all bundle (it has its own version line);
+                      with -NoExtensions it is an engine version.
   -ScalaVersion <ver> Scala version (default: 2.13)
-  -ListVersions       List available versions for the specified ES version
+  -ListVersions       List available versions of the artifact that would be
+                      installed (the -all bundle, or the engine with
+                      -NoExtensions)
+  -NoExtensions       Install the plain, pure Apache-2.0 engine only
   -Help               Show this help message
 
+Default install:
+  ONE self-contained -all assembly (engine + community extensions + the
+  cross-index JOIN extension). The bundle contains components under the Elastic
+  License 2.0 plus the proprietary JOIN engine (free to use) - it is NOT a pure
+  Apache-2.0 artifact. -NoExtensions always yields a pure Apache-2.0 install.
+
 Java Requirements:
-  ES 6, 7, 8  ->  Java 8 or higher
+  ES 6, 7, 8  ->  Java 11 or higher
   ES 9        ->  Java 17 or higher
+  The -all bundle requires Java 11+ (Arrow / logback bytecode).
 
 Examples:
   .\install.ps1
   .\install.ps1 -ListVersions -EsVersion 8
   .\install.ps1 -Target "C:\tools\softclient4es" -EsVersion 8 -Version 1.0.0
-  .\install.ps1 -EsVersion 7 -Version 0.20.0
+  .\install.ps1 -EsVersion 7 -Version 0.20.0 -NoExtensions
 
 "@
     exit 0
@@ -82,7 +95,17 @@ if ($EsVersion -notmatch '^[6-9]$') {
 # Derived Variables
 # =============================================================================
 
-$ARTIFACT_NAME = "softclient4es${EsVersion}-cli_${ScalaVersion}"
+# Plain artifact: the pure Apache-2.0 engine assembly (published by elasticsql).
+$PLAIN_ARTIFACT_NAME = "softclient4es${EsVersion}-cli_${ScalaVersion}"
+# Bundle artifact: the self-contained -all assembly (engine + community
+# extensions + arrow JOIN extension + all dependencies), published by the
+# softclient4es-repl packaging repo on its OWN version line.
+$BUNDLE_ARTIFACT_NAME = "softclient4es${EsVersion}-cli-all_${ScalaVersion}"
+# Finalized by the bundle-selection block below; until then it refers to the
+# plain artifact (fallback/legacy paths).
+$ARTIFACT_NAME = $PLAIN_ARTIFACT_NAME
+
+$WITH_EXTENSIONS = -not $NoExtensions
 
 # =============================================================================
 # Get Required Java Version
@@ -93,8 +116,21 @@ function Get-RequiredJavaVersion {
     if ($EsVer -eq "9") {
         return 17
     } else {
-        return 8
+        # The 0.20+ CLI bundles logback 1.5.x (Java-11 bytecode): the REPL does
+        # not start on Java 8 (--help crashes with UnsupportedClassVersionError).
+        return 11
     }
+}
+
+# Major version of the `java` on PATH, or 0 when it cannot be determined.
+function Get-JavaMajorVersion {
+    try {
+        $out = (& java -version 2>&1 | Select-String -Pattern 'version' | Select-Object -First 1).ToString()
+        if ($out -match '"1\.(\d+)')   { return [int]$Matches[1] }   # 1.8.x
+        elseif ($out -match '"(\d+)')  { return [int]$Matches[1] }   # 11.x, 17.x
+    }
+    catch { }
+    return 0
 }
 
 $REQUIRED_JAVA_VERSION = Get-RequiredJavaVersion -EsVer $EsVersion
@@ -104,7 +140,16 @@ $REQUIRED_JAVA_VERSION = Get-RequiredJavaVersion -EsVer $EsVersion
 # =============================================================================
 
 function Get-AvailableVersions {
-    $apiUrl = "${JFROG_API_URL}/${ARTIFACT_NAME}"
+    param(
+        # Default to the PLAIN artifact, never $ARTIFACT_NAME: that one is
+        # deliberately mutated by the bundle-selection block below.
+        [string]$Artifact = $PLAIN_ARTIFACT_NAME,
+        # Bundle probing must be able to fail softly and fall back to the plain
+        # artifact; the plain path keeps the original fail-hard behaviour.
+        [switch]$Quiet
+    )
+
+    $apiUrl = "${JFROG_API_URL}/${Artifact}"
 
     try {
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -119,17 +164,45 @@ function Get-AvailableVersions {
         return $versions
     }
     catch {
+        if ($Quiet) { return @() }
         Write-Err "Failed to fetch versions from repository"
-        Write-Err "Artifact: $ARTIFACT_NAME"
+        Write-Err "Artifact: $Artifact"
         Write-Err $_.Exception.Message
         exit 1
     }
 }
 
+# HEAD probe: belt-and-braces over the listing check (covers a pruned scala
+# variant or a listing/artifact race).
+function Test-UrlExists {
+    param([string]$Url)
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest -Uri $Url -Method Head -UseBasicParsing -ErrorAction Stop | Out-Null
+        return $true
+    }
+    catch { return $false }
+}
+
 if ($ListVersions) {
     Write-Info "Fetching available versions for ES$EsVersion..."
 
-    $versions = Get-AvailableVersions
+    # List the versions of the artifact the install would actually download: the
+    # -all bundle by default (its OWN version line), the plain artifact under
+    # -NoExtensions or when no bundle is published.
+    if ($WITH_EXTENSIONS) {
+        $listedArtifact = $BUNDLE_ARTIFACT_NAME
+        $versions = Get-AvailableVersions -Artifact $listedArtifact -Quiet
+        if (-not $versions -or $versions.Count -eq 0) {
+            Write-Warn "No -all bundle versions found for $listedArtifact - listing the plain artifact instead"
+            $listedArtifact = $PLAIN_ARTIFACT_NAME
+            $versions = Get-AvailableVersions -Artifact $listedArtifact
+        }
+    } else {
+        $listedArtifact = $PLAIN_ARTIFACT_NAME
+        $versions = Get-AvailableVersions -Artifact $listedArtifact
+    }
+    $ARTIFACT_NAME = $listedArtifact
 
     if (-not $versions -or $versions.Count -eq 0) {
         Write-Err "No versions found for $ARTIFACT_NAME"
@@ -168,31 +241,107 @@ if ($ListVersions) {
 function Resolve-LatestVersion {
     Write-Info "Resolving latest version..."
 
-    $versions = Get-AvailableVersions
+    # Latest of the PLAIN artifact (engine version line) - used on the fallback
+    # and -NoExtensions paths; the bundle path resolves its latest from the
+    # bundle listing in the bundle-selection block below.
+    $versions = Get-AvailableVersions -Artifact $PLAIN_ARTIFACT_NAME
 
     if (-not $versions -or $versions.Count -eq 0) {
         Write-Err "No versions found"
         exit 1
     }
 
-    # Prefer non-snapshot versions
-    $releaseVersions = $versions | Where-Object { $_ -notmatch 'SNAPSHOT' }
+    # Prefer non-snapshot versions.
+    # @(...) matters: with a single match the pipeline yields a bare string, and
+    # [-1] on a string returns its last CHARACTER ("0.20.2" -> "2").
+    $releaseVersions = @($versions | Where-Object { $_ -notmatch 'SNAPSHOT' })
 
-    if ($releaseVersions -and $releaseVersions.Count -gt 0) {
+    if ($releaseVersions.Count -gt 0) {
         return $releaseVersions[-1]
     }
 
     # Fallback to any version
-    return $versions[-1]
+    return @($versions)[-1]
 }
 
-if ($Version -eq "latest") {
+# =============================================================================
+# Bundle Selection: default install = ONE self-contained -all assembly
+# =============================================================================
+# This block owns latest-resolution for BOTH paths: the bundle listing first,
+# the plain listing on fallback. The version list consulted is always the list
+# of the artifact actually downloaded - the bundle has its OWN version line.
+
+# Remember whether the user asked for "latest": if the bundle path is abandoned
+# later by the existence probe, the plain latest must be re-resolved.
+$REQUESTED_VERSION = $Version
+
+$USE_BUNDLE = $false
+if ($WITH_EXTENSIONS) {
+    $bundleVersions = @(Get-AvailableVersions -Artifact $BUNDLE_ARTIFACT_NAME -Quiet |
+        Where-Object { $_ -notmatch 'SNAPSHOT' })
+    if ($bundleVersions.Count -gt 0) {
+        if ($Version -eq "latest") {
+            $Version = $bundleVersions[-1]      # bundle-version line (0.20.2, 0.20.3, ...)
+            $USE_BUNDLE = $true
+            Write-Success "Resolved latest -all bundle version: $Version"
+        }
+        elseif ($bundleVersions -contains $Version) {
+            $USE_BUNDLE = $true                 # -Version selects a BUNDLE version
+        }
+        else {
+            Write-Warn "No -all bundle for version $Version - falling back to the plain artifact"
+        }
+    }
+    else {
+        Write-Warn "No -all bundles published for $BUNDLE_ARTIFACT_NAME - falling back to the plain artifact"
+    }
+
+    # The bundle needs Java 11+ (Arrow / logback bytecode). Check-Prerequisites
+    # aborts below the ES-version floor anyway; this keeps the fallback honest.
+    $javaMajor = Get-JavaMajorVersion
+    if ($USE_BUNDLE -and $javaMajor -gt 0 -and $javaMajor -lt 11) {
+        Write-Warn "Java $javaMajor found - the -all bundle requires Java 11+; falling back to the plain artifact"
+        $USE_BUNDLE = $false
+        $Version = $REQUESTED_VERSION
+    }
+}
+
+# Every fallback above lands on the plain engine. Unlike install.sh, this script
+# has no coursier resolution to populate lib/ with the extensions, so the plain
+# path yields an install with NO cross-index JOIN - say so rather than let the
+# user rediscover it as a missing feature (that is issue #179's own symptom).
+if ($WITH_EXTENSIONS -and -not $USE_BUNDLE) {
+    Write-Warn "Cross-index JOIN and materialized-view extensions are NOT installed on this path"
+    Write-Warn "(the Windows installer has no dependency-resolution fallback - only the -all bundle carries them)."
+}
+
+if (-not $USE_BUNDLE -and $Version -eq "latest") {
+    # Plain/fallback path: resolve latest from the PLAIN artifact's listing
     $Version = Resolve-LatestVersion
     Write-Success "Resolved latest version: $Version"
 }
 
+if ($USE_BUNDLE) {
+    $ARTIFACT_NAME = $BUNDLE_ARTIFACT_NAME
+} else {
+    $ARTIFACT_NAME = $PLAIN_ARTIFACT_NAME
+}
 $JAR_NAME = "${ARTIFACT_NAME}-${Version}-assembly.jar"
 $DOWNLOAD_URL = "${JFROG_REPO_URL}/${ARTIFACT_NAME}/${Version}/${JAR_NAME}"
+
+if ($USE_BUNDLE -and -not (Test-UrlExists -Url $DOWNLOAD_URL)) {
+    Write-Warn "-all bundle not reachable at $DOWNLOAD_URL"
+    Write-Warn "Falling back to the plain artifact"
+    $USE_BUNDLE = $false
+    $ARTIFACT_NAME = $PLAIN_ARTIFACT_NAME
+    $Version = $REQUESTED_VERSION
+    if ($Version -eq "latest") {
+        $Version = Resolve-LatestVersion
+        Write-Success "Resolved latest version: $Version"
+    }
+    $JAR_NAME = "${ARTIFACT_NAME}-${Version}-assembly.jar"
+    $DOWNLOAD_URL = "${JFROG_REPO_URL}/${ARTIFACT_NAME}/${Version}/${JAR_NAME}"
+}
 
 # =============================================================================
 # Check Prerequisites
@@ -201,35 +350,26 @@ $DOWNLOAD_URL = "${JFROG_REPO_URL}/${ARTIFACT_NAME}/${Version}/${JAR_NAME}"
 function Check-Prerequisites {
     Write-Info "Checking prerequisites..."
 
-    # Check Java
-    try {
-        $javaVersionOutput = & java -version 2>&1 | Select-String -Pattern 'version'
-        $javaVersionString = $javaVersionOutput.ToString()
-
-        # Extract version number
-        if ($javaVersionString -match '"1\.(\d+)') {
-            # Old format: 1.8.x
-            $javaVersion = [int]$Matches[1]
-        } elseif ($javaVersionString -match '"(\d+)') {
-            # New format: 11.x, 17.x
-            $javaVersion = [int]$Matches[1]
-        } else {
-            Write-Warn "Could not determine Java version"
-            $javaVersion = 0
-        }
-
-        if ($javaVersion -gt 0 -and $javaVersion -lt $REQUIRED_JAVA_VERSION) {
-            Write-Err "Java $REQUIRED_JAVA_VERSION or higher is required for ES$EsVersion."
-            Write-Err "Found: Java $javaVersion"
-            exit 1
-        }
-
-        Write-Success "Java $javaVersion found (required: ${REQUIRED_JAVA_VERSION}+)"
-    }
-    catch {
+    if (-not (Get-Command java -ErrorAction SilentlyContinue)) {
         Write-Err "Java is not installed."
         Write-Err "ES$EsVersion requires Java $REQUIRED_JAVA_VERSION or higher."
         exit 1
+    }
+
+    # One parse for the whole installer (Get-JavaMajorVersion), so a localised or
+    # multi-line `java -version` cannot be read two different ways.
+    $javaVersion = Get-JavaMajorVersion
+
+    if ($javaVersion -eq 0) {
+        Write-Warn "Could not determine Java version"
+    }
+    elseif ($javaVersion -lt $REQUIRED_JAVA_VERSION) {
+        Write-Err "Java $REQUIRED_JAVA_VERSION or higher is required for ES$EsVersion."
+        Write-Err "Found: Java $javaVersion"
+        exit 1
+    }
+    else {
+        Write-Success "Java $javaVersion found (required: ${REQUIRED_JAVA_VERSION}+)"
     }
 }
 
@@ -283,6 +423,11 @@ function Download-Jar {
 
     $dest = "$Target\lib\$JAR_NAME"
 
+    # The bundle is ~309 MB. On Windows PowerShell 5.1, Invoke-WebRequest calls
+    # Write-Progress per chunk, which slows a download of this size by an order of
+    # magnitude while showing nothing in many hosts - it just looks hung.
+    $previousProgress = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue'
     try {
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
         Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $dest -UseBasicParsing
@@ -294,6 +439,75 @@ function Download-Jar {
         Write-Err "Run with -ListVersions to see available versions."
         Write-Err $_.Exception.Message
         exit 1
+    }
+    finally { $ProgressPreference = $previousProgress }
+}
+
+# =============================================================================
+# Extract the licence bundle (bundle installs only)
+# =============================================================================
+# The -all jar mixes Apache-2.0 + ELv2 + proprietary: materialize licenses/ and
+# NOTICE into the install root so the visible tree is not just the jar.
+
+function Extract-BundleLicenses {
+    if (-not $USE_BUNDLE) { return }
+
+    # Join-Path, not "$Target\lib\...": the ZipFile APIs below are raw .NET and
+    # do not normalise separators the way the PowerShell cmdlets do.
+    $jar = Join-Path (Join-Path $Target 'lib') $JAR_NAME
+    Write-Info "Extracting licence bundle (licenses/ + NOTICE) from $JAR_NAME..."
+
+    try {
+        # PowerShell 5.1 needs the assembly loaded; on PowerShell 7 the types are
+        # already present and Add-Type is a no-op.
+        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
+        $zip = [System.IO.Compression.ZipFile]::OpenRead($jar)
+        try {
+            $wanted = $zip.Entries | Where-Object {
+                $_.FullName -eq 'NOTICE' -or $_.FullName -like 'licenses/*'
+            }
+            foreach ($entry in $wanted) {
+                if ([string]::IsNullOrEmpty($entry.Name)) { continue }   # directory entry
+                # Refuse traversal entries: -like 'licenses/*' happily matches
+                # 'licenses/../../evil.txt', and ExtractToFile overwrites.
+                if ($entry.FullName -match '(^|/)\.\.(/|$)') {
+                    Write-Warn "Skipping suspicious archive entry: $($entry.FullName)"
+                    continue
+                }
+                $dest = Join-Path $Target ($entry.FullName -replace '/', [IO.Path]::DirectorySeparatorChar)
+                $destDir = Split-Path -Parent $dest
+                if (-not (Test-Path $destDir)) {
+                    New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+                }
+                [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $dest, $true)
+            }
+        }
+        finally { $zip.Dispose() }
+
+        Write-Success "Extracted licenses/ and NOTICE to $Target"
+    }
+    catch {
+        # Never fail the install over the licence copy: the canonical copies
+        # ship inside the jar.
+        Write-Warn "Could not extract the licence bundle: $($_.Exception.Message)"
+        Write-Warn "The canonical copies remain inside the jar: licenses/ and NOTICE."
+    }
+}
+
+# =============================================================================
+# License Notice
+# =============================================================================
+
+function Show-LicenseNotice {
+    if ($USE_BUNDLE) {
+        Write-Host "  License: this bundle contains the Apache-2.0 SoftClient4ES engine PLUS"
+        Write-Host "  SoftClient4ES extensions under the Elastic License 2.0 and the proprietary"
+        Write-Host "  cross-index JOIN engine (free to use; see the licenses/ directory and NOTICE"
+        Write-Host "  in the install root - canonical copies ship inside the jar)."
+        Write-Host "  Quota enforcement is active. For a pure Apache-2.0 install re-run with -NoExtensions."
+    }
+    else {
+        Write-Host "  License: pure Apache-2.0 engine (no extensions)."
     }
 }
 
@@ -480,20 +694,37 @@ if not exist "%JAR_FILE%" (
 REM Create logs directory if it doesn't exist
 if not exist "%LOG_DIR%" mkdir "%LOG_DIR%"
 
-REM Check Java
-java -version >nul 2>&1
-if errorlevel 1 (
+if "%JAVA_OPTS%"=="" set JAVA_OPTS=-Xmx512m
+
+REM Java major version (1.8.x -> 8, 11.x -> 11), also our Java presence check.
+REM cmd expands every %VAR% in a parenthesised block in ONE parse pass, so the
+REM second FOR must stay OUTSIDE the first block to see JVER. %%~v strips the
+REM quotes FOR/F leaves around the version token; the per-iteration `if not
+REM defined` keeps the FIRST matching line (parity with install.sh's head -n 1).
+set JAVA_MAJOR=0
+set JVER=
+for /f tokens^=3 %%v in ('java -version 2^>^&1 ^| findstr /i "version"') do if not defined JVER set JVER=%%~v
+if not defined JVER (
     echo Error: Java is not installed. Java %REQUIRED_JAVA%+ is required. >&2
     exit /b 1
 )
+for /f "tokens=1,2 delims=." %%a in ("%JVER%") do if "%%a"=="1" (set JAVA_MAJOR=%%b) else (set JAVA_MAJOR=%%a)
 
-if "%JAVA_OPTS%"=="" set JAVA_OPTS=-Xmx512m
+REM The extensions (Apache Arrow / DuckDB) need reflective access on Java 9+.
+REM JAVA_MAJOR is initialised to 0 above so this comparison always has a left
+REM operand (an empty one is a cmd syntax error that aborts the whole script).
+set EXTRA_OPTS=
+if %JAVA_MAJOR% GEQ 9 set EXTRA_OPTS=--add-opens=java.base/java.nio=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true
 
-REM Logback configuration
+REM Logback configuration (quoted: the default target lives under %USERPROFILE%,
+REM which routinely contains a space)
 set LOGBACK_OPTS=
-if exist "%LOGBACK_FILE%" set LOGBACK_OPTS=-Dlogback.configurationFile=%LOGBACK_FILE%
+if exist "%LOGBACK_FILE%" set LOGBACK_OPTS="-Dlogback.configurationFile=%LOGBACK_FILE%"
 
-java %JAVA_OPTS% -Dconfig.file="%CONFIG_FILE%" -Dlog.dir="%LOG_DIR%" %LOGBACK_OPTS% -jar "%JAR_FILE%" %*
+REM The engine assembly comes first on the classpath so it wins any conflict;
+REM lib\* brings the extension jars, discovered via the ServiceLoader SPI.
+REM (java -jar would ignore the classpath entirely - do not switch back.)
+java %JAVA_OPTS% %EXTRA_OPTS% -Dconfig.file="%CONFIG_FILE%" -Dlog.dir="%LOG_DIR%" %LOGBACK_OPTS% -cp "%JAR_FILE%;%BASE_DIR%\lib\*" app.softnetwork.elastic.client.Cli %*
 
 endlocal
 "@
@@ -526,9 +757,11 @@ if (-not (Test-Path `$LogDir)) {
     New-Item -ItemType Directory -Path `$LogDir | Out-Null
 }
 
-# Check Java
+# Check Java. Select-Object -First 1 matters: with two matching lines (e.g. a
+# deprecation notice from _JAVA_OPTIONS) the pipeline yields an array whose
+# ToString() is "System.Object[]", no regex matches, and the version reads 0.
 try {
-    `$javaVersionOutput = & java -version 2>&1 | Select-String -Pattern 'version'
+    `$javaVersionOutput = & java -version 2>&1 | Select-String -Pattern 'version' | Select-Object -First 1
     `$javaVersionString = `$javaVersionOutput.ToString()
 
     if (`$javaVersionString -match '"1\.(\d+)') {
@@ -549,7 +782,17 @@ catch {
     exit 1
 }
 
-`$JavaOpts = if (`$env:JAVA_OPTS) { `$env:JAVA_OPTS } else { "-Xmx512m" }
+# JAVA_OPTS may carry several flags: split it so each becomes its own argument
+# (a single string would reach the JVM as one unparsable option). Where-Object
+# drops the empty element a leading space produces - java would read it as the
+# main class name and refuse to start.
+`$JavaOpts = if (`$env:JAVA_OPTS) { @(`$env:JAVA_OPTS -split '\s+' | Where-Object { `$_ }) } else { @("-Xmx512m") }
+
+# The extensions (Apache Arrow / DuckDB) need reflective access on Java 9+
+`$ExtraOpts = @()
+if (`$javaVersion -ge 9) {
+    `$ExtraOpts = @("--add-opens=java.base/java.nio=ALL-UNNAMED", "-Dio.netty.tryReflectionSetAccessible=true")
+}
 
 # Logback configuration
 `$LogbackOpts = @()
@@ -557,7 +800,13 @@ if (Test-Path `$LogbackFile) {
     `$LogbackOpts = @("-Dlogback.configurationFile=`$LogbackFile")
 }
 
-& java `$JavaOpts "-Dconfig.file=`$ConfigFile" "-Dlog.dir=`$LogDir" @LogbackOpts -jar `$JarFile `$args
+# The engine assembly comes first on the classpath so it wins any conflict;
+# lib\* brings the extension jars, discovered via the ServiceLoader SPI.
+# (java -jar would ignore the classpath entirely - do not switch back.)
+& java @JavaOpts @ExtraOpts "-Dconfig.file=`$ConfigFile" "-Dlog.dir=`$LogDir" @LogbackOpts -cp "`$JarFile;`$BaseDir\lib\*" app.softnetwork.elastic.client.Cli `$args
+
+# Propagate the CLI's exit status (install.sh uses `exec java` for this)
+exit `$LASTEXITCODE
 "@
 
     $psContent | Out-File -FilePath "$Target\bin\softclient4es.ps1" -Encoding UTF8
@@ -595,6 +844,23 @@ if (`$confirm -eq 'y' -or `$confirm -eq 'Y') {
 # =============================================================================
 
 function Create-VersionInfo {
+    if ($USE_BUNDLE) {
+        $installType = "-all bundle (engine + extensions; the bundle has its OWN version line)"
+        $licenseLine = @"
+
+License:            Apache-2.0 engine PLUS extensions under the Elastic License 2.0
+                    and the proprietary cross-index JOIN engine (free to use).
+                    See licenses\ and NOTICE in the install root.
+"@
+    }
+    else {
+        $installType = "plain engine (pure Apache-2.0, no extensions)"
+        $licenseLine = @"
+
+License:            pure Apache-2.0 engine (no extensions).
+"@
+    }
+
     $versionContent = @"
 SoftClient4ES Installation Info
 ================================
@@ -604,6 +870,8 @@ Version:            $Version
 Scala:              $ScalaVersion
 Java Required:      ${REQUIRED_JAVA_VERSION}+
 Artifact:           $ARTIFACT_NAME
+Install type:       $installType
+$licenseLine
 "@
 
     $versionContent | Out-File -FilePath "$Target\VERSION" -Encoding UTF8
@@ -625,6 +893,11 @@ function Print-Summary {
     Write-Host "  Elasticsearch version:  $EsVersion"
     Write-Host "  SoftClient4ES version:  $Version"
     Write-Host "  Java required:          ${REQUIRED_JAVA_VERSION}+"
+    if ($USE_BUNDLE) {
+        Write-Host "  Install type:           -all bundle (engine + extensions, incl. cross-index JOIN)"
+    } else {
+        Write-Host "  Install type:           plain engine (pure Apache-2.0, no extensions)"
+    }
     Write-Host ""
     Write-Host "  Directory structure:"
     Write-Host "    $Target\"
@@ -638,6 +911,11 @@ function Print-Summary {
     Write-Host "    |   \-- $JAR_NAME"
     Write-Host "    +-- logs\"
     Write-Host "    |   \-- (runtime logs)"
+    if ($USE_BUNDLE) {
+        Write-Host "    +-- licenses\"
+        Write-Host "    |   \-- (per-component licences)"
+        Write-Host "    +-- NOTICE"
+    }
     Write-Host "    +-- LICENSE"
     Write-Host "    +-- README.md"
     Write-Host "    +-- VERSION"
@@ -664,6 +942,10 @@ function Print-Summary {
     Write-Host "  To uninstall:"
     Write-Host "    $Target\uninstall.ps1" -ForegroundColor Cyan
     Write-Host ""
+    # Repeat the licence status here: the mid-install notice has scrolled well
+    # off screen by now (install.sh states it in its summary for the same reason).
+    Show-LicenseNotice
+    Write-Host ""
 }
 
 # =============================================================================
@@ -679,6 +961,8 @@ Write-Host ""
 Check-Prerequisites
 Create-Directories
 Download-Jar
+Extract-BundleLicenses
+Show-LicenseNotice
 Download-Docs
 Create-Config
 Create-LogbackConfig    # <-- Création du fichier logback.xml


### PR DESCRIPTION
Closes #179.

## What was wrong

`install.ps1` was not a port of the current installer — it was roughly the pre-bundle one. Two classes of problem:

**Functional.** Both generated launchers ran `java -jar`, which ignores the classpath entirely, so every extension jar in `lib/` was invisible to the JVM and the cross-index JOIN engine was **silently absent on Windows** — the same silent-wrong-results failure class as #157. [install.sh:1028](install.sh#L1028) carries an explicit comment forbidding exactly this.

**Missing surface.** Grep counts, `install.sh` vs `install.ps1` before this PR: `-all` bundle path 67 hits vs **0**, licence extraction 8 vs **0**, `--add-opens` 1 vs **0**, `--no-extensions` 14 vs **0**. So `install.ps1` could not install the artifact the README's one-liner advertises.

## What this does

Launchers now mirror install.sh: `-cp "<jar>;<base>\lib\*" app.softnetwork.elastic.client.Cli`, plus `--add-opens=java.base/java.nio=ALL-UNNAMED` and `-Dio.netty.tryReflectionSetAccessible=true` on Java 9+ (Arrow/DuckDB need them).

Ported: the bundle path (bundle listing owns its own version line, exact-version match, HEAD existence probe, fallback to plain), licence-bundle extraction (`licenses/` + `NOTICE`, failure-tolerant), the bundle vs pure-Apache licence notice, `-NoExtensions`. Java floor for ES 6/7/8 raised 8 → 11 (the 0.20+ CLI bundles logback 1.5.x, Java-11 bytecode — it does not start on 8).

## Bugs found while testing and fixing

- **`Resolve-LatestVersion` returned `"2"` instead of `"0.20.2"`.** With exactly one release version the pipeline yields a bare `String`, and `[-1]` on a string returns its last **character**. Pre-existing; only manifests when a listing has one release. `@()`-wrapped.
- **`java -version` parsed three different ways** (installer, `.ps1` launcher, `Check-Prerequisites`), none taking the first line only. With two matching lines the pipeline is an `Object[]` whose `ToString()` is `"System.Object[]"`, no regex matches, and the version silently reads 0 — which would drop `--add-opens` with no message. Now one `Get-JavaMajorVersion`, `Select-Object -First 1`.
- **Multi-flag `JAVA_OPTS` reached the JVM as one argument**; now split, with empty elements dropped (a leading space would emit an empty argv entry, which java reads as the main class name and refuses to start).
- **Every fallback yields an install with no JOIN engine** and this script has no coursier resolution to populate `lib/`, so it now says so outright rather than leaving the user to rediscover #179's own symptom.
- java's exit status is now propagated from the `.ps1` launcher (install.sh gets it from `exec java`); logback's `-D` is quoted in the `.bat` (the default target is under `%USERPROFILE%`, routinely containing a space); the 309 MB download sets `$ProgressPreference = 'SilentlyContinue'` (per-chunk `Write-Progress` makes a download this size look hung on 5.1); licence extraction skips path-traversal entries; licence status is repeated in the summary and written into `VERSION`.

## Review caught two HIGH-severity bugs in my first batch attempt

Worth recording, because the batch file is the least testable part. My first version did:

```bat
if defined JVER (
    set JVER=%JVER:"=%
    for /f "tokens=1,2 delims=." %%a in ("%JVER%") do ...
)
```

cmd expands **every** `%VAR%` in a parenthesised block in one parse pass, before executing any line in it. Without `enabledelayedexpansion` the quote-strip was dead code and the inner `FOR` saw the still-quoted value, so `JAVA_MAJOR` became `"11` and the next line was a cmd syntax error — dropping the very `--add-opens` flags this PR exists to add. Separately, `if defined JAVA_MAJOR if %JAVA_MAJOR% GEQ 9` does not guard anything, because `%JAVA_MAJOR%` is expanded at parse time; when empty it degenerates to `if  GEQ 9`, a parse error that aborts the whole script so the REPL never starts.

Both fixed: `JAVA_MAJOR` is initialised to `0`, `%%~v` strips the quotes, the second `FOR` moved out of the block, and the `if defined` guard is gone. A per-iteration `if not defined JVER` also gives first-match-wins parity with install.sh's `head -n 1`.

## Verification (PowerShell 7.4.5, local mirror of the artifact repo)

| Check | Result |
|---|---|
| AST parse | clean, 0 errors |
| Default install | resolves `-all` bundle 0.20.2, downloads, extracts 3 licences + NOTICE |
| `-NoExtensions` | installs the plain jar, no `licenses/`, Apache-only notice, correct version |
| `-ListVersions` | bundle line by default; plain line with `-NoExtensions` |
| Bundle-miss (`-Version 0.19.0`) | warns, falls back to plain, warns that JOIN is absent |
| Launcher's java invocation | starts the CLI and a **real cross-index JOIN returns the correct 5 rows** against live ES 8.18.3 (macOS `:` substituted for Windows `;`) |
| Generated `.bat` structure | `JAVA_MAJOR=0` present, `%%~v` used, second `FOR` outside the block, no `if defined JAVA_MAJOR if`, `LOGBACK_OPTS` quoted |

## NOT verified — needs a Windows reviewer before merge

I have no Windows host, so these are reasoned-and-structurally-checked, not executed:

1. **`cmd.exe` running the generated `bin\softclient4es.bat`.** Confirm `JAVA_MAJOR` is a bare integer and `--add-opens` actually reaches the JVM (temporary `echo %EXTRA_OPTS%`); run with `java` absent from PATH; run from a path containing a space (`C:\Program Files\...` **and** the default `C:\Users\<name with space>\...`); pass an argument containing spaces and one containing `"`.
2. **Windows PowerShell 5.1** (not just 7.x) for the whole installer: bundle resolution, HEAD probe through a corporate proxy, the 309 MB download (time it), licence extraction, both launchers.
3. **`bin\softclient4es.ps1` under 5.1** with `$env:JAVA_OPTS` set (single flag, multi flag, leading space) and a double-quoted SQL identifier in `-c` (5.1's native argument quoting mangles embedded `"`; 7.3+ does not).
4. **`irm … | iex`** (the README's Windows entry point) against the `param()` + `exit` paths — an `exit` inside `iex` terminates the host session.
5. Java 8 (should now abort for ES 6/7/8 with the new floor) and ES 9 + Java 17.

## Deliberately out of scope

**AppCDS is not ported** (install.sh:999-1018, 1050-1084) — a pure cold-start optimisation whose JDK-version gating is the fiddliest part; Windows works correctly without it. Also absent: the `ELASTIC_*` empty-env-unset loop, benign on Windows since setting an env var to `""` deletes it there. Worth a follow-up issue for AppCDS if Windows cold start matters.

Please also confirm whether Windows is a supported R1 install target — if it is, the `-jar` defect this PR fixes was release-blocking for those users.
