### PR TITLE
R1FIX.3 — preserve the HTTP status of thrown client exceptions (#184)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ ThisBuild / organization := "app.softnetwork"
 
 name := "softclient4es"
 
-ThisBuild / version := "0.20.2"
+ThisBuild / version := "0.20.3-SNAPSHOT"
 
 ThisBuild / scalaVersion := scala213
 

--- a/core/src/main/scala/app/softnetwork/elastic/client/DeleteApi.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/DeleteApi.scala
@@ -132,10 +132,13 @@ trait DeleteApi extends ElasticClientHelpers { _: SettingsApi =>
           message =
             s"Exception while deleting document with id '$id' from index '$index': ${exception.getMessage}",
           operation = Some("deleteAsync"),
-          index = Some(index)
+          index = Some(index),
+          cause = Some(exception),
+          statusCode = statusOrServerError(exception)
         )
-        logger.error(s"❌ ${error.message}")
+        // Complete FIRST, log second — see GetApi.getAsync (SoftClient4ES#184).
         promise.success(ElasticResult.failure(error))
+        logger.error(s"❌ ${error.message}", exception)
     }
     promise.future
   }

--- a/core/src/main/scala/app/softnetwork/elastic/client/ElasticClientDelegator.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/ElasticClientDelegator.scala
@@ -27,6 +27,7 @@ import app.softnetwork.elastic.sql.policy.{EnrichPolicy, EnrichPolicyTask}
 import app.softnetwork.elastic.sql.{query, schema, PainlessContextType}
 import app.softnetwork.elastic.sql.query.{
   Delete,
+  FileFormat,
   Insert,
   SQLAggregation,
   SearchStatement,
@@ -42,6 +43,7 @@ import app.softnetwork.elastic.sql.transform.{
 }
 import app.softnetwork.elastic.sql.watcher.{Watcher, WatcherStatus}
 import com.typesafe.config.Config
+import org.apache.hadoop.conf.Configuration
 import org.json4s.Formats
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -270,6 +272,49 @@ trait ElasticClientDelegator extends ElasticClientApi with BulkTypes {
     system: ActorSystem
   ): Future[ElasticResult[DmlResult]] =
     delegate.insertByQuery(index, insert, refresh)
+
+  /** Copy the content of a file into an index.
+    *
+    * Forwarded so that the copy — and in particular its error handling, which derives the HTTP
+    * status of a thrown client exception (SoftClient4ES#184) — runs on the real client rather than
+    * on this wrapper. Default argument values are deliberately NOT repeated: Scala allows them in
+    * exactly one place in an override chain (see `IndicesApi.copyInto`).
+    *
+    * @param source
+    *   - the file to read the documents from
+    * @param target
+    *   - the target index name
+    * @param doUpdate
+    *   - true to update existing documents, false to insert only
+    * @param fileFormat
+    *   - optional file format (if not provided, will be inferred from the file extension)
+    * @param hadoopConf
+    *   - optional Hadoop configuration used to read the source
+    * @return
+    *   the number of documents inserted/updated
+    */
+  override def copyInto(
+    source: String,
+    target: String,
+    doUpdate: Boolean,
+    fileFormat: Option[FileFormat],
+    hadoopConf: Option[Configuration]
+  )(implicit
+    system: ActorSystem
+  ): Future[ElasticResult[DmlResult]] =
+    delegate.copyInto(source, target, doUpdate, fileFormat, hadoopConf)
+
+  /** Resolve the HTTP status of a thrown client exception against the REAL client
+    * (SoftClient4ES#184).
+    *
+    * The `copyInto` forward above fixes one method; this fixes the class of problem. Any core body
+    * that runs on this wrapper rather than being forwarded — today `copyInto` before the override
+    * above, tomorrow whatever is added without a forward — would otherwise resolve `statusOf`
+    * against `ElasticClientHelpers`' `None` default and report an undifferentiated 500. Delegating
+    * the seam itself means the wrapper can never disagree with the client it wraps, whether or not
+    * someone remembers to add the forward.
+    */
+  override private[client] def statusOf(t: Throwable): Option[Int] = delegate.statusOf(t)
 
   /** Load the schema for the provided index.
     *

--- a/core/src/main/scala/app/softnetwork/elastic/client/ElasticClientHelpers.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/ElasticClientHelpers.scala
@@ -16,10 +16,11 @@
 
 package app.softnetwork.elastic.client
 
-import app.softnetwork.elastic.client.result.ElasticError
+import app.softnetwork.elastic.client.result.{ElasticError, ElasticFailure}
 import org.slf4j.Logger
 
 import scala.language.reflectiveCalls
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 trait ElasticClientHelpers {
@@ -496,5 +497,100 @@ trait ElasticClientHelpers {
         logger.error(s"Operation '$operation'$indexStr failed: ${error.message}")
     }
   }
+
+  // ========================================================================
+  // HTTP STATUS EXTRACTION (SoftClient4ES#184)
+  // ========================================================================
+
+  /** Strip the asynchronous plumbing wrappers a throwable may have acquired on its way out of a
+    * `CompletableFuture` / `Future` before its HTTP status can be read.
+    *
+    * `CompletableFuture` wraps an upstream failure in a `CompletionException` when it crosses a
+    * dependent stage, and `Future`/`Await` surfaces `ExecutionException`; neither carries a status
+    * of its own. Unwrapping is a no-op when the wrapper is absent, so it is applied unconditionally
+    * rather than guessed per client library.
+    *
+    * Iterative, with BOTH a self-cause guard and a depth cap. The self-cause guard alone only
+    * covers a 1-cycle; a 2-object cycle (`a.getCause == b`, `b.getCause == a`) would otherwise
+    * recurse until `StackOverflowError` — which is a `VirtualMachineError`, so neither `NonFatal`
+    * nor [[statusOrServerError]] catches it, and the caller's `Promise` would never complete. The
+    * cap makes the method total by construction instead of by assumption; Elasticsearch's own
+    * `ExceptionsHelper.unwrapCause` bails out at 10 levels for the same reason.
+    */
+  private[client] final def unwrapThrowable(t: Throwable): Throwable = {
+    // Deliberately a method-LOCAL val, not a trait member: a `val` in a trait is emitted as a
+    // field plus an initializer setter on the interface, which every already-compiled implementor
+    // would have to provide — an `AbstractMethodError` at construction time and a binary
+    // incompatibility that AD-10 promises this change does not introduce. Real wrapper chains are
+    // 1-2 deep; the cap exists purely so a pathological cause cycle terminates.
+    val depthLimit = 16
+    var current = t
+    var depth = 0
+    var continue = true
+    while (continue && depth < depthLimit) {
+      val cause = current.getCause
+      val isWrapper = current.isInstanceOf[java.util.concurrent.CompletionException] ||
+        current.isInstanceOf[java.util.concurrent.ExecutionException]
+      if (isWrapper && (cause ne null) && (cause ne current)) {
+        current = cause
+        depth += 1
+      } else {
+        continue = false
+      }
+    }
+    current
+  }
+
+  /** Best-effort HTTP status of a throwable raised by the underlying Elasticsearch client.
+    *
+    * The core default understands only the framework's own status-bearing throwables
+    * (`ElasticError` / `ElasticFailure`). Each client module overrides this with the exception
+    * types of its own client library — see `JavaClientHelpers` (ES 8/9) and
+    * `RestHighLevelClientHelpers` (ES 6/7). ES 6 Jest deliberately has no override: its HTTP status
+    * is only ever exposed on `JestResult.getResponseCode`, never on a thrown exception.
+    *
+    * `None` means "no HTTP status could be determined" — it is NOT a synonym for 500 and must never
+    * be read as "not found". Callers that need a status pick their own fallback; the asynchronous
+    * flattening sites in core use [[statusOrServerError]].
+    *
+    * Overrides MUST unwrap first (`unwrapThrowable`), MUST delegate their fallthrough to
+    * `super.statusOf(t)` so the framework throwables keep working, and MUST NOT throw — some
+    * client-library accessors dereference a nullable field (`TransportException.statusCode()` is
+    * `return response.statusCode()` with no null check). [[statusOrServerError]] absorbs a throwing
+    * override as a last line of defence, but an override that needs the guard is a bug in the
+    * override.
+    */
+  private[client] def statusOf(t: Throwable): Option[Int] =
+    unwrapThrowable(t) match {
+      case f: ElasticFailure => f.elasticError.statusCode
+      case e: ElasticError   => e.statusCode
+      case _                 => None
+    }
+
+  /** [[statusOf]] with the "internal server error" fallback used by the asynchronous flattening
+    * sites, where an `ElasticError` must be produced and some status has to be chosen.
+    *
+    * TOTAL BY CONSTRUCTION — it never throws. This is not defensive decoration: every caller runs
+    * inside a `Future.onComplete` callback, and a throw there is swallowed by the
+    * `ExecutionContext` reporter *without completing the promise*, so `getAsync` would return a
+    * `Future` that never completes and the REPL would hang instead of reporting a 500.
+    *
+    * `LinkageError` is caught alongside `NonFatal` on purpose. `scala.util.control.NonFatal` does
+    * NOT cover it, yet `NoClassDefFoundError` is a real, observed failure mode in this repo
+    * (SoftClient4ES#168): an override's type test — e.g. `case ex:
+    * org.elasticsearch.client.ResponseException` in `JavaClientHelpers` — has to resolve that class
+    * at runtime, and a shaded or ProGuarded fat jar can have removed it. Letting it escape would
+    * produce exactly the hang this method exists to prevent. `OutOfMemoryError` and the other
+    * `VirtualMachineError`s still propagate: the JVM is already lost, and swallowing them would
+    * hide it.
+    */
+  private[client] final def statusOrServerError(t: Throwable): Option[Int] =
+    Some(
+      try statusOf(t).getOrElse(500)
+      catch {
+        case NonFatal(_)     => 500
+        case _: LinkageError => 500
+      }
+    )
 
 }

