### PR TITLE
fix(build): bump version to 0.20.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ ThisBuild / organization := "app.softnetwork"
 
 name := "softclient4es"
 
-ThisBuild / version := "0.20.3-SNAPSHOT"
+ThisBuild / version := "0.20.3"
 
 ThisBuild / scalaVersion := scala213
 


### PR DESCRIPTION
First of the six-repo release train: **core → extensions → arrow → jdbc → repl → helm**. Nothing downstream can move until this is merged and published.

## What is in 0.20.3

Nine commits since `0.20.2`, four of them R1 defect closures:

| story | issue | change |
|---|---|---|
| R1FIX.3 | #184 | preserve the HTTP status of thrown ES client exceptions — `None` ≠ 404 ≠ 500, so `IF EXISTS` can tell *absent* from *the cluster is down* |
| R1FIX.4 | #183 | `COPY INTO` reads local files without Hadoop, plus Hadoop 3.4.3 |
| R1FIX.5 | #185 | single-table materialized views are supported — one transform, one stage |
| R1FIX.8 | — | a DDL statement can succeed **with a warning**: `DdlResult(success: Boolean, warnings: Seq[String] = Nil)` |

plus `install.ps1` parity, the logback appender fix and the doc version sweep already on main.

`#183` stays **open on purpose**: the local-file fast path is fixed, but Parquet, Delta and remote sources are still Hadoop-bound and still break from JDK 23.

## ⚠️ Release notes — three user-visible changes

1. **`DdlResult` gained a second field.** Positional pattern matches (`case DdlResult(ok)`) need a trailing `_`; construction is unchanged thanks to the default. Rendering: **ascii and json carry the warnings, csv does not** — `CsvFormatter` has no `DdlResult` case at all and falls through to `"No data"`. That predates R1FIX.8 but is newly consequential, since the whole point is that the warning reaches the user.
2. **Honest materialized-view stage counting** rejects the previously published `REFRESH EVERY 8 SECONDS` + `delay = '2s'` example, and the calculated delay moved from `frequency/(1.5 × stages)` to `frequency/(2 × stages)`.
3. **A cluster with `xpack.watcher.enabled: false`** (HTTP 400, not 403) now hard-fails `CREATE MATERIALIZED VIEW` where it previously succeeded silently, having created a view whose `watcher_id` pointed at a watcher that did not exist.

## Verification

`sbt "show version"` — the build loads and every module reports `0.20.3`.

The behaviour behind these fixes is covered end-to-end, through packaged artefacts against a real Elasticsearch on a **basic** licence, by the three acceptance suites added this cycle: jdbc `.github/scripts/acceptance.sh`, repl `.github/scripts/acceptance.sh` (ES 6/7/8/9), and the arrow Flight SQL python suite.