### PR TITLE
docs: bring user-facing versions up to the 0.20.3 release train

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,10 @@ Download the self-contained fat JAR for your Elasticsearch version:
 
 | Elasticsearch Version | Artifact                               |
 |-----------------------|----------------------------------------|
-| ES 6.x                | `softclient4es6-jdbc-driver-0.2.3.jar` |
-| ES 7.x                | `softclient4es7-jdbc-driver-0.2.3.jar` |
-| ES 8.x                | `softclient4es8-jdbc-driver-0.2.3.jar` |
-| ES 9.x                | `softclient4es9-jdbc-driver-0.2.3.jar` |
+| ES 6.x                | `softclient4es6-jdbc-driver-0.2.4.jar` |
+| ES 7.x                | `softclient4es7-jdbc-driver-0.2.4.jar` |
+| ES 8.x                | `softclient4es8-jdbc-driver-0.2.4.jar` |
+| ES 9.x                | `softclient4es9-jdbc-driver-0.2.4.jar` |
 
 > **Java 11+ recommended** (17+ for ES 9.x): **cross-index JOINs require Java 11+** — the embedded JOIN engine is built on Apache Arrow 18.x, which ships Java-11 bytecode.
 
@@ -219,20 +219,20 @@ Driver class: app.softnetwork.elastic.jdbc.ElasticDriver
 <dependency>
   <groupId>app.softnetwork.elastic</groupId>
   <artifactId>softclient4es8-jdbc-driver</artifactId>
-  <version>0.2.3</version>
+  <version>0.2.4</version>
 </dependency>
 ```
 
 **Gradle:**
 
 ```groovy
-implementation 'app.softnetwork.elastic:softclient4es8-jdbc-driver:0.2.3'
+implementation 'app.softnetwork.elastic:softclient4es8-jdbc-driver:0.2.4'
 ```
 
 **sbt:**
 
 ```scala
-libraryDependencies += "app.softnetwork.elastic" % "softclient4es8-jdbc-driver" % "0.2.3"
+libraryDependencies += "app.softnetwork.elastic" % "softclient4es8-jdbc-driver" % "0.2.4"
 ```
 
 The JDBC driver JARs are Scala-version-independent (no `_2.12` or `_2.13` suffix) and include all required dependencies.
@@ -320,13 +320,13 @@ For programmatic access, add SoftClient4ES to your project.
 resolvers += "Softnetwork" at "https://softnetwork.jfrog.io/artifactory/releases/"
 
 // Choose your Elasticsearch version
-libraryDependencies += "app.softnetwork.elastic" %% "softclient4es8-java-client" % "0.20.2"
+libraryDependencies += "app.softnetwork.elastic" %% "softclient4es8-java-client" % "0.20.3"
 // Add the community extensions for materialized views (optional)
-libraryDependencies += "app.softnetwork.elastic" %% "softclient4es-community-extensions" % "0.2.2"
+libraryDependencies += "app.softnetwork.elastic" %% "softclient4es-community-extensions" % "0.2.3"
 // Add the arrow extensions for cross-index JOIN (required for JOINs; Java 11+)
-libraryDependencies += "app.softnetwork.elastic" %% "softclient4es-arrow-extensions" % "0.2.3"
+libraryDependencies += "app.softnetwork.elastic" %% "softclient4es-arrow-extensions" % "0.2.4"
 // Add the JDBC driver if you want to use it from Scala (optional)
-libraryDependencies += "app.softnetwork.elastic" %% "softclient4es-jdbc-driver" % "0.2.3"
+libraryDependencies += "app.softnetwork.elastic" %% "softclient4es-jdbc-driver" % "0.2.4"
 ```
 
 ```scala

--- a/documentation/client/adbc_driver.md
+++ b/documentation/client/adbc_driver.md
@@ -23,10 +23,10 @@ Download the self-contained fat JAR for your Elasticsearch version:
 
 | Elasticsearch  | Artifact                                            |
 |----------------|-----------------------------------------------------|
-| ES 6.x         | `softclient4es6-adbc-driver-0.2.3.jar` |
-| ES 7.x         | `softclient4es7-adbc-driver-0.2.3.jar` |
-| ES 8.x         | `softclient4es8-adbc-driver-0.2.3.jar` |
-| ES 9.x         | `softclient4es9-adbc-driver-0.2.3.jar` |
+| ES 6.x         | `softclient4es6-adbc-driver-0.2.4.jar` |
+| ES 7.x         | `softclient4es7-adbc-driver-0.2.4.jar` |
+| ES 8.x         | `softclient4es8-adbc-driver-0.2.4.jar` |
+| ES 9.x         | `softclient4es9-adbc-driver-0.2.4.jar` |
 
 ### Maven / Gradle / sbt
 
@@ -36,20 +36,20 @@ Download the self-contained fat JAR for your Elasticsearch version:
 <dependency>
   <groupId>app.softnetwork.elastic</groupId>
   <artifactId>softclient4es8-adbc-driver</artifactId>
-  <version>0.2.3</version>
+  <version>0.2.4</version>
 </dependency>
 ```
 
 **Gradle:**
 
 ```groovy
-implementation 'app.softnetwork.elastic:softclient4es8-adbc-driver:0.2.3'
+implementation 'app.softnetwork.elastic:softclient4es8-adbc-driver:0.2.4'
 ```
 
 **sbt:**
 
 ```scala
-libraryDependencies += "app.softnetwork.elastic" % "softclient4es8-adbc-driver" % "0.2.3"
+libraryDependencies += "app.softnetwork.elastic" % "softclient4es8-adbc-driver" % "0.2.4"
 ```
 
 ---