--- a/core/src/main/scala/app/softnetwork/elastic/client/GetApi.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/GetApi.scala
@@ -195,12 +195,16 @@ trait GetApi extends ElasticClientHelpers {
           ElasticError(
             message =
               s"Exception occurred while retrieving document with id '$id' from index '$index': ${exception.getMessage}",
-            statusCode = Some(500),
+            cause = Some(exception),
+            statusCode = statusOrServerError(exception),
             index = Some(index),
             operation = Some("getAsync")
           )
-        logger.error(s"❌ ${error.message}")
+        // Complete FIRST, log second (SoftClient4ES#184): passing the throwable makes the appender
+        // walk the whole cause chain, and a throw there would leave this Promise uncompleted
+        // forever — a hang, which is strictly worse than a lost log line.
         promise.success(ElasticResult.failure(error))
+        logger.error(s"❌ ${error.message}", exception)
     }
 
     promise.future

--- a/core/src/main/scala/app/softnetwork/elastic/client/IndexApi.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/IndexApi.scala
@@ -217,10 +217,12 @@ trait IndexApi extends ElasticClientHelpers { _: SettingsApi =>
             s"Failed to index document with id '$id' in index '$index': ${exception.getMessage}",
           operation = Some("indexAsync"),
           index = Some(index),
-          cause = Some(exception)
+          cause = Some(exception),
+          statusCode = statusOrServerError(exception)
         )
-        logger.error(s"❌ ${error.message}")
+        // Complete FIRST, log second — see GetApi.getAsync (SoftClient4ES#184).
         promise.success(ElasticResult.failure(error))
+        logger.error(s"❌ ${error.message}", exception)
     }
 
     promise.future

--- a/core/src/main/scala/app/softnetwork/elastic/client/IndicesApi.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/IndicesApi.scala
@@ -1152,7 +1152,9 @@ trait IndicesApi extends ElasticClientHelpers {
             ElasticError(
               message = e.getMessage,
               operation = Some("insertByQuery"),
-              index = Some(index)
+              index = Some(index),
+              cause = Some(e),
+              statusCode = statusOrServerError(e)
             )
           )
       }
@@ -1446,7 +1448,9 @@ trait IndicesApi extends ElasticClientHelpers {
             ElasticError(
               message = e.getMessage,
               operation = Some("copyInto"),
-              index = Some(target)
+              index = Some(target),
+              cause = Some(e),
+              statusCode = statusOrServerError(e)
             )
           )
       }

--- a/core/src/main/scala/app/softnetwork/elastic/client/UpdateApi.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/UpdateApi.scala
@@ -223,12 +223,15 @@ trait UpdateApi extends ElasticClientHelpers { _: SettingsApi =>
       case Failure(exception) =>
         val error = ElasticError(
           message =
-            s"Exception while deleting document with id '$id' from index '$index': ${exception.getMessage}",
-          operation = Some("deleteAsync"),
-          index = Some(index)
+            s"Exception while updating document with id '$id' in index '$index': ${exception.getMessage}",
+          operation = Some("updateAsync"),
+          index = Some(index),
+          cause = Some(exception),
+          statusCode = statusOrServerError(exception)
         )
-        logger.error(s"❌ ${error.message}")
+        // Complete FIRST, log second — see GetApi.getAsync (SoftClient4ES#184).
         promise.success(ElasticResult.failure(error))
+        logger.error(s"❌ ${error.message}", exception)
     }
     promise.future
   }

