### PR TITLE
fix(scroll): sort PIT paging by _doc, not _shard_doc, and gate PIT at 7.12 (#197)

### DIFF
--- a/core/src/main/scala/app/softnetwork/elastic/client/ElasticsearchVersion.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/ElasticsearchVersion.scala
@@ -80,10 +80,16 @@ object ElasticsearchVersion {
     }
   }
 
-  /** Check if PIT is supported (ES >= 7.10)
+  /** Check if PIT is usable for paging (ES >= 7.12).
+    *
+    * The PIT API itself exists from 7.10, but our PIT paging relies on the `_shard_doc` sort field
+    * and on ES appending `_shard_doc` as an automatic tiebreaker under a PIT — both exist only from
+    * 7.12. On 7.10/7.11 a `_doc`-sorted PIT search returns HTTP 200 with NO tiebreaker and silently
+    * drops rows across shards (#197), so those versions must fall back to the classic `_id`-sorted
+    * search_after path.
     */
   def supportsPit(version: String): Boolean = {
-    isAtLeast(version, 7, 10)
+    isAtLeast(version, 7, 12)
   }
 
   /** Check if version is ES 8+

--- a/core/src/main/scala/app/softnetwork/elastic/client/ScrollApi.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/ScrollApi.scala
@@ -82,20 +82,23 @@ import scala.util.{Failure, Success}
   * ┌─────────────────┬───────────────┬──────────────────────────────────┐
   * │ ES Version      │ Aggregations  │ Strategy                         │
   * ├─────────────────┼───────────────┼──────────────────────────────────┤
-  * │ 7.10+           │ No            │ PIT + search_after (recommended) │
-  * │ 7.10+           │ Yes           │ Classic scroll                   │
-  * │ < 7.10          │ No            │ search_after                     │
-  * │ < 7.10          │ Yes           │ Classic scroll                   │
+  * │ 7.12+           │ No            │ PIT + search_after (recommended) │
+  * │ 7.12+           │ Yes           │ Classic scroll                   │
+  * │ < 7.12          │ No            │ search_after                     │
+  * │ < 7.12          │ Yes           │ Classic scroll                   │
   * └─────────────────┴───────────────┴──────────────────────────────────┘
   * }}}
   *
-  * '''Point In Time (PIT) + search_after''' (ES 7.10+, no aggregations):
+  * '''Point In Time (PIT) + search_after''' (ES 7.12+, no aggregations):
   *   - Provides a consistent snapshot of data across pagination
   *   - No scroll context timeout issues
   *   - Better resource usage and performance
   *   - Automatic cleanup on completion
+  *   - Gated at 7.12 (not 7.10, where the PIT API first appeared): the `_shard_doc` tiebreaker ES
+  *     appends under a PIT only exists from 7.12, and without it a paged extraction silently drops
+  *     rows across shards (#197)
   *
-  * '''search_after''' (ES < 7.10, no aggregations):
+  * '''search_after''' (ES < 7.12, no aggregations):
   *   - Efficient pagination without server-side state
   *   - Suitable for deep pagination
   *   - Requires explicit sort fields

--- a/core/src/test/scala/app/softnetwork/elastic/client/ElasticsearchVersionSpec.scala
+++ b/core/src/test/scala/app/softnetwork/elastic/client/ElasticsearchVersionSpec.scala
@@ -44,15 +44,21 @@ class ElasticsearchVersionSpec extends AnyWordSpec with Matchers {
   }
 
   "ElasticsearchVersion.supportsPit" should {
-    "return true for ES >= 7.10" in {
-      ElasticsearchVersion.supportsPit("7.10.0") shouldBe true
-      ElasticsearchVersion.supportsPit("7.10.2") shouldBe true
+    "return true for ES >= 7.12" in {
+      ElasticsearchVersion.supportsPit("7.12.0") shouldBe true
       ElasticsearchVersion.supportsPit("7.17.0") shouldBe true
       ElasticsearchVersion.supportsPit("8.0.0") shouldBe true
       ElasticsearchVersion.supportsPit("8.11.0") shouldBe true
+      ElasticsearchVersion.supportsPit("9.0.0") shouldBe true
     }
 
-    "return false for ES < 7.10" in {
+    // 7.10/7.11 have the PIT API but no _shard_doc sort field and no automatic PIT tiebreaker:
+    // a _doc-sorted PIT search on those versions silently drops rows across shards (#197), so
+    // they must take the classic _id-sorted search_after path instead.
+    "return false for ES < 7.12" in {
+      ElasticsearchVersion.supportsPit("7.11.2") shouldBe false
+      ElasticsearchVersion.supportsPit("7.10.0") shouldBe false
+      ElasticsearchVersion.supportsPit("7.10.2") shouldBe false
       ElasticsearchVersion.supportsPit("7.9.3") shouldBe false
       ElasticsearchVersion.supportsPit("7.0.0") shouldBe false
       ElasticsearchVersion.supportsPit("6.8.23") shouldBe false

--- a/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestClientScrollCompletenessSpec.scala
+++ b/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestClientScrollCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JestClientScrollCompletenessSpec extends ScrollCompletenessSpec

--- a/es6/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientScrollCompletenessSpec.scala
+++ b/es6/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientScrollCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class RestHighLevelClientScrollCompletenessSpec extends ScrollCompletenessSpec

--- a/es7/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientApi.scala
+++ b/es7/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientApi.scala
@@ -1737,10 +1737,14 @@ trait RestHighLevelClientScrollApi extends ScrollApi with RestHighLevelClientHel
 
                   // Check if sorts already exist in the query
                   if (!hasSorts && sourceBuilder.sorts() == null) {
-                    logger.warn(
-                      "No sort fields in query for PIT search_after, adding default _shard_doc sort."
+                    // _doc, NOT _shard_doc: a primary _shard_doc sort defeats the doc-id skip
+                    // optimisation on ES 8 / Lucene 9 (#197); harmless but not needed on 7.x
+                    // either. Under a PIT (>= 7.12) ES appends _shard_doc as an automatic
+                    // tiebreaker, so _doc is a total order and row-complete across shards.
+                    logger.debug(
+                      "No sort fields in query for PIT search_after, adding default _doc sort."
                     )
-                    sourceBuilder.sort("_shard_doc", SortOrder.ASC)
+                    sourceBuilder.sort("_doc", SortOrder.ASC)
                   } else if (hasSorts && sourceBuilder.sorts() != null) {
                     // Sorts already present, check that a tie-breaker exists
                     val hasShardDocSort = sourceBuilder.sorts().asScala.exists {

--- a/es7/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientScrollCompletenessSpec.scala
+++ b/es7/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientScrollCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class RestHighLevelClientScrollCompletenessSpec extends ScrollCompletenessSpec

--- a/es8/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
+++ b/es8/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
@@ -1535,15 +1535,18 @@ trait JavaClientScrollApi extends ScrollApi with JavaClientHelpers {
 
                   // Check if sorts already exist in the query
                   if (!hasSorts && !queryJson.has("sort")) {
-                    logger.warn(
-                      "No sort fields in query for PIT search_after, adding default _shard_doc sort. " +
-                      "_shard_doc is more efficient than _id for PIT."
+                    // _doc, NOT _shard_doc: from ES 8 / Lucene 9 a primary _shard_doc sort
+                    // defeats the doc-id skip optimisation and every page re-scans the whole
+                    // index (#197). Under a PIT (>= 7.12) ES appends _shard_doc as an automatic
+                    // tiebreaker, so _doc is a total order and row-complete across shards.
+                    logger.debug(
+                      "No sort fields in query for PIT search_after, adding default _doc sort."
                     )
                     requestBuilder.sort(
                       SortOptions.of { sortBuilder =>
                         sortBuilder.field(
                           FieldSort.of(fieldSortBuilder =>
-                            fieldSortBuilder.field("_shard_doc").order(SortOrder.Asc)
+                            fieldSortBuilder.field("_doc").order(SortOrder.Asc)
                           )
                         )
                       }

--- a/es8/java/src/test/scala/app/softnetwork/elastic/client/JavaClientScrollCompletenessSpec.scala
+++ b/es8/java/src/test/scala/app/softnetwork/elastic/client/JavaClientScrollCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JavaClientScrollCompletenessSpec extends ScrollCompletenessSpec

--- a/es9/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
+++ b/es9/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
@@ -1531,15 +1531,18 @@ trait JavaClientScrollApi extends ScrollApi with JavaClientHelpers {
 
                   // Check if sorts already exist in the query
                   if (!hasSorts && !queryJson.has("sort")) {
-                    logger.warn(
-                      "No sort fields in query for PIT search_after, adding default _shard_doc sort. " +
-                      "_shard_doc is more efficient than _id for PIT."
+                    // _doc, NOT _shard_doc: from ES 8 / Lucene 9 a primary _shard_doc sort
+                    // defeats the doc-id skip optimisation and every page re-scans the whole
+                    // index (#197). Under a PIT (>= 7.12) ES appends _shard_doc as an automatic
+                    // tiebreaker, so _doc is a total order and row-complete across shards.
+                    logger.debug(
+                      "No sort fields in query for PIT search_after, adding default _doc sort."
                     )
                     requestBuilder.sort(
                       SortOptions.of { sortBuilder =>
                         sortBuilder.field(
                           FieldSort.of(fieldSortBuilder =>
-                            fieldSortBuilder.field("_shard_doc").order(SortOrder.Asc)
+                            fieldSortBuilder.field("_doc").order(SortOrder.Asc)
                           )
                         )
                       }

--- a/es9/java/src/test/scala/app/softnetwork/elastic/client/JavaClientScrollCompletenessSpec.scala
+++ b/es9/java/src/test/scala/app/softnetwork/elastic/client/JavaClientScrollCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JavaClientScrollCompletenessSpec extends ScrollCompletenessSpec

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/ScrollCompletenessSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/ScrollCompletenessSpec.scala
@@ -38,10 +38,10 @@ import scala.language.implicitConversions
   * exactly once on a MULTI-SHARD index.
   *
   * The failure mode this guards against is SILENT: a `_doc` sort without a cross-shard tiebreaker
-  * (i.e. without a PIT on ES >= 7.12) returns HTTP 200 on every page and simply loses the rows
-  * that tie at page boundaries — `_doc` values collide across shards by construction. A
-  * single-shard fixture can never catch it, and the default test index template pins
-  * `number_of_shards` to 1, so this spec creates its index with explicit multi-shard settings.
+  * (i.e. without a PIT on ES >= 7.12) returns HTTP 200 on every page and simply loses the rows that
+  * tie at page boundaries — `_doc` values collide across shards by construction. A single-shard
+  * fixture can never catch it, and the default test index template pins `number_of_shards` to 1, so
+  * this spec creates its index with explicit multi-shard settings.
   */
 trait ScrollCompletenessSpec extends AnyFlatSpecLike with ElasticDockerTestKit with Matchers {
 
@@ -55,8 +55,8 @@ trait ScrollCompletenessSpec extends AnyFlatSpecLike with ElasticDockerTestKit w
 
   private val index = "scroll_completeness"
 
-  /** 3 shards x 1000 docs with pages of 100: every page boundary lands on `_doc` values that
-    * exist in all three shards, so a missing tiebreaker loses rows immediately.
+  /** 3 shards x 1000 docs with pages of 100: every page boundary lands on `_doc` values that exist
+    * in all three shards, so a missing tiebreaker loses rows immediately.
     */
   private val totalDocs = 3000
 

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/ScrollCompletenessSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/ScrollCompletenessSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{Sink, Source}
+import app.softnetwork.elastic.client.bulk._
+import app.softnetwork.elastic.client.result.{ElasticFailure, ElasticSuccess}
+import app.softnetwork.elastic.client.scroll.ScrollConfig
+import app.softnetwork.elastic.client.spi.ElasticClientFactory
+import app.softnetwork.elastic.scalatest.ElasticDockerTestKit
+import app.softnetwork.elastic.sql.query.SelectStatement
+import app.softnetwork.persistence.generateUUID
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.implicitConversions
+
+/** Regression test for issue #197: a paged extraction with no `ORDER BY` must return every row
+  * exactly once on a MULTI-SHARD index.
+  *
+  * The failure mode this guards against is SILENT: a `_doc` sort without a cross-shard tiebreaker
+  * (i.e. without a PIT on ES >= 7.12) returns HTTP 200 on every page and simply loses the rows
+  * that tie at page boundaries — `_doc` values collide across shards by construction. A
+  * single-shard fixture can never catch it, and the default test index template pins
+  * `number_of_shards` to 1, so this spec creates its index with explicit multi-shard settings.
+  */
+trait ScrollCompletenessSpec extends AnyFlatSpecLike with ElasticDockerTestKit with Matchers {
+
+  lazy val log: Logger = LoggerFactory.getLogger(getClass.getName)
+
+  implicit val system: ActorSystem = ActorSystem(generateUUID())
+
+  implicit val context: ConversionContext = NativeContext
+
+  lazy val client: ElasticClientApi = ElasticClientFactory.create(elasticConfig)
+
+  private val index = "scroll_completeness"
+
+  /** 3 shards x 1000 docs with pages of 100: every page boundary lands on `_doc` values that
+    * exist in all three shards, so a missing tiebreaker loses rows immediately.
+    */
+  private val totalDocs = 3000
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val settings = """{"number_of_shards": 3, "number_of_replicas": 0}"""
+    val mapping =
+      """{
+        |  "properties": {
+        |    "id":    { "type": "keyword" },
+        |    "value": { "type": "integer" }
+        |  }
+        |}""".stripMargin
+
+    client.createIndex(index, settings = settings).get shouldBe true
+    client.setMapping(index, mapping).get shouldBe true
+
+    val docs = (1 to totalDocs).map(i => s"""{"id":"$i","value":$i}""").toList
+
+    implicit val bulkOptions: BulkOptions = BulkOptions(
+      defaultIndex = index,
+      logEvery = 1000
+    )
+
+    implicit def listToSource[T](list: List[T]): Source[T, NotUsed] =
+      Source.fromIterator(() => list.iterator)
+
+    client.bulk[String](docs, identity, idKey = Some(Set("id"))) match {
+      case ElasticSuccess(_) => // ok
+      case ElasticFailure(error) =>
+        error.cause.foreach(_.printStackTrace())
+        fail(s"Bulk indexing failed: ${error.message}")
+    }
+
+    client.refresh(index)
+  }
+
+  override def afterAll(): Unit = {
+    client.deleteIndex(index)
+    super.afterAll()
+  }
+
+  "scrolling without ORDER BY over a multi-shard index" should "return every row exactly once" in {
+    val source = client.scroll(
+      SelectStatement(s"SELECT id, value FROM $index"),
+      ScrollConfig(scrollSize = 100)
+    )
+
+    val rows = Await.result(source.runWith(Sink.seq), 5.minutes)
+
+    rows should have size totalDocs.toLong
+
+    val ids = rows.map(_._1("id").toString)
+    ids.toSet should have size totalDocs.toLong
+
+    log.info(s"✓ ${rows.size} rows, ${ids.toSet.size} distinct ids from $index (3 shards)")
+  }
+
+  it should "return every row exactly once with a small final page" in {
+    // 3000 % 7 != 0 — exercises the partial-last-page path as well
+    val source = client.scroll(
+      SelectStatement(s"SELECT id FROM $index"),
+      ScrollConfig(scrollSize = 7)
+    )
+
+    val rows = Await.result(source.runWith(Sink.seq), 5.minutes)
+
+    rows should have size totalDocs.toLong
+    rows.map(_._1("id").toString).toSet should have size totalDocs.toLong
+  }
+}


