### PR TITLE
docs: bring user-facing versions up to the 0.20.2 release train

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,10 @@ Download the self-contained fat JAR for your Elasticsearch version:
 
 | Elasticsearch Version | Artifact                               |
 |-----------------------|----------------------------------------|
-| ES 6.x                | `softclient4es6-jdbc-driver-0.2.1.jar` |
-| ES 7.x                | `softclient4es7-jdbc-driver-0.2.1.jar` |
-| ES 8.x                | `softclient4es8-jdbc-driver-0.2.1.jar` |
-| ES 9.x                | `softclient4es9-jdbc-driver-0.2.1.jar` |
+| ES 6.x                | `softclient4es6-jdbc-driver-0.2.3.jar` |
+| ES 7.x                | `softclient4es7-jdbc-driver-0.2.3.jar` |
+| ES 8.x                | `softclient4es8-jdbc-driver-0.2.3.jar` |
+| ES 9.x                | `softclient4es9-jdbc-driver-0.2.3.jar` |
 
 > **Java 11+ recommended** (17+ for ES 9.x): **cross-index JOINs require Java 11+** — the embedded JOIN engine is built on Apache Arrow 18.x, which ships Java-11 bytecode.
 
@@ -219,20 +219,20 @@ Driver class: app.softnetwork.elastic.jdbc.ElasticDriver
 <dependency>
   <groupId>app.softnetwork.elastic</groupId>
   <artifactId>softclient4es8-jdbc-driver</artifactId>
-  <version>0.2.1</version>
+  <version>0.2.3</version>
 </dependency>
 ```
 
 **Gradle:**
 
 ```groovy
-implementation 'app.softnetwork.elastic:softclient4es8-jdbc-driver:0.2.1'
+implementation 'app.softnetwork.elastic:softclient4es8-jdbc-driver:0.2.3'
 ```
 
 **sbt:**
 
 ```scala
-libraryDependencies += "app.softnetwork.elastic" % "softclient4es8-jdbc-driver" % "0.2.1"
+libraryDependencies += "app.softnetwork.elastic" % "softclient4es8-jdbc-driver" % "0.2.3"
 ```
 
 The JDBC driver JARs are Scala-version-independent (no `_2.12` or `_2.13` suffix) and include all required dependencies.
@@ -320,11 +320,13 @@ For programmatic access, add SoftClient4ES to your project.
 resolvers += "Softnetwork" at "https://softnetwork.jfrog.io/artifactory/releases/"
 
 // Choose your Elasticsearch version
-libraryDependencies += "app.softnetwork.elastic" %% "softclient4es8-java-client" % "0.20.0"
+libraryDependencies += "app.softnetwork.elastic" %% "softclient4es8-java-client" % "0.20.2"
 // Add the community extensions for materialized views (optional)
-libraryDependencies += "app.softnetwork.elastic" %% "softclient4es-community-extensions" % "0.2.0"
+libraryDependencies += "app.softnetwork.elastic" %% "softclient4es-community-extensions" % "0.2.2"
+// Add the arrow extensions for cross-index JOIN (required for JOINs; Java 11+)
+libraryDependencies += "app.softnetwork.elastic" %% "softclient4es-arrow-extensions" % "0.2.3"
 // Add the JDBC driver if you want to use it from Scala (optional)
-libraryDependencies += "app.softnetwork.elastic" %% "softclient4es-jdbc-driver" % "0.2.1"
+libraryDependencies += "app.softnetwork.elastic" %% "softclient4es-jdbc-driver" % "0.2.3"
 ```
 
 ```scala

--- a/documentation/client/adbc_driver.md
+++ b/documentation/client/adbc_driver.md
@@ -23,10 +23,10 @@ Download the self-contained fat JAR for your Elasticsearch version:
 
 | Elasticsearch  | Artifact                                            |
 |----------------|-----------------------------------------------------|
-| ES 6.x         | `softclient4es6-adbc-driver-0.2.1.jar` |
-| ES 7.x         | `softclient4es7-adbc-driver-0.2.1.jar` |
-| ES 8.x         | `softclient4es8-adbc-driver-0.2.1.jar` |
-| ES 9.x         | `softclient4es9-adbc-driver-0.2.1.jar` |
+| ES 6.x         | `softclient4es6-adbc-driver-0.2.3.jar` |
+| ES 7.x         | `softclient4es7-adbc-driver-0.2.3.jar` |
+| ES 8.x         | `softclient4es8-adbc-driver-0.2.3.jar` |
+| ES 9.x         | `softclient4es9-adbc-driver-0.2.3.jar` |
 
 ### Maven / Gradle / sbt
 
@@ -36,20 +36,20 @@ Download the self-contained fat JAR for your Elasticsearch version:
 <dependency>
   <groupId>app.softnetwork.elastic</groupId>
   <artifactId>softclient4es8-adbc-driver</artifactId>
-  <version>0.2.1</version>
+  <version>0.2.3</version>
 </dependency>
 ```
 
 **Gradle:**
 
 ```groovy
-implementation 'app.softnetwork.elastic:softclient4es8-adbc-driver:0.2.1'
+implementation 'app.softnetwork.elastic:softclient4es8-adbc-driver:0.2.3'
 ```
 
 **sbt:**
 
 ```scala
-libraryDependencies += "app.softnetwork.elastic" % "softclient4es8-adbc-driver" % "0.2.1"
+libraryDependencies += "app.softnetwork.elastic" % "softclient4es8-adbc-driver" % "0.2.3"
 ```
 
 ---