--- a/documentation/client/arrow_flight_sql.md
+++ b/documentation/client/arrow_flight_sql.md
@@ -49,15 +49,15 @@ Available images per ES version:
 ### Fat JAR
 
 ```bash
-java -jar softclient4es8-arrow-flight-sql-0.2.3.jar
+java -jar softclient4es8-arrow-flight-sql-0.2.4.jar
 ```
 
 | Elasticsearch | Artifact |
 |---------------|----------|
-| ES 6.x | `softclient4es6-arrow-flight-sql-0.2.3.jar` |
-| ES 7.x | `softclient4es7-arrow-flight-sql-0.2.3.jar` |
-| ES 8.x | `softclient4es8-arrow-flight-sql-0.2.3.jar` |
-| ES 9.x | `softclient4es9-arrow-flight-sql-0.2.3.jar` |
+| ES 6.x | `softclient4es6-arrow-flight-sql-0.2.4.jar` |
+| ES 7.x | `softclient4es7-arrow-flight-sql-0.2.4.jar` |
+| ES 8.x | `softclient4es8-arrow-flight-sql-0.2.4.jar` |
+| ES 9.x | `softclient4es9-arrow-flight-sql-0.2.4.jar` |
 
 ---
 

--- a/documentation/client/download_analytics.md
+++ b/documentation/client/download_analytics.md
@@ -15,7 +15,7 @@ beacon to a public endpoint with exactly these fields:
 |---------------|----------|-----------------------------------------------|
 | `source`      | `portal` | Where the count came from (the docs button)   |
 | `driver`      | `jdbc`   | Which driver family (`jdbc` or `adbc`)        |
-| `version`     | `0.2.3`  | The published artifact version                |
+| `version`     | `0.2.4`  | The published artifact version                |
 | `count_delta` | `1`      | One download                                  |
 
 A timestamp is added on the server. That is the **entire** record.

--- a/documentation/client/jdbc.md
+++ b/documentation/client/jdbc.md
@@ -20,10 +20,10 @@ Download the self-contained fat JAR for your Elasticsearch version. The JARs are
 
 | Elasticsearch | Artifact |
 |---------------|----------|