### PR DESCRIPTION
## What

Implements the fix exactly as specified in the rewritten #197 (post-architect-review version).

**The bug.** For a query with no `ORDER BY`, the PIT + `search_after` path injects `_shard_doc` as the **primary** sort. From ES 8 / Lucene 9 that defeats the doc-id skip optimisation, so every page re-scans the whole index — measured 60.5 ms/page vs 8.1 with `_doc` on a 10M index (server-side, flat in page depth, linear in index size). ES 7.17 pays no penalty; 8.18 pays 3.0–4.5×, 9.0 pays 2.5–3.0×.

**The fix (4 files + docs, no API change):**

1. `_doc` instead of `_shard_doc` in the no-`ORDER BY` branch of the PIT path — `es8`/`es9` `JavaClientApi`, `es7` `RestHighLevelClientApi`. **We stay on PIT**: under a PIT, ES appends `_shard_doc` as an automatic tiebreaker, which is exactly what makes `_doc` a safe total order across shards. The `ORDER BY` tiebreaker branch (secondary `_shard_doc`, ~9% cost) is deliberately untouched.
2. **`supportsPit` gate 7.10 → 7.12** — this is part of the fix, not polish. The `_shard_doc` field and the automatic PIT tiebreaker only exist from 7.12; on a real 7.11 cluster a `_doc`-sorted PIT search returns HTTP 200 with **no** tiebreaker and silently drops rows (59,882 of 60,000 measured in the issue). 7.10/7.11 now take the classic `_id`-sorted `search_after` path — slower, but row-complete.
3. Per-page "adding default sort" WARN → debug (it fires inside the `unfoldAsync` step: ~10k log lines per 10M-row extraction).
4. `ScrollApi` scaladoc strategy table updated 7.10 → 7.12, with the reason recorded.