--- a/documentation/client/arrow_flight_sql.md
+++ b/documentation/client/arrow_flight_sql.md
@@ -49,15 +49,15 @@ Available images per ES version:
 ### Fat JAR
 
 ```bash
-java -jar softclient4es8-arrow-flight-sql-0.2.1.jar
+java -jar softclient4es8-arrow-flight-sql-0.2.3.jar
 ```
 
 | Elasticsearch | Artifact |
 |---------------|----------|
-| ES 6.x | `softclient4es6-arrow-flight-sql-0.2.1.jar` |
-| ES 7.x | `softclient4es7-arrow-flight-sql-0.2.1.jar` |
-| ES 8.x | `softclient4es8-arrow-flight-sql-0.2.1.jar` |
-| ES 9.x | `softclient4es9-arrow-flight-sql-0.2.1.jar` |
+| ES 6.x | `softclient4es6-arrow-flight-sql-0.2.3.jar` |
+| ES 7.x | `softclient4es7-arrow-flight-sql-0.2.3.jar` |
+| ES 8.x | `softclient4es8-arrow-flight-sql-0.2.3.jar` |
+| ES 9.x | `softclient4es9-arrow-flight-sql-0.2.3.jar` |
 
 ---
 

--- a/documentation/client/download_analytics.md
+++ b/documentation/client/download_analytics.md
@@ -15,7 +15,7 @@ beacon to a public endpoint with exactly these fields:
 |---------------|----------|-----------------------------------------------|
 | `source`      | `portal` | Where the count came from (the docs button)   |
 | `driver`      | `jdbc`   | Which driver family (`jdbc` or `adbc`)        |
-| `version`     | `0.2.1`  | The published artifact version                |
+| `version`     | `0.2.3`  | The published artifact version                |
 | `count_delta` | `1`      | One download                                  |
 
 A timestamp is added on the server. That is the **entire** record.

--- a/documentation/client/jdbc.md
+++ b/documentation/client/jdbc.md
@@ -20,10 +20,10 @@ Download the self-contained fat JAR for your Elasticsearch version. The JARs are
 
 | Elasticsearch | Artifact |
 |---------------|----------|
-| ES 6.x | `softclient4es6-jdbc-driver-0.2.1.jar` |
-| ES 7.x | `softclient4es7-jdbc-driver-0.2.1.jar` |
-| ES 8.x | `softclient4es8-jdbc-driver-0.2.1.jar` |
-| ES 9.x | `softclient4es9-jdbc-driver-0.2.1.jar` |
+| ES 6.x | `softclient4es6-jdbc-driver-0.2.3.jar` |
+| ES 7.x | `softclient4es7-jdbc-driver-0.2.3.jar` |
+| ES 8.x | `softclient4es8-jdbc-driver-0.2.3.jar` |
+| ES 9.x | `softclient4es9-jdbc-driver-0.2.3.jar` |
 
 ### Build Tool Integration
 
