### PR TITLE
fix(scroll): the three #197 follow-ups — no hit totals on paging, preferSearchAfter honored, single PIT close (#200 #201 #202)

### DIFF
--- a/core/src/main/scala/app/softnetwork/elastic/client/ScrollApi.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/ScrollApi.scala
@@ -89,6 +89,10 @@ import scala.util.{Failure, Success}
   * └─────────────────┴───────────────┴──────────────────────────────────┘
   * }}}
   *
+  * [[ScrollConfig.preferSearchAfter]] ` = false` overrides the no-aggregation rows and forces
+  * classic scroll on every version — an operational opt-out for clusters that restrict the PIT API.
+  * Slower than the PIT path (9.55 s vs 6.15 s per 1M rows) but equally row-complete.
+  *
   * '''Point In Time (PIT) + search_after''' (ES 7.12+, no aggregations):
   *   - Provides a consistent snapshot of data across pagination
   *   - No scroll context timeout issues
@@ -286,7 +290,8 @@ trait ScrollApi extends ElasticClientHelpers {
     */
   private def determineScrollStrategy(
     elasticQuery: ElasticQuery,
-    aggregations: ListMap[String, SQLAggregation]
+    aggregations: ListMap[String, SQLAggregation],
+    config: ScrollConfig
   ): ScrollStrategy = {
     // If aggregations are present, use classic scrolling
     if (aggregations.nonEmpty) {
@@ -294,6 +299,11 @@ trait ScrollApi extends ElasticClientHelpers {
     } else {
       // Check if the query contains aggregations in the JSON
       if (hasAggregations(elasticQuery.query)) {
+        UseScroll
+      } else if (!config.preferSearchAfter) {
+        // Operational opt-out (#201): classic scroll is slower than fixed PIT (9.55 s vs
+        // 6.15 s per 1M rows) but works on clusters that restrict the PIT API.
+        logger.info("preferSearchAfter is disabled, using classic scroll")
         UseScroll
       } else {
         // Detect version and choose implementation
@@ -398,7 +408,7 @@ trait ScrollApi extends ElasticClientHelpers {
     system: ActorSystem,
     context: ConversionContext
   ): Source[ListMap[String, Any], NotUsed] = {
-    val strategy = determineScrollStrategy(elasticQuery, aggregations)
+    val strategy = determineScrollStrategy(elasticQuery, aggregations, config)
 
     logger.info(
       s"Using scroll strategy: $strategy for query \n$elasticQuery"
@@ -409,7 +419,7 @@ trait ScrollApi extends ElasticClientHelpers {
         logger.info("Using classic scroll (supports aggregations)")
         scrollClassic(elasticQuery, fieldAliases, aggregations, config)
 
-      case UseSearchAfter if config.preferSearchAfter =>
+      case UseSearchAfter =>
         logger.info("Using search_after (optimized for hits only)")
         searchAfter(elasticQuery, fieldAliases, config, hasSorts)
 

--- a/core/src/main/scala/app/softnetwork/elastic/client/scroll/package.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/scroll/package.scala
@@ -25,7 +25,8 @@ package object scroll {
     scrollSize: Int = 1000, // Number of documents per batch
     logEvery: Int = 10, // Log progress every n batches
     maxDocuments: Option[Long] = None, // Optional maximum number of documents to retrieve
-    preferSearchAfter: Boolean = true, // Prefer search_after over scroll when possible
+    preferSearchAfter: Boolean =
+      true, // false = force classic scroll even where PIT/search_after is available (slower; for clusters restricting the PIT API)
     metrics: ScrollMetrics = ScrollMetrics(), // Initial scroll metrics
     retryConfig: RetryConfig = RetryConfig(), // Retry configuration
     failOnWindowError: Option[Boolean] = None

--- a/es7/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientApi.scala
+++ b/es7/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientApi.scala
@@ -1606,7 +1606,12 @@ trait RestHighLevelClientScrollApi extends ScrollApi with RestHighLevelClientHel
                 query
               )
             val sourceBuilder =
-              SearchSourceBuilder.fromXContent(xContentParser).size(config.scrollSize)
+              SearchSourceBuilder
+                .fromXContent(xContentParser)
+                .size(config.scrollSize)
+                // The paging path never reads hits.total — computing it costs ~30% of the
+                // ES-side CPU per page (#200)
+                .trackTotalHits(false)
 
             // Check if sorts already exist in the query
             if (!hasSorts && sourceBuilder.sorts() == null) {
@@ -1734,6 +1739,9 @@ trait RestHighLevelClientScrollApi extends ScrollApi with RestHighLevelClientHel
                   val sourceBuilder = SearchSourceBuilder
                     .fromXContent(xContentParser)
                     .size(config.scrollSize)
+                    // The paging path never reads hits.total — computing it costs ~30% of the
+                    // ES-side CPU per page (#200)
+                    .trackTotalHits(false)
 
                   // Check if sorts already exist in the query
                   if (!hasSorts && sourceBuilder.sorts() == null) {

--- a/es7/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientApi.scala
+++ b/es7/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientApi.scala
@@ -1797,8 +1797,7 @@ trait RestHighLevelClientScrollApi extends ScrollApi with RestHighLevelClientHel
                   val hits = extractHitsOnly(response.toString, fieldAliases)
 
                   if (hits.isEmpty) {
-                    closePit(pitId)
-                    None
+                    None // end of stream — watchTermination owns the single PIT close (#202)
                   } else {
                     val searchHits = response.getHits.getHits
                     val lastHit = searchHits.last
@@ -1810,11 +1809,13 @@ trait RestHighLevelClientScrollApi extends ScrollApi with RestHighLevelClientHel
                 }
               }(system, logger).recover { case ex: Exception =>
                 logger.error(s"PIT search_after failed after retries: ${ex.getMessage}", ex)
-                closePit(pitId)
-                None
+                None // ends the stream — watchTermination owns the single PIT close (#202)
               }
             }
             .watchTermination() { (_, done) =>
+              // Single owner of the PIT close (#202): completion, failure and downstream
+              // cancellation all land here. The former in-loop closes made every clean run
+              // close twice and log a spurious "PIT close reported failure" WARN.
               done.onComplete {
                 case scala.util.Success(_) =>
                   logger.info(s"PIT search_after completed, closing PIT: ${pitId.take(20)}...")

--- a/es8/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
+++ b/es8/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
@@ -81,7 +81,7 @@ import co.elastic.clients.elasticsearch.core.msearch.{
 }
 import co.elastic.clients.elasticsearch.core._
 import co.elastic.clients.elasticsearch.core.reindex.{Destination, Source => ESSource}
-import co.elastic.clients.elasticsearch.core.search.PointInTimeReference
+import co.elastic.clients.elasticsearch.core.search.{PointInTimeReference, TrackHits}
 import co.elastic.clients.elasticsearch.enrich.{
   DeletePolicyRequest,
   ExecutePolicyRequest,
@@ -1532,6 +1532,10 @@ trait JavaClientScrollApi extends ScrollApi with JavaClientHelpers {
                   if (queryJson.has("query")) {
                     requestBuilder.withJson(new StringReader(elasticQuery.query))
                   }
+
+                  // The paging path never reads hits.total — computing it costs ~30% of the
+                  // ES-side CPU per page (#200). Set after withJson so the query cannot re-enable it.
+                  requestBuilder.trackTotalHits(TrackHits.of(t => t.enabled(false)))
 
                   // Check if sorts already exist in the query
                   if (!hasSorts && !queryJson.has("sort")) {

--- a/es8/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
+++ b/es8/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
@@ -1615,9 +1615,7 @@ trait JavaClientScrollApi extends ScrollApi with JavaClientHelpers {
                   val hits = extractHitsOnly(response, fieldAliases)
 
                   if (hits.isEmpty) {
-                    // Close PIT when done
-                    closePit(pitId)
-                    None
+                    None // end of stream — watchTermination owns the single PIT close (#202)
                   } else {
                     val lastHit = response.hits().hits().asScala.lastOption
                     val nextSearchAfter = lastHit.flatMap { hit =>
@@ -1642,12 +1640,13 @@ trait JavaClientScrollApi extends ScrollApi with JavaClientHelpers {
                 }
               }(system, logger).recover { case ex: Exception =>
                 logger.error(s"PIT search_after failed after retries: ${ex.getMessage}", ex)
-                closePit(pitId)
-                None
+                None // ends the stream — watchTermination owns the single PIT close (#202)
               }
             }
             .watchTermination() { (_, done) =>
-              // Cleanup PIT on stream completion/failure
+              // Single owner of the PIT close (#202): completion, failure and downstream
+              // cancellation all land here. The former in-loop closes made every clean run
+              // close twice and log a spurious "PIT close reported failure" WARN.
               done.onComplete {
                 case scala.util.Success(_) =>
                   logger.info(

--- a/es9/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
+++ b/es9/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
@@ -76,7 +76,11 @@ import co.elastic.clients.elasticsearch.core.bulk.{
 import co.elastic.clients.elasticsearch.core.msearch.{MultisearchHeader, RequestItem}
 import co.elastic.clients.elasticsearch.core._
 import co.elastic.clients.elasticsearch.core.reindex.{Destination, Source => ESSource}
-import co.elastic.clients.elasticsearch.core.search.{PointInTimeReference, SearchRequestBody}
+import co.elastic.clients.elasticsearch.core.search.{
+  PointInTimeReference,
+  SearchRequestBody,
+  TrackHits
+}
 import co.elastic.clients.elasticsearch.enrich.{
   DeletePolicyRequest,
   ExecutePolicyRequest,
@@ -1528,6 +1532,10 @@ trait JavaClientScrollApi extends ScrollApi with JavaClientHelpers {
                   if (queryJson.has("query")) {
                     requestBuilder.withJson(new StringReader(elasticQuery.query))
                   }
+
+                  // The paging path never reads hits.total — computing it costs ~30% of the
+                  // ES-side CPU per page (#200). Set after withJson so the query cannot re-enable it.
+                  requestBuilder.trackTotalHits(TrackHits.of(t => t.enabled(false)))
 
                   // Check if sorts already exist in the query
                   if (!hasSorts && !queryJson.has("sort")) {

--- a/es9/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
+++ b/es9/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
@@ -1615,9 +1615,7 @@ trait JavaClientScrollApi extends ScrollApi with JavaClientHelpers {
                   val hits = extractHitsOnly(response, fieldAliases)
 
                   if (hits.isEmpty) {
-                    // Close PIT when done
-                    closePit(pitId)
-                    None
+                    None // end of stream — watchTermination owns the single PIT close (#202)
                   } else {
                     val lastHit = response.hits().hits().asScala.lastOption
                     val nextSearchAfter = lastHit.flatMap { hit =>
@@ -1642,12 +1640,13 @@ trait JavaClientScrollApi extends ScrollApi with JavaClientHelpers {
                 }
               }(system, logger).recover { case ex: Exception =>
                 logger.error(s"PIT search_after failed after retries: ${ex.getMessage}", ex)
-                closePit(pitId)
-                None
+                None // ends the stream — watchTermination owns the single PIT close (#202)
               }
             }
             .watchTermination() { (_, done) =>
-              // Cleanup PIT on stream completion/failure
+              // Single owner of the PIT close (#202): completion, failure and downstream
+              // cancellation all land here. The former in-loop closes made every clean run
+              // close twice and log a spurious "PIT close reported failure" WARN.
               done.onComplete {
                 case scala.util.Success(_) =>
                   logger.info(

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/ScrollCompletenessSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/ScrollCompletenessSpec.scala
@@ -128,4 +128,19 @@ trait ScrollCompletenessSpec extends AnyFlatSpecLike with ElasticDockerTestKit w
     rows should have size totalDocs.toLong
     rows.map(_._1("id").toString).toSet should have size totalDocs.toLong
   }
+
+  it should "return every row exactly once with preferSearchAfter disabled (classic scroll)" in {
+    // #201 — preferSearchAfter = false is an operational opt-out that must force classic
+    // scroll on every ES version (it used to be silently ignored on 7.12+), and classic
+    // scroll must be just as row-complete on a multi-shard index.
+    val source = client.scroll(
+      SelectStatement(s"SELECT id FROM $index"),
+      ScrollConfig(scrollSize = 100, preferSearchAfter = false)
+    )
+
+    val rows = Await.result(source.runWith(Sink.seq), 5.minutes)
+
+    rows should have size totalDocs.toLong
+    rows.map(_._1("id").toString).toSet should have size totalDocs.toLong
+  }
 }


### PR DESCRIPTION
## What

The three loose ends left in #197's wake, one commit each:

**Commit 1 — #200, `track_total_hits: false` on the paging path** (`perf`). The search_after/PIT paging path never reads `hits.total`, yet every page paid for computing it — ~30% of ES-side CPU per page on the #197 harness (~2% wall). Now set on the page-request builders in es7 (`searchAfter` + `pitSearchAfter`) and es8/es9 (`pitSearchAfter`; their `searchAfter` delegates to it), placed **after** the query JSON is applied so nothing can re-enable it. Verified before the change: neither the core scroll layer (`ScrollApi`, `ScrollMetrics`) nor the per-page extraction reads `hits.total` on this path. es6 untouched (no `track_total_hits` on 6.x); classic scroll out of scope per the issue.

**Commit 2 — #201, honor `preferSearchAfter`** (`fix`). The flag was only consulted on the `UseSearchAfter` dispatch arm — dead code on ES 7.12+ where the strategy is always `UsePIT` — so `false` was silently ignored on every modern cluster (the footgun that misled the original #197 filing). Strategy selection now owns the decision: `determineScrollStrategy` receives the `ScrollConfig`, and `preferSearchAfter = false` forces classic scroll on **every** version — an operational opt-out for clusters that restrict the PIT API (slower than fixed PIT, 9.55 s vs 6.15 s per 1M rows, but equally row-complete). The now-redundant dispatch guard is removed; config comment + `ScrollApi` scaladoc updated to say what the flag actually does.

**Commit 3 — #202, close the PIT exactly once** (`fix`). The PIT was closed inside the `unfoldAsync` page loop (empty-final-page arm + retry-exhausted recover arm) AND again in `watchTermination`, so every successful extraction logged a spurious `WARN PIT close reported failure`. `watchTermination` is now the single owner — completion, failure and downstream cancellation all land there — applied symmetrically to es7/es8/es9.

## Verification

`ScrollCompletenessSpec` gains a `preferSearchAfter = false` case (classic scroll must be exactly as row-complete on a multi-shard index) — now 3 tests per client, all against real Docker ES:

| Version | Client(s) | Result | `PIT close reported failure` WARNs |
|---|---|---|---|
| 6.8.23 | rest, jest | 3/3 each | n/a (no PIT) |
| 7.17.29 | rest | 3/3 | 0 |
| 8.18.3 | java | 3/3 | **0** (was 2+ per run) |
| 9.0.3 | java | 3/3 | 0 |

Core tests 724/724; scalafmt, cross-compile 2.12/2.13, headerCheck all green. Adversarial pass on #202's close paths: `openPit` failure (no PIT to close), `maxDocuments`/downstream cancellation, and retry-exhaustion all close exactly once via `watchTermination`.

Closes #200
Closes #201
Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