--- a/core/src/main/scala/app/softnetwork/elastic/client/metrics/MetricsElasticClient.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/metrics/MetricsElasticClient.scala
@@ -36,6 +36,7 @@ import app.softnetwork.elastic.sql.policy.{EnrichPolicy, EnrichPolicyTask}
 import app.softnetwork.elastic.sql.{query, schema}
 import app.softnetwork.elastic.sql.query.{
   Delete,
+  FileFormat,
   Insert,
   SQLAggregation,
   SearchStatement,
@@ -49,6 +50,7 @@ import app.softnetwork.elastic.sql.transform.{
   TransformStats
 }
 import app.softnetwork.elastic.sql.watcher.{Watcher, WatcherStatus}
+import org.apache.hadoop.conf.Configuration
 import org.json4s.Formats
 
 import scala.collection.immutable.ListMap
@@ -273,6 +275,32 @@ class MetricsElasticClient(
   ): Future[ElasticResult[DmlResult]] = {
     measureAsync("insertByQuery", Some(index)) {
       delegate.insertByQuery(index, insert, refresh)
+    }(system.dispatcher)
+  }
+
+  /** `COPY INTO` (SoftClient4ES#184).
+    *
+    * `ElasticClientDelegator` now forwards `copyInto` to the real client so its error handling
+    * derives the HTTP status there. Before that forward existed, this wrapper ran the core
+    * `IndicesApi.copyInto` body itself, and the operation was measured only INCIDENTALLY, through
+    * the `getIndex` and `bulkWithResult` overrides its body happens to call on `this`. Forwarding
+    * removes those incidental measurements, so `COPY INTO` would silently contribute nothing to
+    * `getMetrics` / `getAggregatedMetrics` — and `MonitoredElasticClient`'s failure-rate and
+    * latency alerts would stop seeing file-copy traffic entirely. Measuring it explicitly here both
+    * restores the signal and improves it: one honest `copyInto` operation instead of a scattering
+    * of sub-calls.
+    */
+  override def copyInto(
+    source: String,
+    target: String,
+    doUpdate: Boolean,
+    fileFormat: Option[FileFormat],
+    hadoopConf: Option[Configuration]
+  )(implicit
+    system: ActorSystem
+  ): Future[ElasticResult[DmlResult]] = {
+    measureAsync("copyInto", Some(target)) {
+      delegate.copyInto(source, target, doUpdate, fileFormat, hadoopConf)
     }(system.dispatcher)
   }
 

--- a/core/src/test/scala/app/softnetwork/elastic/client/AsyncFlatteningStatusSpec.scala
+++ b/core/src/test/scala/app/softnetwork/elastic/client/AsyncFlatteningStatusSpec.scala
@@ -1,0 +1,123 @@
+package app.softnetwork.elastic.client
+
+import app.softnetwork.elastic.client.result._
+import org.mockito.MockitoSugar
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.slf4j.Logger
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+/** SoftClient4ES#184 — the three sibling asynchronous flattening sites (`IndexApi.indexAsync`,
+  * `UpdateApi.updateAsync`, `DeleteApi.deleteAsync`) must derive the HTTP status exactly like
+  * `GetApi.getAsync`, and `updateAsync` must report its own identity (AC 6 — it used to be a
+  * verbatim copy-paste of `DeleteApi`, telling operators an UPDATE failure came from
+  * `deleteAsync`).
+  *
+  * Docker-free: the `executeXAsync` members are stubbed, so a failure here means the status
+  * derivation or the operation identity is wrong, never that a cluster was unavailable.
+  */
+class AsyncFlatteningStatusSpec extends AnyWordSpec with Matchers with MockitoSugar {
+
+  private val mockLogger: Logger = mock[Logger]
+
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  private val timeout = Duration(10, TimeUnit.SECONDS)
+
+  private class TestApi(failure: Throwable) extends NopeClientApi {
+    override protected def logger: Logger = mockLogger
+
+    override private[client] def executeIndexAsync(
+      index: String,
+      id: String,
+      source: String,
+      wait: Boolean
+    )(implicit ec: ExecutionContext): Future[ElasticResult[Boolean]] = Future.failed(failure)
+
+    override private[client] def executeUpdateAsync(
+      index: String,
+      id: String,
+      source: String,
+      upsert: Boolean,
+      wait: Boolean
+    )(implicit ec: ExecutionContext): Future[ElasticResult[Boolean]] = Future.failed(failure)
+
+    override private[client] def executeDeleteAsync(index: String, id: String, wait: Boolean)(
+      implicit ec: ExecutionContext
+    ): Future[ElasticResult[Boolean]] = Future.failed(failure)
+  }
+
+  private val notFound = ElasticError("no such index [absent]", statusCode = Some(404))
+  private val refused = new java.net.ConnectException("Connection refused")
+
+  "indexAsync" should {
+
+    "preserve the HTTP status of a status-bearing exception" in {
+      val error =
+        Await.result(new TestApi(notFound).indexAsync("some_index", "1", "{}"), timeout).error.get
+
+      error.statusCode shouldBe Some(404)
+      error.operation shouldBe Some("indexAsync")
+      error.index shouldBe Some("some_index")
+      error.cause shouldBe Some(notFound)
+    }
+
+    "fall back to 500 for a transport failure" in {
+      Await
+        .result(new TestApi(refused).indexAsync("some_index", "1", "{}"), timeout)
+        .error
+        .get
+        .statusCode shouldBe Some(500)
+    }
+  }
+
+  "updateAsync" should {
+
+    "preserve the HTTP status of a status-bearing exception" in {
+      val error = Await
+        .result(new TestApi(notFound).updateAsync("some_index", "1", "{}", upsert = false), timeout)
+        .error
+        .get
+
+      error.statusCode shouldBe Some(404)
+      error.cause shouldBe Some(notFound)
+    }
+
+    "report its own operation and an 'updating' message, not deleteAsync's (AC 6)" in {
+      val error = Await
+        .result(new TestApi(refused).updateAsync("some_index", "1", "{}", upsert = false), timeout)
+        .error
+        .get
+
+      error.operation shouldBe Some("updateAsync")
+      error.message should include("updating")
+      error.message should not include "deleting"
+      error.statusCode shouldBe Some(500)
+    }
+  }
+
+  "deleteAsync" should {
+
+    "preserve the HTTP status of a status-bearing exception" in {
+      val error = Await
+        .result(new TestApi(notFound).deleteAsync("1", "some_index", wait = false), timeout)
+        .error
+        .get
+
+      error.statusCode shouldBe Some(404)
+      error.operation shouldBe Some("deleteAsync")
+      error.cause shouldBe Some(notFound)
+    }
+
+    "fall back to 500 for a transport failure" in {
+      Await
+        .result(new TestApi(refused).deleteAsync("1", "some_index", wait = false), timeout)
+        .error
+        .get
+        .statusCode shouldBe Some(500)
+    }
+  }
+}

--- a/core/src/test/scala/app/softnetwork/elastic/client/ElasticClientDelegatorCopyIntoSpec.scala
+++ b/core/src/test/scala/app/softnetwork/elastic/client/ElasticClientDelegatorCopyIntoSpec.scala
@@ -1,0 +1,100 @@
+package app.softnetwork.elastic.client
+
+import akka.actor.ActorSystem
+import app.softnetwork.elastic.client.result._
+import app.softnetwork.elastic.sql.query.{FileFormat, Json}
+import org.apache.hadoop.conf.Configuration
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+/** SoftClient4ES#184 / AC 5 — `copyInto` was the ONE public method among the six touched by this
+  * story that `ElasticClientDelegator` did not forward. The REPL and the JDBC driver never hold a
+  * raw client (`MonitoredElasticClient` -> `MetricsElasticClient` -> `ElasticClientDelegator`), so
+  * without the forward the `recover` block inside `IndicesApi.copyInto` would resolve `statusOf`
+  * against the wrapper's core default and silently report `Some(500)` for every failure.
+  *
+  * This spec locks the forward in place. If it ever goes red, the status derivation for `COPY INTO`
+  * has become inert on every wrapped client.
+  */
+class ElasticClientDelegatorCopyIntoSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  implicit val system: ActorSystem = ActorSystem("elastic-client-delegator-copy-into-test")
+
+  override def afterAll(): Unit = {
+    Await.result(system.terminate(), Duration(30, TimeUnit.SECONDS))
+    super.afterAll()
+  }
+
+  /** Records whether the delegate — i.e. the real client — actually ran the call, and with which
+    * arguments. ALL five parameters are captured on purpose: an override written
+    * `delegate.copyInto(source, target, doUpdate)` would forward correctly enough to keep a
+    * 3-argument assertion green while silently discarding the user's `FILE_FORMAT` clause and
+    * Hadoop configuration — the same silent-drop class of bug this spec exists to prevent.
+    */
+  private class RecordingClient extends NopeClientApi {
+    override protected def logger: Logger = LoggerFactory.getLogger(getClass.getName)
+
+    var copyIntoCalls: List[(String, String, Boolean, Option[FileFormat], Option[Configuration])] =
+      Nil
+
+    override def copyInto(
+      source: String,
+      target: String,
+      doUpdate: Boolean,
+      fileFormat: Option[FileFormat],
+      hadoopConf: Option[Configuration]
+    )(implicit system: ActorSystem): Future[ElasticResult[DmlResult]] = {
+      copyIntoCalls = copyIntoCalls :+ ((source, target, doUpdate, fileFormat, hadoopConf))
+      Future.successful(ElasticSuccess(DmlResult(inserted = 1L, rejected = 0L)))
+    }
+  }
+
+  "ElasticClientDelegator" should {
+
+    "forward copyInto to the delegate so the status derivation runs on the real client (AC 5)" in {
+      val recording = new RecordingClient
+      val delegator = new ElasticClientDelegator {
+        override val delegate: ElasticClientApi = recording
+      }
+      val conf = new Configuration()
+
+      val result = Await.result(
+        delegator.copyInto(
+          "/tmp/source.json",
+          "target_index",
+          doUpdate = true,
+          fileFormat = Some(Json),
+          hadoopConf = Some(conf)
+        ),
+        Duration(10, TimeUnit.SECONDS)
+      )
+
+      recording.copyIntoCalls shouldBe List(
+        ("/tmp/source.json", "target_index", true, Some(Json), Some(conf))
+      )
+      result shouldBe ElasticSuccess(DmlResult(inserted = 1L, rejected = 0L))
+    }
+
+    "forward statusOf to the delegate so a wrapper can never disagree with its client" in {
+      // Stands in for a real client family override (JavaClientHelpers / RestHighLevelClientHelpers)
+      // that recognises a library-specific exception the core default knows nothing about.
+      val recording = new RecordingClient {
+        override private[client] def statusOf(t: Throwable): Option[Int] = Some(418)
+      }
+      val delegator = new ElasticClientDelegator {
+        override val delegate: ElasticClientApi = recording
+      }
+
+      // Without the delegator's forward this is the core default's None, and every core body that
+      // runs on the wrapper would report an undifferentiated 500.
+      delegator.statusOf(new RuntimeException("boom")) shouldBe Some(418)
+      delegator.statusOrServerError(new RuntimeException("boom")) shouldBe Some(418)
+    }
+  }
+}

