### PR TITLE
fix: bump Hadoop to 3.4.3 — COPY INTO Parquet/Delta/remote work on JDK 23+ (closes #183)

### DIFF
--- a/documentation/sql/dml_statements.md
+++ b/documentation/sql/dml_statements.md
@@ -397,42 +397,48 @@ This allows fine-grained property overrides without changing environment variabl
 (`/path/to/file.jsonl`, `file:///path/to/file.jsonl`) directly through `java.nio.file`, so they work
 on every supported JVM, **including JDK 23, 24 and 25**.
 
-`PARQUET`, `DELTA_LAKE` and **every remote scheme** go through Apache Hadoop, whose
-`UserGroupInformation.getCurrentUser()` calls
-`javax.security.auth.Subject.getSubject(AccessControlContext)`. That method was re-specified in
-**JDK 23** to throw whenever a Security Manager is not allowed (which is the default), and
-[JEP 486](https://openjdk.org/jeps/486) made it throw *unconditionally* in **JDK 24** while removing
-the escape hatch — a JDK 24+ launcher refuses to start if `java.security.manager` is set. Those
-paths therefore fail with:
+`PARQUET`, `DELTA_LAKE` and every remote scheme go through Apache Hadoop, and **they now work on
+every supported JVM too** — including JDK 23, 24 and 25.
+
+| `COPY INTO` source | JDK 8 – 22 | JDK 23 | JDK 24+ |
+|---|---|---|---|
+| local `JSON` / `JSON_ARRAY`, schemeless or `file:` | ✔ | ✔ | ✔ |
+| local file with auto-detected format | ✔ | ✔ | ✔ |
+| local `PARQUET` | ✔ | ✔ | ✔ |
+| local `DELTA_LAKE` | ✔ | ✔ | ✔ |
+| any remote scheme (`s3a://`, `s3://`, `gs://`, `abfs*://`, `wasb*://`, `hdfs://`) | ✔ | ✔ | ✔ |
+
+##### If you are on an older release
+
+Releases up to and including **0.20.3** fail on **JDK 23 and newer** for `PARQUET`, `DELTA_LAKE` and
+remote schemes, with:
 
 | JDK | Error text | `-Djava.security.manager=allow` |
 |---|---|---|
 | 23 | `getSubject is supported only if a security manager is allowed` | works around it |
 | 24 and newer | `getSubject is not supported` | JVM refuses to start |
 
-| `COPY INTO` source | JDK 8 – 22 | JDK 23 | JDK 24+ |
-|---|---|---|---|
-| local `JSON` / `JSON_ARRAY`, schemeless or `file:` | ✔ | ✔ | ✔ |
-| local file with auto-detected format | ✔ | ✔ | ✔ |
-| local `PARQUET` | ✔ | ✖ * | ✖ |
-| local `DELTA_LAKE` | ✔ | ✖ * | ✖ |
-| any remote scheme (`s3a://`, `s3://`, `gs://`, `abfs*://`, `wasb*://`, `hdfs://`) | ✔ | ✖ * | ✖ |
+The cause was Apache Hadoop: `UserGroupInformation.getCurrentUser()` called
+`javax.security.auth.Subject.getSubject(AccessControlContext)`, which **JDK 23** re-specified to
+throw whenever a Security Manager is not allowed (the default), and which
+[JEP 486](https://openjdk.org/jeps/486) made throw *unconditionally* in **JDK 24** while removing the
+escape hatch — a JDK 24+ launcher refuses to start if `java.security.manager` is set.
 
-\* works on JDK 23 if the host process is started with `-Djava.security.manager=allow`.
+This is fixed upstream in **Hadoop 3.4.3** ([HADOOP-19212](https://issues.apache.org/jira/browse/HADOOP-19212)),
+which this client now bundles; `UserGroupInformation` uses `Subject.current()` instead. Local
+`JSON` / `JSON_ARRAY` were additionally moved off Hadoop entirely in 0.20.3, which is why they work
+on every release.
 
-**Workaround for the unsupported combinations:** run the host process on **JDK 21** (or any
-JDK ≤ 22). On JDK 23 you may instead add `-Djava.security.manager=allow`; on JDK 24+ there is no
-flag that helps. For DBeaver, add this to `dbeaver.ini` **before** `-vmargs` (a DBeaver update
-overwrites the file):
+**If you cannot upgrade yet,** run the host process on **JDK 21** (or any JDK ≤ 22); on JDK 23 you
+may instead add `-Djava.security.manager=allow`. For DBeaver, add this to `dbeaver.ini` **before**
+`-vmargs` (a DBeaver update overwrites the file):
 
 ```
 -vm
 /path/to/jdk-21/Contents/Home/lib/libjli.dylib
 ```
 
-Lifting the Parquet / Delta / remote restriction depends on an upstream Hadoop release that no
-longer calls `Subject.getSubject`. Tracked as
-[SoftClient4ES#183](https://github.com/SOFTNETWORK-APP/SoftClient4ES/issues/183).
+Tracked as [SoftClient4ES#183](https://github.com/SOFTNETWORK-APP/SoftClient4ES/issues/183).
 
 **Local path notes:** `~` is **not** expanded — pass an absolute path. Relative paths resolve
 against the working directory of the process running the query. A `file://` URI may percent-encode

--- a/documentation/sql/known_limitations.md
+++ b/documentation/sql/known_limitations.md
@@ -51,16 +51,6 @@ WHERE department_id IN (SELECT id FROM departments WHERE region = 'EU');
 
 The parser rejects this — `IN` accepts only literal value lists today, not a nested `SELECT`. Rewrite it as an explicit JOIN (fully supported), or wait for the next release where the subquery form lands as-is.
 
-## Runtime / JVM limitations
-
-These are constraints of the host JVM, not unimplemented SQL features — they have no delivery date because they depend on upstream projects.
-
-- **`COPY INTO` with `PARQUET`, `DELTA_LAKE`, or a remote URI (`s3a://`, `gs://`, `abfs://`,
-  `hdfs://`) does not work on JDK 23 or newer.** Local `JSON` / `JSON_ARRAY` files do, on every JDK.
-  This is an Apache Hadoop limitation (JDK 23 re-specified, and JEP 486 in JDK 24 removed, the API
-  Hadoop's `UserGroupInformation` depends on); run the host process on JDK 21 for those sources. See
-  [DML statements → COPY INTO → JVM compatibility](dml_statements.md#jvm-compatibility--jdk-23-and-newer).
-
 ## Coming in the upcoming release (Quarter 1 2027)
 
 - **Heterogeneous federation**: JOIN or correlate Elasticsearch with PostgreSQL, MySQL, ClickHouse, Snowflake, and more — plus cross-cluster subqueries (e.g. correlate one cluster's data against another's).

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -61,7 +61,7 @@ object Versions {
   val fansi = "0.5.1"
 
   // Cloud storage connectors (provided scope — must be on classpath at runtime)
-  val hadoop = "3.4.2" // must match hadoop-client in core/build.sbt
+  val hadoop = "3.4.3" // must match hadoop-client in core/build.sbt
 
   val gcsConnector = "hadoop3-2.2.24"
 }


### PR DESCRIPTION
Closes #183.

## What

One line: `project/Versions.scala:64`, `Versions.hadoop` **3.4.2 → 3.4.3**. `hadoop-client`,
`hadoop-aws` and `hadoop-azure` all read that constant, so they move together.

Plus the documentation that constant made false.

## Why

R1FIX.4 (#188) fixed local `JSON` / `JSON_ARRAY` by routing them off Hadoop entirely, and we
concluded the rest — local `PARQUET`, local `DELTA_LAKE`, every remote scheme — was blocked
indefinitely on upstream Hadoop. **It wasn't: the upstream fix shipped five months ago and we were
one patch release behind.**

[HADOOP-19212](https://issues.apache.org/jira/browse/HADOOP-19212) *"[JDK25] UserGroupInformation use
of Subject needs to move to replacement APIs"* was resolved 2025-11-07, fix versions **3.4.3** and
3.5.0. Hadoop **3.4.3** was released 2026-02-24.

Verified against the actual jars rather than the changelog:

- `UserGroupInformation.getCurrentUser()` now calls **`SubjectUtil.current()`**. The
  `AccessController.getContext()` → `Subject.getSubject(...)` chain that #183 died in is **gone**.
- `SubjectUtil.current()` invokes a `MethodHandle` built by `lookupCurrent()`, which `findStatic`s
  **`Subject.current()`** (JDK 18+) and on `NoSuchMethodException` falls back to
  `filterReturnValue(getContext, getSubject)`. So it works on JDK 24/25 **and** still on our JDK 8/11
  floor.
- `hadoop-common-3.4.3` is still **major version 52** (Java 8) bytecode — `-target:jvm-1.8` intact.

## Evidence

| Check | Result |
|---|---|
| `core/testOnly *FileSourceSpec` forked onto **Zulu 25.0.4** | **26 passed, 0 failed** (baseline on `main`: 19 passed, **7 failed**) |
| `core/testOnly *LocalPathSpec *FileSourceSpec` on default **JDK 11** | 67 passed, 0 failed |
| `core/test` on default JDK 11 | **716 passed, 0 failed** |
| `+ core/compile` (2.12 + 2.13) | clean |
| `es8java/testOnly *CopyIntoS3*` (MinIO, Docker, JDK 17) | 3 passed |
| `headerCheck scalafmtSbtCheck scalafmtCheck test:scalafmtCheck` | clean |

The 7 previously-failing tests were exactly `read Parquet file`, `read Parquet file with nested
structures`, `get Parquet file metadata`, `read Delta Lake table`, `read Delta table with time
travel`, `get Delta table info`, `read Delta table with partitions`. All green on JDK 25 now.

**Remote schemes on JDK 25** are not covered by any suite, so they were probed directly against the
real `core/Test` classpath (which carries `hadoop-aws-3.4.3`, it being `% Provided`):

```
java         = 25.0.4
hadoop       = 3.4.3
UGI          = OK -> smanciot
s3a get      = OK -> org.apache.hadoop.fs.s3a.S3AFileSystem
VERDICT      = PASS (remote scheme resolved, no getSubject)
```

On that same JVM with 3.4.2, #188's `Probe183` control printed
`UnsupportedOperationException: getSubject is not supported`. The probe used static credentials and
`fs.s3a.bucket.probe=0` so the default AWS credential chain (and its IMDS probe) was never consulted.

The MinIO run is the meaningful regression check here: 3.4.3 carries a **cloud-connector
reorganisation** that could have moved S3A wiring. It didn't.

## Docs

The `COPY INTO` JVM-compatibility matrix in `documentation/sql/dml_statements.md` collapses to all-✔.
The older-release guidance is **kept**, under a new *"If you are on an older release"* subsection —
including the DBeaver `-vm` recipe and the `-Djava.security.manager=allow` note for JDK 23 — because
users on ≤ 0.20.3 still need it. The heading text is unchanged so the existing anchor keeps working.

`known_limitations.md`'s *"Runtime / JVM limitations"* section existed solely for this bullet and is
removed — a resolved item on a known-limitations page misleads anyone skimming for current
constraints. No inbound links to that anchor (checked).

## Notes for review

- **The version line is untouched.** `build.sbt:23` still reads `0.20.3-SNAPSHOT`; per the epic
  release protocol the first PR to merge owns it and R1FIX.3 already claimed it. **But 0.20.3 has
  just been released, so the line may well need to move to `0.20.4-SNAPSHOT` — that is your call,
  not something this PR should decide.** The docs deliberately do not name the version that carries
  this fix; they say "up to and including 0.20.3" for the broken releases, which is true either way.
- **Not verified: `abfs*://` / `gs://` on JDK 25.** Same `UserGroupInformation` root cause, now
  fixed, and `hadoop-azure` moves with the same constant — but there is no test for either, and the
  **GCS connector is pinned separately** (`Versions.scala:66`, `hadoop3-2.2.24`) and was not touched.
- **This obsoletes an epic finding.** The R1FIX.4 findings log records *"expect exactly 7
  Parquet/Delta failures on any JDK ≥ 23 run of `FileSourceSpec`, do not call it a regression"*. With
  3.4.3 the expected count is **zero**, and `FileSourceSpec` stops being self-controlling on JDK 25.
- **Companion PR:** the web docs mirror is
  [SOFTNETWORK-APP/softclient4es-web#31](https://github.com/SOFTNETWORK-APP/softclient4es-web/pull/31)
  (`feedback_dual_docs_sync`). Merge the two together, web after this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