-| ES 6.x | `softclient4es6-jdbc-driver-0.2.3.jar` |
-| ES 7.x | `softclient4es7-jdbc-driver-0.2.3.jar` |
-| ES 8.x | `softclient4es8-jdbc-driver-0.2.3.jar` |
-| ES 9.x | `softclient4es9-jdbc-driver-0.2.3.jar` |
+| ES 6.x | `softclient4es6-jdbc-driver-0.2.4.jar` |
+| ES 7.x | `softclient4es7-jdbc-driver-0.2.4.jar` |
+| ES 8.x | `softclient4es8-jdbc-driver-0.2.4.jar` |
+| ES 9.x | `softclient4es9-jdbc-driver-0.2.4.jar` |
 
 ### Build Tool Integration
 
@@ -33,20 +33,20 @@ Download the self-contained fat JAR for your Elasticsearch version. The JARs are
 <dependency>
   <groupId>app.softnetwork.elastic</groupId>
   <artifactId>softclient4es8-jdbc-driver</artifactId>
-  <version>0.2.3</version>
+  <version>0.2.4</version>
 </dependency>
 ```
 
 **Gradle:**
 
 ```groovy
-implementation 'app.softnetwork.elastic:softclient4es8-jdbc-driver:0.2.3'
+implementation 'app.softnetwork.elastic:softclient4es8-jdbc-driver:0.2.4'
 ```
 
 **sbt:**
 
 ```scala
-libraryDependencies += "app.softnetwork.elastic" % "softclient4es8-jdbc-driver" % "0.2.3"
+libraryDependencies += "app.softnetwork.elastic" % "softclient4es8-jdbc-driver" % "0.2.4"
 ```
 
 ---

--- a/documentation/client/repl.md
+++ b/documentation/client/repl.md
@@ -118,6 +118,7 @@ Before installing, you can list all available versions for a specific Elasticsea
 
     • 0.20.1
     • 0.20.2
+    • 0.20.3
 
   Total: 2 version(s)
 
@@ -147,7 +148,7 @@ Before installing, you can list all available versions for a specific Elasticsea
 ./install.sh --list-versions --es-version 8
 
 # Install specific version
-./install.sh --es-version 8 --version 0.20.1
+./install.sh --es-version 8 --version 0.20.3
 
 # Install for Elasticsearch 9 (requires Java 17+)
 ./install.sh --es-version 9
@@ -156,7 +157,7 @@ Before installing, you can list all available versions for a specific Elasticsea
 ./install.sh --target /opt/softclient4es
 
 # Full custom installation
-./install.sh --target ~/tools/softclient4es --es-version 7 --version 0.20.1
+./install.sh --target ~/tools/softclient4es --es-version 7 --version 0.20.3
 ```
 
 #### Windows
@@ -169,7 +170,7 @@ Before installing, you can list all available versions for a specific Elasticsea
 .\install.ps1 -ListVersions -EsVersion 8
 
 # Install specific version
-.\install.ps1 -EsVersion 8 -Version 0.20.1
+.\install.ps1 -EsVersion 8 -Version 0.20.3
 
 # Install for Elasticsearch 9 (requires Java 17+)
 .\install.ps1 -EsVersion 9
@@ -178,7 +179,7 @@ Before installing, you can list all available versions for a specific Elasticsea
 .\install.ps1 -Target "C:\tools\softclient4es"
 
 # Full custom installation
-.\install.ps1 -Target "C:\tools\softclient4es" -EsVersion 7 -Version 0.20.1
+.\install.ps1 -Target "C:\tools\softclient4es" -EsVersion 7 -Version 0.20.3
 ```
 
 ---

--- a/documentation/sql/dml_statements.md
+++ b/documentation/sql/dml_statements.md
@@ -410,7 +410,7 @@ every supported JVM too** — including JDK 23, 24 and 25.
 
 ##### If you are on an older release
 
-Releases up to and including **0.20.3** fail on **JDK 23 and newer** for `PARQUET`, `DELTA_LAKE` and
+Releases up to and including **0.20.2** fail on **JDK 23 and newer** for `PARQUET`, `DELTA_LAKE` and
 remote schemes, with:
 
 | JDK | Error text | `-Djava.security.manager=allow` |

--- a/documentation/sql/materialized_views.md
+++ b/documentation/sql/materialized_views.md
@@ -536,13 +536,25 @@ To automate this re-execution, the engine creates an **Elasticsearch Watcher** t
 The warning looks like this:
 
 ```