--- a/core/src/test/scala/app/softnetwork/elastic/client/GetApiStatusSpec.scala
+++ b/core/src/test/scala/app/softnetwork/elastic/client/GetApiStatusSpec.scala
@@ -1,0 +1,173 @@
+package app.softnetwork.elastic.client
+
+import app.softnetwork.elastic.client.result._
+import org.mockito.MockitoSugar
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.slf4j.Logger
+
+import java.util.concurrent.{CompletionException, TimeUnit}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+/** SoftClient4ES#184 — the asynchronous flattening sites must map a thrown client exception back to
+  * its HTTP status, falling back to 500 only when no status can be determined.
+  *
+  * Docker-free by construction: `executeGetAsync` is stubbed, so this spec fails for exactly one
+  * reason — the status derivation — and never for cluster availability.
+  */
+class GetApiStatusSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with MockitoSugar {
+
+  private val mockLogger: Logger = mock[Logger]
+
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  class TestGetApi extends NopeClientApi {
+    override protected def logger: Logger = mockLogger
+
+    var asyncFailure: Option[Throwable] = None
+
+    override private[client] def executeGetAsync(index: String, id: String)(implicit
+      ec: ExecutionContext
+    ): Future[ElasticResult[Option[String]]] =
+      asyncFailure match {
+        case Some(t) => Future.failed(t)
+        case None    => Future.successful(ElasticSuccess(Some("""{"id":"1"}""")))
+      }
+  }
+
+  private var api: TestGetApi = _
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    api = new TestGetApi()
+  }
+
+  private def getAsyncResult(): ElasticResult[Option[String]] =
+    Await.result(api.getAsync("1", "some_index"), Duration(10, TimeUnit.SECONDS))
+
+  "statusOf" should {
+
+    "read the status carried by an ElasticError" in {
+      api.statusOf(ElasticError("boom", statusCode = Some(404))) shouldBe Some(404)
+    }
+
+    "read the status carried by an ElasticFailure" in {
+      api.statusOf(
+        ElasticFailure(ElasticError("boom", statusCode = Some(409)))
+      ) shouldBe Some(409)
+    }
+
+    "unwrap a CompletionException before reading the status" in {
+      val wrapped = new CompletionException(ElasticError("boom", statusCode = Some(404)))
+      api.statusOf(wrapped) shouldBe Some(404)
+    }
+
+    "unwrap nested plumbing wrappers" in {
+      val wrapped = new CompletionException(
+        new java.util.concurrent.ExecutionException(ElasticError("boom", statusCode = Some(403)))
+      )
+      api.statusOf(wrapped) shouldBe Some(403)
+    }
+
+    "return None for a throwable that carries no status" in {
+      api.statusOf(new java.net.ConnectException("Connection refused")) shouldBe None
+    }
+
+    "not loop on a self-referential cause" in {
+      // `initCause` is NOT usable here: every CompletionException constructor sets the cause
+      // (to null if none is given), and Throwable.initCause then throws IllegalStateException.
+      // Overriding getCause is the only way to build a genuinely self-causing throwable.
+      class SelfCause extends CompletionException("self", null) {
+        override def getCause: Throwable = this
+      }
+      api.statusOf(new SelfCause) shouldBe None
+    }
+
+    "terminate on a two-object cause cycle instead of recursing" in {
+      // The self-cause guard alone does NOT cover this shape: a.getCause == b, b.getCause == a.
+      // Without the depth cap in `unwrapThrowable` this recurses to StackOverflowError, which is a
+      // VirtualMachineError — neither NonFatal nor statusOrServerError catches it, so the caller's
+      // Promise would never complete. Assert termination, not a particular value.
+      class Cyclic(name: String) extends CompletionException(name, null) {
+        var other: Throwable = _
+        override def getCause: Throwable = other
+      }
+      val a = new Cyclic("a")
+      val b = new Cyclic("b")
+      a.other = b
+      b.other = a
+
+      api.statusOf(a) shouldBe None
+      api.statusOrServerError(a) shouldBe Some(500)
+    }
+  }
+
+  "statusOrServerError" should {
+
+    "fall back to 500 when no status can be determined" in {
+      api.statusOrServerError(new java.net.ConnectException("Connection refused")) shouldBe Some(
+        500
+      )
+    }
+
+    "never propagate an exception thrown by an extractor (AC 8)" in {
+      // Models `TransportException.statusCode()` NPE-ing on a null `response`: a throw here would
+      // escape the Future.onComplete callback and leave the Promise uncompleted forever.
+      class Exploding extends RuntimeException("boom")
+      val exploding = new TestGetApi {
+        override private[client] def statusOf(t: Throwable): Option[Int] = t match {
+          case _: Exploding => throw new NullPointerException("response is null")
+          case other        => super.statusOf(other)
+        }
+      }
+      exploding.statusOrServerError(new Exploding) shouldBe Some(500)
+    }
+  }
+
+  "getAsync" should {
+
+    "preserve the HTTP status of a status-bearing exception (SoftClient4ES#184)" in {
+      api.asyncFailure = Some(
+        ElasticError("no such index [absent]", statusCode = Some(404), index = Some("absent"))
+      )
+
+      val result = getAsyncResult()
+
+      result.isFailure shouldBe true
+      result.error.get.statusCode shouldBe Some(404)
+      result.error.get.operation shouldBe Some("getAsync")
+      result.error.get.index shouldBe Some("some_index")
+    }
+
+    "preserve the status through a CompletableFuture wrapper" in {
+      api.asyncFailure = Some(
+        new CompletionException(ElasticError("no such index [absent]", statusCode = Some(404)))
+      )
+
+      getAsyncResult().error.get.statusCode shouldBe Some(404)
+    }
+
+    "still report 500 for a genuine transport failure (AC 2)" in {
+      api.asyncFailure = Some(new java.net.ConnectException("Connection refused"))
+
+      val result = getAsyncResult()
+
+      result.isFailure shouldBe true
+      result.error.get.statusCode shouldBe Some(500)
+    }
+
+    "attach the exception as the error cause" in {
+      val boom = new java.net.SocketTimeoutException("read timed out")
+      api.asyncFailure = Some(boom)
+
+      getAsyncResult().error.get.cause shouldBe Some(boom)
+    }
+
+    "leave the success path untouched" in {
+      api.asyncFailure = None
+      getAsyncResult() shouldBe ElasticSuccess(Some("""{"id":"1"}"""))
+    }
+  }
+}