`preferSearchAfter` is untouched (it is a no-op ≥ 7.10 and never set in any repo); extensions/arrow/jdbc/federation inherit the fix by rebuilding.

## The regression test the issue demands

The failure mode this guards against is **silent**: a paged extraction without a cross-shard tiebreaker returns HTTP 200 on every page and simply loses rows that tie at page boundaries. No single-shard fixture can catch it — the default test template pins `number_of_shards: 1`.

New `ScrollCompletenessSpec` (testkit template + concrete specs in every client module): 3-shard index, 3000 docs, no `ORDER BY`, paged at 100 and at 7 (partial final page); asserts **exact row count and distinct-id uniqueness**.

Verified green against real Docker ES on every supported version:

| Version | Client(s) | Strategy taken | Result |
|---|---|---|---|
| 6.8.23 | rest, jest | classic `search_after` (`_id`) | 2/2 each — 3000/3000 distinct |
| 7.17.29 | rest | PIT + `_doc` | 2/2 |
| 8.18.3 | java | PIT + `_doc` | 2/2 |
| 9.0.3 | java | PIT + `_doc` | 2/2 |

Also: `ElasticsearchVersionSpec` updated for the 7.12 gate (7.10/7.11 now false, with the why recorded); core tests, cross-compile 2.12/2.13, scalafmt, headerCheck all green.

## Deliberately deferred

`trackTotalHits(false)` (optional item 5 — 2% wall, ~30% ES-side CPU) is left out to keep this change minimal; it can ship as its own free item.

## Expected effect

At 10M rows the paging leg goes ~605 s → ~81 s; at 1M, 12.81 s → ~6.15 s. Combined with the already-merged #198 and arrow#140 (arrow#139), the 1M Flight extraction projects to ~8 s from the 70.75 s shipped baseline. As the issue notes, this is a correctness-and-scale fix in its own right — the Epic 18 headline number is re-measured only on a released image.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)