@@ -33,20 +33,20 @@ Download the self-contained fat JAR for your Elasticsearch version. The JARs are
 <dependency>
   <groupId>app.softnetwork.elastic</groupId>
   <artifactId>softclient4es8-jdbc-driver</artifactId>
-  <version>0.2.1</version>
+  <version>0.2.3</version>
 </dependency>
 ```
 
 **Gradle:**
 
 ```groovy
-implementation 'app.softnetwork.elastic:softclient4es8-jdbc-driver:0.2.1'
+implementation 'app.softnetwork.elastic:softclient4es8-jdbc-driver:0.2.3'
 ```
 
 **sbt:**
 
 ```scala
-libraryDependencies += "app.softnetwork.elastic" % "softclient4es8-jdbc-driver" % "0.2.1"
+libraryDependencies += "app.softnetwork.elastic" % "softclient4es8-jdbc-driver" % "0.2.3"
 ```
 
 ---

--- a/documentation/client/repl.md
+++ b/documentation/client/repl.md
@@ -116,8 +116,8 @@ Before installing, you can list all available versions for a specific Elasticsea
 
   Versions:
 
+    • 0.20.1
     • 0.20.2
-    • 0.20.3
 
   Total: 2 version(s)
 
@@ -147,7 +147,7 @@ Before installing, you can list all available versions for a specific Elasticsea
 ./install.sh --list-versions --es-version 8
 
 # Install specific version
-./install.sh --es-version 8 --version 0.16.0
+./install.sh --es-version 8 --version 0.20.1
 
 # Install for Elasticsearch 9 (requires Java 17+)
 ./install.sh --es-version 9
@@ -156,7 +156,7 @@ Before installing, you can list all available versions for a specific Elasticsea
 ./install.sh --target /opt/softclient4es
 
 # Full custom installation
-./install.sh --target ~/tools/softclient4es --es-version 7 --version 0.16.0
+./install.sh --target ~/tools/softclient4es --es-version 7 --version 0.20.1
 ```
 
 #### Windows
@@ -169,7 +169,7 @@ Before installing, you can list all available versions for a specific Elasticsea
 .\install.ps1 -ListVersions -EsVersion 8
 
 # Install specific version
-.\install.ps1 -EsVersion 8 -Version 0.16.0
+.\install.ps1 -EsVersion 8 -Version 0.20.1
 
 # Install for Elasticsearch 9 (requires Java 17+)
 .\install.ps1 -EsVersion 9
@@ -178,7 +178,7 @@ Before installing, you can list all available versions for a specific Elasticsea
 .\install.ps1 -Target "C:\tools\softclient4es"
 
 # Full custom installation