--- a/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestClientHelpers.scala
+++ b/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestClientHelpers.scala
@@ -96,6 +96,11 @@ trait JestClientHelpers extends ElasticClientHelpers { _: JestClientCompanion =>
           ElasticError(
             message = s"Exception during $operation: ${ex.getMessage}",
             cause = Some(ex),
+            // The Jest 6.3.1 client exposes the HTTP status only on `JestResult.getResponseCode`
+            // (see the non-succeeded branches below); its thrown exceptions are plain IOExceptions
+            // with no status. There is therefore deliberately NO `statusOf` override in this trait
+            // — core's default applies and the async flattening sites fall back to 500
+            // (SoftClient4ES#184, AD-6).
             statusCode = None,
             operation = Some(operation)
           )
@@ -361,7 +366,16 @@ trait JestClientHelpers extends ElasticClientHelpers { _: JestClientCompanion =>
         val error = ElasticError(
           message = s"Exception during $operation: ${ex.getMessage}",
           cause = Some(ex),
-          statusCode = None,
+          // `JestClientResultHandler` turns a non-succeeded `JestResult` into an `ElasticError`
+          // carrying its `getResponseCode`, so the status survives the trip through this failed
+          // Future — core's default `statusOf` reads it back. A genuine transport failure is a
+          // plain IOException with no status and still yields `None`, which is honest and is what
+          // AD-5 requires here: Jest 6.3.1 exposes an HTTP status only on `JestResult`, never on a
+          // thrown exception. That is why there is deliberately NO `statusOf` override in this
+          // trait (SoftClient4ES#184, AD-6). Read through `Try` rather than `statusOrServerError`
+          // so the `None` is preserved, while still guaranteeing this `onComplete` callback cannot
+          // throw before `promise.success` below.
+          statusCode = Try(statusOf(ex)).toOption.flatten,
           operation = Some(operation)
         )
         promise.success(ElasticResult.failure(error))

--- a/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestClientResultHandler.scala
+++ b/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestClientResultHandler.scala
@@ -16,6 +16,7 @@
 
 package app.softnetwork.elastic.client.jest
 
+import app.softnetwork.elastic.client.result.ElasticError
 import io.searchbox.action.Action
 import io.searchbox.client.{JestClient, JestResult, JestResultHandler}
 import io.searchbox.core.BulkResult
@@ -30,7 +31,30 @@ private class JestClientResultHandler[T <: JestResult] extends JestResultHandler
 
   override def completed(result: T): Unit =
     if (!result.isSucceeded)
-      promise.failure(new Exception(s"${result.getErrorMessage} - ${result.getJsonString}"))
+      // SoftClient4ES#184 — this handler is the ONLY place a non-succeeded `JestResult` is turned
+      // into a throwable, and a plain `Exception` here used to destroy the HTTP status the result
+      // carried: `JestClientHelpers.executeAsyncJestAction`'s `Failure` branch could then only
+      // report `statusCode = None`, so ES 6 Jest answered `None` (never `Some(404)`) for every
+      // asynchronous call against a missing index. Raising an `ElasticError` instead keeps the
+      // status readable through `ElasticClientHelpers.statusOf`, whose core default already
+      // understands the framework's own status-bearing throwables. The message is deliberately
+      // byte-identical to the previous `Exception`'s so downstream text does not move.
+      //
+      // ⚠️ `ElasticError` extends `Throwable`, NOT `Exception`. The single consumer of this
+      // promise (`JestClientHelpers.executeAsyncJestAction`) matches `case Failure(ex)`, which
+      // catches any throwable, so nothing changes today — but a future
+      // `recover { case e: Exception => … }` on the ASYNC Jest path would silently stop catching
+      // this. (`JestScrollApi`'s `case ex: Exception` recovers are on the synchronous
+      // `apply().execute(...)` path and are unaffected.)
+      promise.failure(
+        ElasticError(
+          message = s"${result.getErrorMessage} - ${result.getJsonString}",
+          statusCode = result.getResponseCode match {
+            case 0    => None // No HTTP response
+            case code => Some(code)
+          }
+        )
+      )
     else {
       result match {
         case r: BulkResult if !r.getFailedItems.isEmpty =>

--- a/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestClientErrorStatusSpec.scala
+++ b/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestClientErrorStatusSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JestClientErrorStatusSpec extends ClientErrorStatusSpec

--- a/es6/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientHelpers.scala
+++ b/es6/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientHelpers.scala
@@ -453,4 +453,25 @@ trait RestHighLevelClientHelpers extends ElasticClientHelpers { _: RestHighLevel
       _.isAcknowledged
     )
   }
+
+  /** @see
+    *   [[app.softnetwork.elastic.client.ElasticClientHelpers.statusOf]]
+    *
+    * `org.elasticsearch.ElasticsearchException.status()` returns a `RestStatus`
+    * (`ElasticsearchStatusException`, raised for `index_not_found_exception`, is a subclass);
+    * `org.elasticsearch.client.ResponseException` carries the raw HTTP status line. Both are
+    * already mapped in the synchronous branches of this trait — this override makes the same
+    * mapping reachable from `core`'s asynchronous flattening sites.
+    *
+    * `ResponseException` is read through `Try`: `getResponse` may be null and `getStatusLine` is
+    * not null-checked either, and an extractor must never throw (see `statusOrServerError`).
+    */
+  override private[client] def statusOf(t: Throwable): Option[Int] =
+    unwrapThrowable(t) match {
+      case ex: org.elasticsearch.ElasticsearchException =>
+        Option(ex.status()).map(_.getStatus)
+      case ex: org.elasticsearch.client.ResponseException =>
+        Try(ex.getResponse.getStatusLine.getStatusCode).toOption
+      case other => super.statusOf(other)
+    }
 }

--- a/es6/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientErrorStatusSpec.scala
+++ b/es6/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientErrorStatusSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class RestHighLevelClientErrorStatusSpec extends ClientErrorStatusSpec

--- a/es6/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientStatusOfSpec.scala
+++ b/es6/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientStatusOfSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import app.softnetwork.elastic.client.rest.{
+  RestHighLevelClientCompanion,
+  RestHighLevelClientHelpers
+}
+import com.typesafe.config.ConfigFactory
+import org.elasticsearch.rest.RestStatus
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.concurrent.CompletionException
+
+/** SoftClient4ES#184 — proves the ES 6/7 `statusOf` extractor against hand-built real exception
+  * instances, without Docker: `ElasticClientCompanion` creates the underlying client lazily, and
+  * `apply()` is never called here.
+  */
+class RestHighLevelClientStatusOfSpec extends AnyWordSpec with Matchers {
+
+  private case class Probe(config: ElasticConfig)
+      extends RestHighLevelClientCompanion
+      with RestHighLevelClientHelpers {
+    override def elasticConfig: ElasticConfig = config
+  }
+
+  private val probe = Probe(ElasticConfig(ConfigFactory.load()))
+
+  "statusOf" should {
+
+    "map ElasticsearchStatusException to its RestStatus" in {
+      val ex = new org.elasticsearch.ElasticsearchStatusException(
+        "no such index [absent]",
+        RestStatus.NOT_FOUND
+      )
+      probe.statusOf(ex) shouldBe Some(404)
+    }
+
+    "unwrap a CompletionException first" in {
+      val ex = new org.elasticsearch.ElasticsearchStatusException("gone", RestStatus.CONFLICT)
+      probe.statusOf(new CompletionException(ex)) shouldBe Some(409)
+    }
+
+    "return None for a plain transport failure" in {
+      probe.statusOf(new java.net.ConnectException("Connection refused")) shouldBe None
+    }
+
+    "fall through to the core default for a framework throwable" in {
+      probe.statusOf(
+        app.softnetwork.elastic.client.result.ElasticError("boom", statusCode = Some(403))
+      ) shouldBe Some(403)
+    }
+  }
+}

--- a/es7/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientHelpers.scala
+++ b/es7/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientHelpers.scala
@@ -453,4 +453,25 @@ trait RestHighLevelClientHelpers extends ElasticClientHelpers { _: RestHighLevel
       _.isAcknowledged
     )
   }
+
+  /** @see
+    *   [[app.softnetwork.elastic.client.ElasticClientHelpers.statusOf]]
+    *
+    * `org.elasticsearch.ElasticsearchException.status()` returns a `RestStatus`
+    * (`ElasticsearchStatusException`, raised for `index_not_found_exception`, is a subclass);
+    * `org.elasticsearch.client.ResponseException` carries the raw HTTP status line. Both are
+    * already mapped in the synchronous branches of this trait — this override makes the same
+    * mapping reachable from `core`'s asynchronous flattening sites.
+    *
+    * `ResponseException` is read through `Try`: `getResponse` may be null and `getStatusLine` is
+    * not null-checked either, and an extractor must never throw (see `statusOrServerError`).
+    */
+  override private[client] def statusOf(t: Throwable): Option[Int] =
+    unwrapThrowable(t) match {
+      case ex: org.elasticsearch.ElasticsearchException =>
+        Option(ex.status()).map(_.getStatus)
+      case ex: org.elasticsearch.client.ResponseException =>
+        Try(ex.getResponse.getStatusLine.getStatusCode).toOption
+      case other => super.statusOf(other)
+    }
 }