-✅ Success (14203ms)
+✅ Success (9549ms)
 ⚠️ Materialized view 'orders_with_customers_mv' was created, but automatic refresh is
-   unavailable: this Elasticsearch cluster's licence does not include Watcher, so the joined
-   data cannot be refreshed on a schedule. Run 'REFRESH MATERIALIZED VIEW
-   orders_with_customers_mv' whenever the joined tables change, or schedule that statement
-   externally (cron, Kubernetes CronJob, Airflow). Elasticsearch reported: …
+   unavailable: this deployment cannot host the refresh watcher, so the joined data cannot
+   be refreshed on a schedule. Run 'REFRESH MATERIALIZED VIEW orders_with_customers_mv'
+   whenever the joined tables change, or schedule that statement externally (cron,
+   Kubernetes CronJob, Airflow). Reason: Elasticsearch error during createWatcher:
+   security_exception - current license is non-compliant for [watcher]
 ```
+
+The wording names **no cause** — the licence is only one of two ways to end up here, and the
+actual one is quoted verbatim after `Reason:`. The other is a cluster with no usable webhook
+credentials for the watcher to call back with, which is what `xpack.security.enabled: false`
+gives you — the default local, CI and testkit setup. Both are the same outcome: the view exists
+and is queryable, only the scheduled refresh is missing, and `REFRESH MATERIALIZED VIEW` is the
+manual equivalent.
+
+A **wrong** credential is not this case. Supplying a username with no password, or a bad API key,
+keeps failing the statement loudly — that is a fixable misconfiguration, not a missing capability,
+and hiding it behind a warning would hide the typo.
 
 A view created this way keeps `auto_refresh: unavailable` even if the cluster is later upgraded to a license that includes Watcher — re-run `CREATE OR REPLACE MATERIALIZED VIEW` with a changed definition to redeploy it with a watcher.
 

--- a/install.ps1
+++ b/install.ps1
@@ -63,7 +63,7 @@ Examples:
   .\install.ps1
   .\install.ps1 -ListVersions -EsVersion 8
   .\install.ps1 -Target "C:\tools\softclient4es" -EsVersion 8 -Version 1.0.0
-  .\install.ps1 -EsVersion 7 -Version 0.20.2 -NoExtensions
+  .\install.ps1 -EsVersion 7 -Version 0.20.3 -NoExtensions
 
 "@
     exit 0
@@ -253,7 +253,7 @@ function Resolve-LatestVersion {
 
     # Prefer non-snapshot versions.
     # @(...) matters: with a single match the pipeline yields a bare string, and
-    # [-1] on a string returns its last CHARACTER ("0.20.2" -> "2").
+    # [-1] on a string returns its last CHARACTER ("0.20.3" -> "3").
     $releaseVersions = @($versions | Where-Object { $_ -notmatch 'SNAPSHOT' })
 
     if ($releaseVersions.Count -gt 0) {
@@ -281,7 +281,7 @@ if ($WITH_EXTENSIONS) {
         Where-Object { $_ -notmatch 'SNAPSHOT' })
     if ($bundleVersions.Count -gt 0) {
         if ($Version -eq "latest") {
-            $Version = $bundleVersions[-1]      # bundle-version line (0.20.2, 0.20.3, ...)
+            $Version = $bundleVersions[-1]      # bundle-version line (0.20.2, 0.20.3, 0.20.4, ...)
             $USE_BUNDLE = $true
             Write-Success "Resolved latest -all bundle version: $Version"
         }

--- a/install.sh
+++ b/install.sh
@@ -174,7 +174,7 @@ Examples:
   $0
   $0 --list-versions --es-version 8
   $0 --target /opt/softclient4es --es-version 8 --no-extensions
-  $0 -t ~/tools/softclient4es -e 7 -v 0.20.2 --no-extensions
+  $0 -t ~/tools/softclient4es -e 7 -v 0.20.3 --no-extensions
 
 Detected OS: $OS_TYPE
 
@@ -424,7 +424,7 @@ if [[ "$WITH_EXTENSIONS" == true ]]; then
     bundle_versions=$(fetch_versions "$BUNDLE_ARTIFACT_NAME" 2>/dev/null | grep -v 'SNAPSHOT' || true)
     if [[ -n "$bundle_versions" ]]; then
         if [[ "$SOFT_VERSION" == "latest" ]]; then
-            SOFT_VERSION=$(echo "$bundle_versions" | tail -1)   # bundle-version line (0.20.1, 0.20.2, ...)
+            SOFT_VERSION=$(echo "$bundle_versions" | tail -1)   # bundle-version line (0.20.1, 0.20.2, 0.20.3, ...)
             USE_BUNDLE=true
             success "Resolved latest -all bundle version: $SOFT_VERSION"
         elif echo "$bundle_versions" | grep -qx "$SOFT_VERSION"; then


### PR DESCRIPTION
Post-release documentation sweep for the 0.20.3 train.

## Version bookkeeping

Every version below was **checked against JFrog before being written**, not inferred from the train:

| what | from | to |
|---|---|---|
| `jdbc-driver` / `adbc-driver` / `arrow-flight-sql` | `0.2.3` | `0.2.4` |
| `community-extensions` | `0.2.2` | `0.2.3` |
| `arrow-extensions` | `0.2.3` | `0.2.4` |
| `java-client` (engine) | `0.20.2` | `0.20.3` |
| installer examples + bundle-version list | `0.20.1` / `0.20.2` | `0.20.3` |

The 0.20.2 sweep had to fix a doc that installed a version which never shipped, and the failure mode is quiet: a version with **no `-all` bundle** silently falls back to the plain artifact, which has no arrow extensions and therefore no cross-index JOIN. The docs would be demonstrating the path that loses the headline feature. So `softclient4es{6,8,9}-cli-all_2.13:0.20.3`, `*-adbc-driver:0.2.4`, `*-arrow-flight-sql:0.2.4`, `*-jdbc-driver:0.2.4` and `softclient4es8-java-client_2.13:0.20.3` were each confirmed `200` first.

## Two corrections that are not bookkeeping

**1. `dml_statements.md` told 0.20.3 users their own release was broken.**

It said *"releases up to and including **0.20.3** fail on JDK 23 and newer"* for `PARQUET`, `DELTA_LAKE` and remote schemes — sitting directly beneath a table stating those work on every JDK. The boundary is **0.20.2**, confirmed from the published POMs rather than the commit title:

```
core_2.13-0.20.3.pom   hadoop-client 3.4.3   ← HADOOP-19212, the fix
core_2.13-0.20.2.pom   hadoop-client 3.4.2
```

**2. `materialized_views.md` quoted a watcher warning that is not the one that ships.**

The doc's version named the licence as the cause. The shipped wording deliberately names **no cause**, because the licence is only one of two ways to reach it — the other is a cluster with no usable webhook credentials, which is exactly what `xpack.security.enabled: false` gives you (the default local, CI and testkit setup). The real cause is quoted verbatim after `Reason:`.

Replaced with the exact output captured from the `-all` bundle against a basic cluster, and documented the second cause — plus the boundary that keeps the degradation honest: a **wrong** credential still fails loudly, because that is a fixable typo, not a missing capability.

## Left alone

Historical statements: `since v0.14.0` feature markers and CONTRIBUTING's release-process example describe the past, not what to install.

`ThisBuild / version` stays at `0.20.3`. This repo bumps to the next `-SNAPSHOT` with the first post-release change rather than in a dedicated commit — say the word if you would rather open `0.20.4-SNAPSHOT` here.