-.\install.ps1 -Target "C:\tools\softclient4es" -EsVersion 7 -Version 0.16.0
+.\install.ps1 -Target "C:\tools\softclient4es" -EsVersion 7 -Version 0.20.1
 ```
 
 ---

--- a/install.ps1
+++ b/install.ps1
@@ -63,7 +63,7 @@ Examples:
   .\install.ps1
   .\install.ps1 -ListVersions -EsVersion 8
   .\install.ps1 -Target "C:\tools\softclient4es" -EsVersion 8 -Version 1.0.0
-  .\install.ps1 -EsVersion 7 -Version 0.20.0 -NoExtensions
+  .\install.ps1 -EsVersion 7 -Version 0.20.2 -NoExtensions
 
 "@
     exit 0

--- a/install.sh
+++ b/install.sh
@@ -174,7 +174,7 @@ Examples:
   $0
   $0 --list-versions --es-version 8
   $0 --target /opt/softclient4es --es-version 8 --no-extensions
-  $0 -t ~/tools/softclient4es -e 7 -v 0.20.0 --no-extensions
+  $0 -t ~/tools/softclient4es -e 7 -v 0.20.2 --no-extensions
 
 Detected OS: $OS_TYPE
 
@@ -424,7 +424,7 @@ if [[ "$WITH_EXTENSIONS" == true ]]; then
     bundle_versions=$(fetch_versions "$BUNDLE_ARTIFACT_NAME" 2>/dev/null | grep -v 'SNAPSHOT' || true)
     if [[ -n "$bundle_versions" ]]; then
         if [[ "$SOFT_VERSION" == "latest" ]]; then
-            SOFT_VERSION=$(echo "$bundle_versions" | tail -1)   # bundle-version line (0.20.2, 0.20.3, ...)
+            SOFT_VERSION=$(echo "$bundle_versions" | tail -1)   # bundle-version line (0.20.1, 0.20.2, ...)
             USE_BUNDLE=true
             success "Resolved latest -all bundle version: $SOFT_VERSION"
         elif echo "$bundle_versions" | grep -qx "$SOFT_VERSION"; then


### PR DESCRIPTION
Brings every user-facing version reference in the core docs up to what the 0.20.2 release train actually published.

## Versions

| Artifact | Was | Now |
|---|---|---|
| engine / `softclient4es8-java-client` | 0.20.0 | **0.20.2** |
| `softclient4es-community-extensions` | 0.2.0 | **0.2.2** |
| `softclient4es-arrow-extensions` | (absent) | **0.2.3** |
| `softclient4es{6,7,8,9}-jdbc-driver` | 0.2.1 | **0.2.3** |
| `softclient4es{6,7,8,9}-adbc-driver` | 0.2.1 | **0.2.3** |
| `softclient4es{6,7,8,9}-arrow-flight-sql` | 0.2.1 | **0.2.3** |
| `softclient4es-jdbc-driver_2.13` (`%%` form) | 0.2.1 | **0.2.3** |

Every pair was checked against the JFrog listing API before editing. Note the deliberate asymmetry: **community-extensions stops at 0.2.2 — 0.2.3 does not exist for it** — while arrow-extensions is at 0.2.3. Review independently confirmed both, and that arrow-extensions 0.2.3's POM does not depend on community-extensions, so the mixed pairing is safe.

## Beyond the mechanical bump

**`repl.md` contradicted itself three ways.** The `--list-versions` sample advertised "0.20.2 / 0.20.3" (0.20.3 never shipped), and the Installation Examples thirty lines below then installed `0.16.0`. So one page showed three different ideas of what exists. The sample now lists the real bundle line (0.20.1 / 0.20.2) and the examples install 0.20.1.

This is not cosmetic. Per install.sh, a version with no matching `-all` bundle logs `No -all bundle for version … falling back to the plain artifact`, and per repl.md's own text the plain artifact has no arrow extensions and therefore **no cross-index JOIN**. The docs were handing users a copy-paste command that silently loses the headline feature.

**README's sbt block never mentioned arrow-extensions**, only community-extensions — while repl.md calls arrow-extensions *required* for cross-index JOIN. Added, with the Java 11+ note.

**`install.sh`**: the `--help` example pinned 0.20.0 (same no-bundle fallback trap) and a comment still referenced the phantom 0.20.3.

## Deliberately unchanged

Historical statements: `documentation/sql/*` "since v0.14.0" feature markers and CONTRIBUTING's release-process example describe the past, not what to install. Rewriting them would make them false.

## Verification

Review swept both this repo and the web repo over all tracked files and found no remaining stale reference; confirmed every bumped pair resolves on JFrog; and checked MD↔MDX parity (versions, artifact names, Java floor, install commands all agree). The one divergence it found — arrow-extensions described as "optional" on the web while this PR calls it required — is fixed in the companion web PR.

The `install.ps1` stale example the review also flagged is fixed in #180 instead, which owns that file, to avoid a merge conflict.

## Companion

softclient4es-web `docs/versions-0.20.2` — same bump for the public site, including the four download buttons and their `data-version` analytics attributes.