--- a/es7/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientErrorStatusSpec.scala
+++ b/es7/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientErrorStatusSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class RestHighLevelClientErrorStatusSpec extends ClientErrorStatusSpec

--- a/es7/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientStatusOfSpec.scala
+++ b/es7/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientStatusOfSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import app.softnetwork.elastic.client.rest.{
+  RestHighLevelClientCompanion,
+  RestHighLevelClientHelpers
+}
+import com.typesafe.config.ConfigFactory
+import org.elasticsearch.rest.RestStatus
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.concurrent.CompletionException
+
+/** SoftClient4ES#184 — proves the ES 6/7 `statusOf` extractor against hand-built real exception
+  * instances, without Docker: `ElasticClientCompanion` creates the underlying client lazily, and
+  * `apply()` is never called here.
+  */
+class RestHighLevelClientStatusOfSpec extends AnyWordSpec with Matchers {
+
+  private case class Probe(config: ElasticConfig)
+      extends RestHighLevelClientCompanion
+      with RestHighLevelClientHelpers {
+    override def elasticConfig: ElasticConfig = config
+  }
+
+  private val probe = Probe(ElasticConfig(ConfigFactory.load()))
+
+  "statusOf" should {
+
+    "map ElasticsearchStatusException to its RestStatus" in {
+      val ex = new org.elasticsearch.ElasticsearchStatusException(
+        "no such index [absent]",
+        RestStatus.NOT_FOUND
+      )
+      probe.statusOf(ex) shouldBe Some(404)
+    }
+
+    "unwrap a CompletionException first" in {
+      val ex = new org.elasticsearch.ElasticsearchStatusException("gone", RestStatus.CONFLICT)
+      probe.statusOf(new CompletionException(ex)) shouldBe Some(409)
+    }
+
+    "return None for a plain transport failure" in {
+      probe.statusOf(new java.net.ConnectException("Connection refused")) shouldBe None
+    }
+
+    "fall through to the core default for a framework throwable" in {
+      probe.statusOf(
+        app.softnetwork.elastic.client.result.ElasticError("boom", statusCode = Some(403))
+      ) shouldBe Some(403)
+    }
+  }
+}

--- a/es8/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientHelpers.scala
+++ b/es8/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientHelpers.scala
@@ -298,4 +298,36 @@ trait JavaClientHelpers extends ElasticClientHelpers with JavaClientConversion {
     )
   }
 
+  /** @see
+    *   [[app.softnetwork.elastic.client.ElasticClientHelpers.statusOf]]
+    *
+    * `co.elastic.clients.elasticsearch._types.ElasticsearchException` is a `RuntimeException`
+    * exposing `int status()`; `co.elastic.clients.transport.TransportException` is an `IOException`
+    * exposing `int statusCode()`. Both verified against elasticsearch-java v8.18.3 / v9.0.3.
+    * `org.elasticsearch.client.ResponseException` (low-level REST client, on this module's
+    * classpath via `elasticsearch-rest-client`) can surface for responses the java client cannot
+    * decode.
+    *
+    * `TransportException.statusCode()` is `return response.statusCode()` over a field that is never
+    * null-checked, so it is read through `Try` — an extractor must never throw (see
+    * `statusOrServerError`). `ResponseException` is read the same way: `getResponse` may be null
+    * and `getStatusLine` is not null-checked either.
+    *
+    * Both java-client accessors return a PRIMITIVE `int`, so an absent status surfaces as `0`
+    * rather than null. `0` is not an HTTP status — `filter(_ > 0)` turns it back into "unknown",
+    * which the async flattening sites then render as 500. Emitting `Some(0)` would defeat
+    * `isNotFound` and every `IF EXISTS` check, i.e. reintroduce the very bug this fixes. The Jest
+    * client uses the same `case 0 => None` convention.
+    */
+  override private[client] def statusOf(t: Throwable): Option[Int] =
+    unwrapThrowable(t) match {
+      case ex: co.elastic.clients.elasticsearch._types.ElasticsearchException =>
+        Some(ex.status()).filter(_ > 0)
+      case ex: co.elastic.clients.transport.TransportException =>
+        Try(ex.statusCode()).toOption.filter(_ > 0)
+      case ex: org.elasticsearch.client.ResponseException =>
+        Try(ex.getResponse.getStatusLine.getStatusCode).toOption.filter(_ > 0)
+      case other => super.statusOf(other)
+    }
+
 }

--- a/es8/java/src/test/scala/app/softnetwork/elastic/client/JavaClientErrorStatusSpec.scala
+++ b/es8/java/src/test/scala/app/softnetwork/elastic/client/JavaClientErrorStatusSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JavaClientErrorStatusSpec extends ClientErrorStatusSpec

--- a/es8/java/src/test/scala/app/softnetwork/elastic/client/JavaClientStatusOfSpec.scala
+++ b/es8/java/src/test/scala/app/softnetwork/elastic/client/JavaClientStatusOfSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import app.softnetwork.elastic.client.java.{JavaClientCompanion, JavaClientHelpers}
+import co.elastic.clients.elasticsearch._types.{ElasticsearchException, ErrorCause, ErrorResponse}
+import com.typesafe.config.ConfigFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+// `java` is shadowed by the sibling `app.softnetwork.elastic.client.java` sub-package — the
+// `_root_.` prefix is mandatory here (SoftClient4ES#184, Task 10.4).
+import _root_.java.util.concurrent.CompletionException
+
+/** SoftClient4ES#184 — proves the ES 8/9 `statusOf` extractor against hand-built real exception
+  * instances, without Docker: `ElasticClientCompanion` creates the underlying client lazily, and
+  * `apply()` is never called here.
+  */
+class JavaClientStatusOfSpec extends AnyWordSpec with Matchers {
+
+  private case class Probe(config: ElasticConfig)
+      extends JavaClientCompanion
+      with JavaClientHelpers {
+    override def elasticConfig: ElasticConfig = config
+  }
+
+  private val probe = Probe(ElasticConfig(ConfigFactory.load()))
+
+  private def esException(status: Int, errType: String): ElasticsearchException =
+    new ElasticsearchException(
+      "es/get",
+      ErrorResponse.of((r: ErrorResponse.Builder) =>
+        r.status(status)
+          .error((e: ErrorCause.Builder) => e.`type`(errType).reason("no such index [absent]"))
+      )
+    )
+
+  "statusOf" should {
+
+    "map an ElasticsearchException to its status" in {
+      probe.statusOf(esException(404, "index_not_found_exception")) shouldBe Some(404)
+    }
+
+    "unwrap a CompletionException first" in {
+      probe.statusOf(
+        new CompletionException(esException(409, "version_conflict_engine_exception"))
+      ) shouldBe Some(409)
+    }
+
+    "return None for a plain transport failure" in {
+      probe.statusOf(new _root_.java.net.ConnectException("Connection refused")) shouldBe None
+    }
+
+    "treat the primitive 0 sentinel as 'unknown', never as an HTTP status" in {
+      // `ElasticsearchException.status()` returns a primitive int, so an absent status is 0.
+      // Some(0) would defeat isNotFound and every IF EXISTS check (SoftClient4ES#184).
+      probe.statusOf(esException(0, "unknown")) shouldBe None
+      probe.statusOrServerError(esException(0, "unknown")) shouldBe Some(500)
+    }
+
+    "fall through to the core default for a framework throwable" in {
+      probe.statusOf(
+        app.softnetwork.elastic.client.result.ElasticError("boom", statusCode = Some(403))
+      ) shouldBe Some(403)
+    }
+  }
+}

--- a/es9/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientHelpers.scala
+++ b/es9/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientHelpers.scala
@@ -298,4 +298,36 @@ trait JavaClientHelpers extends ElasticClientHelpers with JavaClientConversion {
     )
   }
 
+  /** @see
+    *   [[app.softnetwork.elastic.client.ElasticClientHelpers.statusOf]]
+    *
+    * `co.elastic.clients.elasticsearch._types.ElasticsearchException` is a `RuntimeException`
+    * exposing `int status()`; `co.elastic.clients.transport.TransportException` is an `IOException`
+    * exposing `int statusCode()`. Both verified against elasticsearch-java v8.18.3 / v9.0.3.
+    * `org.elasticsearch.client.ResponseException` (low-level REST client, on this module's
+    * classpath via `elasticsearch-rest-client`) can surface for responses the java client cannot
+    * decode.
+    *
+    * `TransportException.statusCode()` is `return response.statusCode()` over a field that is never
+    * null-checked, so it is read through `Try` — an extractor must never throw (see
+    * `statusOrServerError`). `ResponseException` is read the same way: `getResponse` may be null
+    * and `getStatusLine` is not null-checked either.
+    *
+    * Both java-client accessors return a PRIMITIVE `int`, so an absent status surfaces as `0`
+    * rather than null. `0` is not an HTTP status — `filter(_ > 0)` turns it back into "unknown",
+    * which the async flattening sites then render as 500. Emitting `Some(0)` would defeat
+    * `isNotFound` and every `IF EXISTS` check, i.e. reintroduce the very bug this fixes. The Jest
+    * client uses the same `case 0 => None` convention.
+    */
+  override private[client] def statusOf(t: Throwable): Option[Int] =
+    unwrapThrowable(t) match {
+      case ex: co.elastic.clients.elasticsearch._types.ElasticsearchException =>
+        Some(ex.status()).filter(_ > 0)
+      case ex: co.elastic.clients.transport.TransportException =>
+        Try(ex.statusCode()).toOption.filter(_ > 0)
+      case ex: org.elasticsearch.client.ResponseException =>
+        Try(ex.getResponse.getStatusLine.getStatusCode).toOption.filter(_ > 0)
+      case other => super.statusOf(other)
+    }
+
 }

--- a/es9/java/src/test/scala/app/softnetwork/elastic/client/JavaClientErrorStatusSpec.scala
+++ b/es9/java/src/test/scala/app/softnetwork/elastic/client/JavaClientErrorStatusSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JavaClientErrorStatusSpec extends ClientErrorStatusSpec

--- a/es9/java/src/test/scala/app/softnetwork/elastic/client/JavaClientStatusOfSpec.scala
+++ b/es9/java/src/test/scala/app/softnetwork/elastic/client/JavaClientStatusOfSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import app.softnetwork.elastic.client.java.{JavaClientCompanion, JavaClientHelpers}
+import co.elastic.clients.elasticsearch._types.{ElasticsearchException, ErrorCause, ErrorResponse}
+import com.typesafe.config.ConfigFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+// `java` is shadowed by the sibling `app.softnetwork.elastic.client.java` sub-package — the
+// `_root_.` prefix is mandatory here (SoftClient4ES#184, Task 10.4).
+import _root_.java.util.concurrent.CompletionException
+
+/** SoftClient4ES#184 — proves the ES 8/9 `statusOf` extractor against hand-built real exception
+  * instances, without Docker: `ElasticClientCompanion` creates the underlying client lazily, and
+  * `apply()` is never called here.
+  */
+class JavaClientStatusOfSpec extends AnyWordSpec with Matchers {
+
+  private case class Probe(config: ElasticConfig)
+      extends JavaClientCompanion
+      with JavaClientHelpers {
+    override def elasticConfig: ElasticConfig = config
+  }
+
+  private val probe = Probe(ElasticConfig(ConfigFactory.load()))
+
+  private def esException(status: Int, errType: String): ElasticsearchException =
+    new ElasticsearchException(
+      "es/get",
+      ErrorResponse.of((r: ErrorResponse.Builder) =>
+        r.status(status)
+          .error((e: ErrorCause.Builder) => e.`type`(errType).reason("no such index [absent]"))
+      )
+    )
+
+  "statusOf" should {
+
+    "map an ElasticsearchException to its status" in {
+      probe.statusOf(esException(404, "index_not_found_exception")) shouldBe Some(404)
+    }
+
+    "unwrap a CompletionException first" in {
+      probe.statusOf(
+        new CompletionException(esException(409, "version_conflict_engine_exception"))
+      ) shouldBe Some(409)
+    }
+
+    "return None for a plain transport failure" in {
+      probe.statusOf(new _root_.java.net.ConnectException("Connection refused")) shouldBe None
+    }
+
+    "treat the primitive 0 sentinel as 'unknown', never as an HTTP status" in {
+      // `ElasticsearchException.status()` returns a primitive int, so an absent status is 0.
+      // Some(0) would defeat isNotFound and every IF EXISTS check (SoftClient4ES#184).
+      probe.statusOf(esException(0, "unknown")) shouldBe None
+      probe.statusOrServerError(esException(0, "unknown")) shouldBe Some(500)
+    }
+
+    "fall through to the core default for a framework throwable" in {
+      probe.statusOf(
+        app.softnetwork.elastic.client.result.ElasticError("boom", statusCode = Some(403))
+      ) shouldBe Some(403)
+    }
+  }
+}

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/ClientErrorStatusSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/ClientErrorStatusSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import akka.actor.ActorSystem
+import app.softnetwork.elastic.client.result.ElasticFailure
+import app.softnetwork.elastic.client.spi.ElasticClientFactory
+import app.softnetwork.elastic.scalatest.ElasticDockerTestKit
+import app.softnetwork.persistence.generateUUID
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContextExecutor}
+
+/** A minimal document shape for the `getAsyncAs` probe — mirrors the call
+  * `MaterializedViewExtension.loadMetadata` makes (extensions#40 / SoftClient4ES#184).
+  */
+case class StatusProbeDocument(id: String)
+
+/** SoftClient4ES#184 — `ElasticError.statusCode` must reflect what Elasticsearch actually returned,
+  * so that `IF EXISTS` and other 404-keyed branches work.
+  *
+  * Asserted on all four ES lines. Before the fix this trait is RED on es8/es9 (their
+  * `executeGetAsync` returns a failed `Future`, which `GetApi.getAsync` flattened to a hardcoded
+  * 500) and GREEN on es6/es7 (their `executeGetAsync` always returns a successful `Future` holding
+  * an `ElasticFailure` that already carries the status). Both cases are wanted: the fix for one,
+  * regression protection for the other.
+  */
+trait ClientErrorStatusSpec extends AnyFlatSpecLike with ElasticDockerTestKit with Matchers {
+
+  lazy val log: Logger = LoggerFactory.getLogger(getClass.getName)
+
+  implicit val system: ActorSystem = ActorSystem(generateUUID())
+
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
+
+  // `implicit def formats: Formats` comes from ElasticRestClientTestKit — do NOT redeclare it
+  // (it is a concrete member; redeclaring fails with "override modifier required").
+
+  lazy val client: ElasticClientApi = ElasticClientFactory.create(elasticConfig)
+
+  override def afterAll(): Unit = {
+    Await.result(system.terminate(), Duration(30, TimeUnit.SECONDS))
+    super.afterAll()
+  }
+
+  /** Never created by this or any other spec — the whole point is that the index is absent. */
+  private val absentIndex = "r1fix3_absent_index"
+
+  private val timeout = Duration(30, TimeUnit.SECONDS)
+
+  "get on a non-existent index" should "report HTTP 404, not 500" in {
+    val result = client.get("any-id", absentIndex)
+
+    result.isFailure shouldBe true
+    result.error.get.statusCode shouldBe Some(404)
+  }
+
+  "getAsync on a non-existent index" should "report HTTP 404, not 500" in {
+    val result = Await.result(client.getAsync("any-id", absentIndex), timeout)
+
+    result.isFailure shouldBe true
+    result.error.get.statusCode shouldBe Some(404)
+  }
+
+  "getAsyncAs on a non-existent index" should "report HTTP 404, not 500" in {
+    // The exact call shape used by MaterializedViewExtension.loadMetadata (extensions#40).
+    val result = Await.result(
+      client.getAsyncAs[StatusProbeDocument](id = "any-id", index = Some(absentIndex)),
+      timeout
+    )
+
+    result.isFailure shouldBe true
+    result.error.get.statusCode shouldBe Some(404)
+  }
+
+  "a failure on a non-existent index" should "be recognised by ElasticFailure.isNotFound" in {
+    client.get("any-id", absentIndex) match {
+      case f: ElasticFailure => f.isNotFound shouldBe true
+      case other             => fail(s"expected an ElasticFailure, got $other")
+    }
+  }
+}


### PR DESCRIPTION
Closes #184. Story **R1FIX.3** of the R1 defect-closure epic (Layer 0, elasticsql).

`GetApi.getAsync` hardcoded `statusCode = Some(500)` and never set `cause`, so a missing index surfaced as an undifferentiated server error and every `IF EXISTS` / 404-keyed branch misfired — including `DROP MATERIALIZED VIEW IF EXISTS` (companion: extensions#40).

## The fix

One overridable seam on the **existing** `ElasticClientHelpers` trait — `private[client] def statusOf(t: Throwable): Option[Int]`, with a concrete `None` default plus the total `statusOrServerError` used by core's asynchronous flattening sites. It is overridden once per client family, where the ES exception types are already on the classpath. No new trait, no signature churn, and because the default is **concrete**, `NopeClientApi` / `MockElasticClientApi` / `ElasticClientDelegator` and every third-party client compile untouched.

`None` keeps meaning *"no HTTP status could be determined"* — it is not a synonym for 500 and must never be read as "not found". Only the async flattening sites normalise unknown to 500; the synchronous branches still emit `None`.

## ⚠️ How to read the tests — this matters, or the suite looks vacuous

The four-ES-line assertion is a **contract**, not four fixes.

| Line | Before the fix | After |
|---|---|---|
| **es8 / es9** | 🔴 **RED, 2 of 4** — `getAsync` and `getAsyncAs` both `Some(500) was not equal to Some(404)`. Their sync `get` was already green. | 9/9 |
| **es7 / es6-rest** | 🟢 **GREEN 4/4 before any production change** — they never had the bug (`executeGetAsync` returns a *successful* Future wrapping an `ElasticFailure` that already carries the status). | 8/8 |
| **es6 / jest** | 🔴 **RED, 2 of 4 — and the issue text and the story spec were both wrong about this line.** They claimed jest already returned `Some(404)`; measured against live ES 6.8.23 it returned **`None`**. | 4/4 |

Red-before-green was captured for real: the testkit trait and its five subclasses were written and run **first**, with no production code, and the es8 output was `Tests: succeeded 2, failed 2`.

### The es6/jest discovery

Our own `JestClientResultHandler.completed` wrapped **every** non-succeeded `JestResult` in a status-less `new Exception(...)`, which makes `executeAsyncJestAction`'s `getResponseCode` mapping **unreachable on the async path**. That is the same defect class as #184 — our code fabricating a throwable from a status-bearing response and discarding the status — so it is fixed here. Blast radius is provably contained: that handler has **exactly one consumer repo-wide**, and the error message is byte-identical to before. There is still deliberately **no** `statusOf` override in `JestClientHelpers`.

## Also fixed (same defect class)

- The four sibling async flattening sites (`indexAsync`, `updateAsync`, `deleteAsync`, `insertByQuery` + `copyInto`) now derive the status and keep the exception as `ElasticError.cause`.
- **`updateAsync` reported `operation = Some("deleteAsync")`** and *"Exception while deleting…"* — a verbatim copy-paste from `DeleteApi` that sent anyone debugging a failed UPDATE to the wrong API. ⚠️ **Behaviour note for reviewers:** `ElasticError.operation` is part of the public failure payload, so anything keyed on the old (wrong) value changes. Nothing in-repo keys on it; metrics label independently.
- `ElasticClientDelegator` did not forward `copyInto`, so on the wrapper the REPL and JDBC driver actually hold (`MonitoredElasticClient` → `MetricsElasticClient` → `ElasticClientDelegator`) the whole derivation was inert. It now forwards `copyInto` **and the seam itself**, so no wrapper can ever disagree with the client it wraps.

## What the code review changed

Three parallel adversarial layers ran before commit. No BLOCKER; the acceptance audit returned *"no BLOCKER or HIGH — satisfies AC 1-8 and every audited constraint"*. Thirteen patches were applied anyway, four of which are worth your attention:

1. 🔴 **The `copyInto` forward silently removed all `COPY INTO` metrics.** Before it, the wrapper ran core's body and the operation was measured *incidentally* through the `getIndex` / `bulkWithResult` calls that body makes on `this`. Forwarding routed it past `MetricsElasticClient` entirely, so `COPY INTO` would have contributed **zero** operations to `getMetrics` and `MonitoredElasticClient`'s alerts would have stopped seeing file-copy traffic — on the default deployment path. Repaired with an explicit `measureAsync("copyInto", …)`. **General rule this establishes: adding a delegator forward can un-measure an operation.**
2. **`statusOrServerError` was not actually total.** `NonFatal` excludes `LinkageError`, and `NoClassDefFoundError` is an *observed* failure mode in this repo (#168) — the es8/es9 `case ex: ResponseException` is an `instanceof` against a class a shaded/ProGuarded fat jar can remove. It now absorbs `LinkageError` too; `OutOfMemoryError` still propagates.
3. **`unwrapThrowable` recursed forever on a 2-object cause cycle**, and the resulting `StackOverflowError` is fatal — nothing caught it and the `Promise` hung. Now iterative with a depth cap.
4. **The first depth-limit attempt used a trait `val` and broke binary compatibility.** `core/test` went red instantly with `AbstractMethodError: … UnwrapDepthLimit_$eq` from three *unrelated* pre-existing specs: a `val` in a trait adds an initializer setter to the interface that every pre-compiled implementor must supply. Made method-local. Worth remembering — it is exactly the guarantee this change relies on.

The four `Promise` sites also now complete **before** they log, because this PR newly passes the throwable to `logger.error`, which makes the appender walk the whole cause chain.

## Verification

| | |
|---|---|
| `core/test` | **669/669**, 21 suites, 0 aborted |
| Cross-compile 2.12 + 2.13, `headerCheck`, `scalafmtCheck` | 17 successes, 0 errors |
| es8 / es9 / es7 / es6-rest / es6-jest error-status + `statusOf` specs | 9 / 9 / 8 / 8 / 4 — all green |
| `es8java/testOnly *JavaClient*` (regression sweep) | **270/270**, 15 suites, 0 aborted |

`es6jest/test` reports 232 passed, **0 failed**, and 3 suites aborted — `JestClientCompanionSpec`, `JestClientPipelineApiSpec`, `JestBulkApiSpec`. Those are **pre-existing and environmental, A/B-proven against pristine `main` @ `2e02e45c`**: `EmbeddedElasticTestKit` launches an x86 embedded ES that cannot boot on an arm64 machine (`Unrecognized VM option 'UseAVX=2'`). They fail in the spec constructor, before any client code runs.

## Version line

**Bumped `build.sbt:23` from `0.20.2` to `0.20.3-SNAPSHOT`.** This is the first elasticsql PR of the epic, so it owns the line; R1FIX.4 and R1FIX.5 must verify it and change nothing.

## 🔴 Nothing was published

No `publish`, no `publishLocal`, no `release.yml` dispatch, no `v*` tag. This story ends at the PR — the release is yours.

Task 10 (the per-client `statusOf` unit specs) was marked OPTIONAL/PROPOSED in the spec, to be dropped if the `Probe` stub fought the `_: JavaClientCompanion =>` / `_: RestHighLevelClientCompanion =>` self-types. **It did not — all four were written**, they satisfy both self-types with only an `elasticConfig` override, and they are Docker-free (`apply()` is never called).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
