### PR TITLE
fix(group-by): emit an explicit terms size so GROUP BY returns every group (#205)

### DIFF
--- a/bridge/src/main/scala/app/softnetwork/elastic/sql/bridge/ElasticAggregation.scala
+++ b/bridge/src/main/scala/app/softnetwork/elastic/sql/bridge/ElasticAggregation.scala
@@ -519,25 +519,29 @@ object ElasticAggregation {
           }
           agg match {
             case termsAgg: TermsAggregation =>
-              bucket.size.foreach(s => agg = termsAgg.size(s))
+              // each step must chain on the previous one — restarting from `termsAgg`
+              // would silently discard the earlier updates (issue #205)
+              var terms = termsAgg
+              bucket.size.foreach(s => terms = terms.size(s))
               having match {
                 case Some(criteria) =>
                   criteria.includes(bucket, not = false, BucketIncludesExcludes()) match {
                     case BucketIncludesExcludes(_, Some(regex)) if regex.nonEmpty =>
-                      agg = termsAgg.includeRegex(regex)
+                      terms = terms.includeRegex(regex)
                     case BucketIncludesExcludes(values, _) if values.nonEmpty =>
-                      agg = termsAgg.includeExactValues(values.toArray)
+                      terms = terms.includeExactValues(values.toArray)
                     case _ =>
                   }
                   criteria.excludes(bucket, not = false, BucketIncludesExcludes()) match {
                     case BucketIncludesExcludes(_, Some(regex)) if regex.nonEmpty =>
-                      agg = termsAgg.excludeRegex(regex)
+                      terms = terms.excludeRegex(regex)
                     case BucketIncludesExcludes(values, _) if values.nonEmpty =>
-                      agg = termsAgg.excludeExactValues(values.toArray)
+                      terms = terms.excludeExactValues(values.toArray)
                     case _ =>
                   }
                 case _ =>
               }
+              agg = terms
             case _ =>
           }
           current match {

--- a/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLQuerySpec.scala
+++ b/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLQuerySpec.scala
@@ -533,6 +533,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "exclude": ["USA"],
         |        "min_doc_count": 1,
         |        "order": {
@@ -543,6 +544,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |        "City": {
         |          "terms": {
         |            "field": "City",
+        |            "size": 65536,
         |            "exclude": ["Berlin"],
         |            "min_doc_count": 1,
         |            "order": {
@@ -1016,6 +1018,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "userId": {
         |      "terms": {
         |        "field": "userId",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {
@@ -1065,6 +1068,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "exclude": ["USA"],
         |        "min_doc_count": 1,
         |        "order": {
@@ -1075,6 +1079,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |        "City": {
         |          "terms": {
         |            "field": "City",
+        |            "size": 65536,
         |            "exclude": ["Berlin"],
         |            "min_doc_count": 1
         |          },
@@ -1136,6 +1141,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "exclude": ["USA"],
         |        "min_doc_count": 1,
         |        "order": {
@@ -1146,6 +1152,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |        "City": {
         |          "terms": {
         |            "field": "City",
+        |            "size": 65536,
         |            "exclude": ["Berlin"],
         |            "min_doc_count": 1
         |          },
@@ -1213,6 +1220,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "identifier": {
         |      "terms": {
         |        "field": "identifier",
+        |        "size": 65536,
         |        "min_doc_count": 1,
         |        "order": {
         |          "ct": "desc"
@@ -1429,6 +1437,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "identifier": {
         |      "terms": {
         |        "field": "identifier",
+        |        "size": 65536,
         |        "min_doc_count": 1,
         |        "order": {
         |          "ct": "desc"
@@ -1587,6 +1596,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "identifier": {
         |      "terms": {
         |        "field": "identifier",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {
@@ -3938,12 +3948,14 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {
         |        "City": {
         |          "terms": {
         |            "field": "City",
+        |            "size": 65536,
         |            "min_doc_count": 1,
         |            "order": {
         |              "__c3": "desc"
@@ -3997,6 +4009,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {
@@ -4052,6 +4065,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {
@@ -4155,6 +4169,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "min_doc_count": 1,
         |        "order": {
         |          "count_all": "desc"
@@ -4193,6 +4208,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {
@@ -4241,6 +4257,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {
@@ -4329,7 +4346,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |  "_source": false,
         |  "aggs": {
         |    "department": {
-        |      "terms": { "field": "department", "min_doc_count": 1 },
+        |      "terms": { "field": "department", "size": 65536, "min_doc_count": 1 },
         |      "aggs": {
         |        "sd": { "extended_stats": { "field": "salary" } }
         |      }
@@ -4377,7 +4394,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |  "_source": false,
         |  "aggs": {
         |    "department": {
-        |      "terms": { "field": "department", "min_doc_count": 1 },
+        |      "terms": { "field": "department", "size": 65536, "min_doc_count": 1 },
         |      "aggs": {
         |        "v": { "extended_stats": { "field": "salary" } }
         |      }
@@ -4440,7 +4457,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |  "_source": false,
         |  "aggs": {
         |    "department": {
-        |      "terms": { "field": "department", "min_doc_count": 1 },
+        |      "terms": { "field": "department", "size": 65536, "min_doc_count": 1 },
         |      "aggs": {
         |        "p99": { "percentiles": { "field": "salary", "percents": [99.0] } }
         |      }
@@ -4464,7 +4481,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |  "_source": false,
         |  "aggs": {
         |    "department": {
-        |      "terms": { "field": "department", "min_doc_count": 1 },
+        |      "terms": { "field": "department", "size": 65536, "min_doc_count": 1 },
         |      "aggs": {
         |        "p95": { "percentiles": { "field": "salary", "percents": [95.0] } }
         |      }
@@ -4523,7 +4540,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |  "_source": false,
         |  "aggs": {
         |    "department": {
-        |      "terms": { "field": "department", "min_doc_count": 1 },
+        |      "terms": { "field": "department", "size": 65536, "min_doc_count": 1 },
         |      "aggs": {
         |        "p50": { "percentiles": { "field": "salary", "percents": [50.0, 95.0, 99.0] } }
         |      }

--- a/es6/bridge/src/main/scala/app/softnetwork/elastic/sql/bridge/ElasticAggregation.scala
+++ b/es6/bridge/src/main/scala/app/softnetwork/elastic/sql/bridge/ElasticAggregation.scala
@@ -515,25 +515,29 @@ object ElasticAggregation {
           }
           agg match {
             case termsAgg: TermsAggregation =>
-              bucket.size.foreach(s => agg = termsAgg.size(s))
+              // each step must chain on the previous one — restarting from `termsAgg`
+              // would silently discard the earlier updates (issue #205)
+              var terms = termsAgg
+              bucket.size.foreach(s => terms = terms.size(s))
               having match {
                 case Some(criteria) =>
                   criteria.includes(bucket, not = false, BucketIncludesExcludes()) match {
                     case BucketIncludesExcludes(_, Some(regex)) if regex.nonEmpty =>
-                      agg = termsAgg.include(regex)
+                      terms = terms.include(regex)
                     case BucketIncludesExcludes(values, _) if values.nonEmpty =>
-                      agg = termsAgg.include(values.toArray)
+                      terms = terms.include(values.toArray)
                     case _ =>
                   }
                   criteria.excludes(bucket, not = false, BucketIncludesExcludes()) match {
                     case BucketIncludesExcludes(_, Some(regex)) if regex.nonEmpty =>
-                      agg = termsAgg.exclude(regex)
+                      terms = terms.exclude(regex)
                     case BucketIncludesExcludes(values, _) if values.nonEmpty =>
-                      agg = termsAgg.exclude(values.toArray)
+                      terms = terms.exclude(values.toArray)
                     case _ =>
                   }
                 case _ =>
               }
+              agg = terms
             case _ =>
           }
           current match {

--- a/es6/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLQuerySpec.scala
+++ b/es6/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLQuerySpec.scala
@@ -533,6 +533,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
       |    "Country": {
       |      "terms": {
       |        "field": "Country",
+      |        "size": 65536,
       |        "exclude": "USA",
       |        "min_doc_count": 1,
       |        "order": {
@@ -543,6 +544,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
       |        "City": {
       |          "terms": {
       |            "field": "City",
+      |            "size": 65536,
       |            "exclude": "Berlin",
       |            "min_doc_count": 1,
       |            "order": {
@@ -1016,6 +1018,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
       |    "userId": {
       |      "terms": {
       |        "field": "userId",
+      |        "size": 65536,
       |        "min_doc_count": 1
       |      },
       |      "aggs": {
@@ -1065,6 +1068,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
       |    "Country": {
       |      "terms": {
       |        "field": "Country",
+      |        "size": 65536,
       |        "exclude": "USA",
       |        "min_doc_count": 1,
       |        "order": {
@@ -1075,6 +1079,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
       |        "City": {
       |          "terms": {
       |            "field": "City",
+      |            "size": 65536,
       |            "exclude": "Berlin",
       |            "min_doc_count": 1
       |          },
@@ -1136,6 +1141,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
       |    "Country": {
       |      "terms": {
       |        "field": "Country",
+      |        "size": 65536,
       |        "exclude": "USA",
       |        "min_doc_count": 1,
       |        "order": {
@@ -1146,6 +1152,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
       |        "City": {
       |          "terms": {
       |            "field": "City",
+      |            "size": 65536,
       |            "exclude": "Berlin",
       |            "min_doc_count": 1
       |          },
@@ -1213,6 +1220,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
       |    "identifier": {
       |      "terms": {
       |        "field": "identifier",
+      |        "size": 65536,
       |        "min_doc_count": 1,
       |        "order": {
       |          "ct": "desc"
@@ -1429,6 +1437,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
       |    "identifier": {
       |      "terms": {
       |        "field": "identifier",
+      |        "size": 65536,
       |        "min_doc_count": 1,
       |        "order": {
       |          "ct": "desc"
@@ -1587,6 +1596,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
       |    "identifier": {
       |      "terms": {
       |        "field": "identifier",
+      |        "size": 65536,
       |        "min_doc_count": 1
       |      },
       |      "aggs": {
@@ -3929,12 +3939,14 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {
         |        "City": {
         |          "terms": {
         |            "field": "City",
+        |            "size": 65536,
         |            "min_doc_count": 1,
         |            "order": {
         |              "__c3": "desc"
@@ -3988,6 +4000,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {
@@ -4043,6 +4056,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {
@@ -4146,6 +4160,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "min_doc_count": 1,
         |        "order": {
         |          "count_all": "desc"
@@ -4184,6 +4199,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {
@@ -4232,6 +4248,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "Country": {
         |      "terms": {
         |        "field": "Country",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {
@@ -4393,7 +4410,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |  "_source": false,
         |  "aggs": {
         |    "department": {
-        |      "terms": { "field": "department", "min_doc_count": 1 },
+        |      "terms": { "field": "department", "size": 65536, "min_doc_count": 1 },
         |      "aggs": {
         |        "sd": { "extended_stats": { "field": "salary" } }
         |      }
@@ -4441,7 +4458,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |  "_source": false,
         |  "aggs": {
         |    "department": {
-        |      "terms": { "field": "department", "min_doc_count": 1 },
+        |      "terms": { "field": "department", "size": 65536, "min_doc_count": 1 },
         |      "aggs": {
         |        "v": { "extended_stats": { "field": "salary" } }
         |      }
@@ -4504,7 +4521,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |  "_source": false,
         |  "aggs": {
         |    "department": {
-        |      "terms": { "field": "department", "min_doc_count": 1 },
+        |      "terms": { "field": "department", "size": 65536, "min_doc_count": 1 },
         |      "aggs": {
         |        "p99": { "percentiles": { "field": "salary", "percents": [99.0] } }
         |      }
@@ -4528,7 +4545,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |  "_source": false,
         |  "aggs": {
         |    "department": {
-        |      "terms": { "field": "department", "min_doc_count": 1 },
+        |      "terms": { "field": "department", "size": 65536, "min_doc_count": 1 },
         |      "aggs": {
         |        "p95": { "percentiles": { "field": "salary", "percents": [95.0] } }
         |      }
@@ -4582,7 +4599,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |  "_source": false,
         |  "aggs": {
         |    "department": {
-        |      "terms": { "field": "department", "min_doc_count": 1 },
+        |      "terms": { "field": "department", "size": 65536, "min_doc_count": 1 },
         |      "aggs": {
         |        "p50": { "percentiles": { "field": "salary", "percents": [50.0, 95.0, 99.0] } }
         |      }

--- a/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestClientGroupByCompletenessSpec.scala
+++ b/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestClientGroupByCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JestClientGroupByCompletenessSpec extends GroupByCompletenessSpec

--- a/es6/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientGroupByCompletenessSpec.scala
+++ b/es6/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientGroupByCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class RestHighLevelClientGroupByCompletenessSpec extends GroupByCompletenessSpec

--- a/es7/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientGroupByCompletenessSpec.scala
+++ b/es7/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientGroupByCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class RestHighLevelClientGroupByCompletenessSpec extends GroupByCompletenessSpec

--- a/es8/java/src/test/scala/app/softnetwork/elastic/client/JavaClientGroupByCompletenessSpec.scala
+++ b/es8/java/src/test/scala/app/softnetwork/elastic/client/JavaClientGroupByCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JavaClientGroupByCompletenessSpec extends GroupByCompletenessSpec

--- a/es9/java/src/test/scala/app/softnetwork/elastic/client/JavaClientGroupByCompletenessSpec.scala
+++ b/es9/java/src/test/scala/app/softnetwork/elastic/client/JavaClientGroupByCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JavaClientGroupByCompletenessSpec extends GroupByCompletenessSpec

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/query/GroupBy.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/query/GroupBy.scala
@@ -50,6 +50,16 @@ case class GroupBy(buckets: Seq[Bucket]) extends Updateable {
     buckets.flatMap(_.nestedElement).distinct
 }
 
+object Bucket {
+
+  /** SQL `GROUP BY` with no `LIMIT` means every group, but an Elasticsearch `terms` aggregation
+    * without an explicit `size` silently returns only its default 10 buckets (issue #205). Emit
+    * Elasticsearch's own `search.max_buckets` ceiling (65536) instead: cardinalities beyond it fail
+    * loudly server-side rather than truncate silently.
+    */
+  val DefaultSize: Int = 65536
+}
+
 case class Bucket(
   identifier: Identifier,
   size: Option[Int] = None
@@ -59,6 +69,7 @@ case class Bucket(
   def table: Option[String] = identifier.table
   override def sql: String = s"$identifier"
   def update(request: SingleSearch): Bucket = {
+    val bucketSize = request.limit.map(_.limit).orElse(Some(Bucket.DefaultSize))
     identifier.functions.headOption match {
       case Some(func: LongValue) =>
         if (func.value <= 0) {
@@ -69,10 +80,10 @@ case class Bucket(
           )
         } else {
           val field = request.select.fields(func.value.toInt - 1)
-          this.copy(identifier = field.identifier, size = request.limit.map(_.limit))
+          this.copy(identifier = field.identifier, size = bucketSize)
         }
       case _ =>
-        this.copy(identifier = identifier.update(request), size = request.limit.map(_.limit))
+        this.copy(identifier = identifier.update(request), size = bucketSize)
     }
   }
 

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/GroupByCompletenessSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/GroupByCompletenessSpec.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
+import app.softnetwork.elastic.client.bulk._
+import app.softnetwork.elastic.client.result.{ElasticFailure, ElasticSuccess}
+import app.softnetwork.elastic.client.spi.ElasticClientFactory
+import app.softnetwork.elastic.scalatest.ElasticDockerTestKit
+import app.softnetwork.persistence.generateUUID
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.language.implicitConversions
+
+case class CategoryCount(category: String, cnt: Long)
+
+/** Regression test for issue #205: `GROUP BY` with no `LIMIT` must return EVERY group.
+  *
+  * The failure mode this guards against is SILENT: without an explicit `size` on the `terms`
+  * aggregation, Elasticsearch returns its default 10 buckets with HTTP 200 and no truncation flag,
+  * so a 37-category index silently reports 10 plausible-looking groups. Every fixture in the other
+  * suites has cardinality <= 10, which is exactly why this went unnoticed — this spec asserts
+  * group count AND total doc coverage at cardinality > 10, on a multi-shard index.
+  */
+trait GroupByCompletenessSpec extends AnyFlatSpecLike with ElasticDockerTestKit with Matchers {
+
+  lazy val log: Logger = LoggerFactory.getLogger(getClass.getName)
+
+  implicit val system: ActorSystem = ActorSystem(generateUUID())
+
+  lazy val client: ElasticClientApi = ElasticClientFactory.create(elasticConfig)
+
+  private val index = "group_by_completeness"
+
+  /** 37 categories — far above the ES `terms` default of 10 buckets. Category `cat_i` holds
+    * exactly `i` docs, so both the group count and every per-group count are exact oracles.
+    */
+  private val categories = 37
+
+  private val totalDocs = (1 to categories).sum
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val settings = """{"number_of_shards": 3, "number_of_replicas": 0}"""
+    val mapping =
+      """{
+        |  "properties": {
+        |    "id":       { "type": "keyword" },
+        |    "category": { "type": "keyword" },
+        |    "amount":   { "type": "integer" }
+        |  }
+        |}""".stripMargin
+
+    client.createIndex(index, settings = settings).get shouldBe true
+    client.setMapping(index, mapping).get shouldBe true
+
+    val docs = (for {
+      c <- 1 to categories
+      d <- 1 to c
+    } yield {
+      val category = f"cat_$c%02d"
+      s"""{"id":"${category}_$d","category":"$category","amount":$d}"""
+    }).toList
+
+    implicit val bulkOptions: BulkOptions = BulkOptions(
+      defaultIndex = index,
+      logEvery = 1000
+    )
+
+    implicit def listToSource[T](list: List[T]): Source[T, NotUsed] =
+      Source.fromIterator(() => list.iterator)
+
+    client.bulk[String](docs, identity, idKey = Some(Set("id"))) match {
+      case ElasticSuccess(_) => // ok
+      case ElasticFailure(error) =>
+        error.cause.foreach(_.printStackTrace())
+        fail(s"Bulk indexing failed: ${error.message}")
+    }
+
+    client.refresh(index)
+  }
+
+  override def afterAll(): Unit = {
+    client.deleteIndex(index)
+    super.afterAll()
+  }
+
+  "GROUP BY without LIMIT" should "return every group and account for every document" in {
+    client.searchAs[CategoryCount](
+      "SELECT category, COUNT(*) AS cnt FROM group_by_completeness GROUP BY category"
+    ) match {
+      case ElasticSuccess(rows) =>
+        rows should have size categories.toLong
+
+        val counts = rows.map(r => r.category -> r.cnt).toMap
+        counts should have size categories.toLong
+        (1 to categories).foreach { c =>
+          counts(f"cat_$c%02d") shouldBe c.toLong
+        }
+
+        rows.map(_.cnt).sum shouldBe totalDocs.toLong
+
+        log.info(s"✓ ${rows.size} groups covering ${rows.map(_.cnt).sum} docs from $index")
+
+      case ElasticFailure(error) =>
+        fail(s"Query failed: ${error.message}")
+    }
+  }
+
+  "GROUP BY with LIMIT" should "still bound the number of groups" in {
+    client.searchAs[CategoryCount](
+      "SELECT category, COUNT(*) AS cnt FROM group_by_completeness GROUP BY category LIMIT 5"
+    ) match {
+      case ElasticSuccess(rows) =>
+        rows should have size 5
+
+      case ElasticFailure(error) =>
+        fail(s"Query failed: ${error.message}")
+    }
+  }
+
+  "GROUP BY with ORDER BY on the bucket key and LIMIT" should "return the exact top groups" in {
+    // Key ordering is exact on a multi-shard index; ordering by the metric (ORDER BY cnt DESC)
+    // is NOT — the pushed-down terms top-N is shard-approximate by design (doc_count_error),
+    // so a metric-ordered assertion here would flake on routing skew.
+    client.searchAs[CategoryCount](
+      "SELECT category, COUNT(*) AS cnt FROM group_by_completeness GROUP BY category ORDER BY category DESC LIMIT 3"
+    ) match {
+      case ElasticSuccess(rows) =>
+        rows.map(r => r.category -> r.cnt) shouldBe (0 until 3).map { i =>
+          val c = categories - i
+          f"cat_$c%02d" -> c.toLong
+        }
+
+      case ElasticFailure(error) =>
+        fail(s"Query failed: ${error.message}")
+    }
+  }
+}

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/GroupByCompletenessSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/GroupByCompletenessSpec.scala
@@ -37,8 +37,8 @@ case class CategoryCount(category: String, cnt: Long)
   * The failure mode this guards against is SILENT: without an explicit `size` on the `terms`
   * aggregation, Elasticsearch returns its default 10 buckets with HTTP 200 and no truncation flag,
   * so a 37-category index silently reports 10 plausible-looking groups. Every fixture in the other
-  * suites has cardinality <= 10, which is exactly why this went unnoticed — this spec asserts
-  * group count AND total doc coverage at cardinality > 10, on a multi-shard index.
+  * suites has cardinality <= 10, which is exactly why this went unnoticed — this spec asserts group
+  * count AND total doc coverage at cardinality > 10, on a multi-shard index.
   */
 trait GroupByCompletenessSpec extends AnyFlatSpecLike with ElasticDockerTestKit with Matchers {
 
@@ -50,8 +50,8 @@ trait GroupByCompletenessSpec extends AnyFlatSpecLike with ElasticDockerTestKit 
 
   private val index = "group_by_completeness"
 
-  /** 37 categories — far above the ES `terms` default of 10 buckets. Category `cat_i` holds
-    * exactly `i` docs, so both the group count and every per-group count are exact oracles.
+  /** 37 categories — far above the ES `terms` default of 10 buckets. Category `cat_i` holds exactly
+    * `i` docs, so both the group count and every per-group count are exact oracles.
     */
   private val categories = 37
 


### PR DESCRIPTION
Fixes #205.

## What

`SELECT category, COUNT(*) FROM t GROUP BY category` on an index with 100 distinct categories
returned **10 rows** — Elasticsearch's default `terms` bucket size — with no error, no warning,
and no truncation flag. In SQL, `GROUP BY` with no `LIMIT` means *every* group.

## Fix (2 defects)

1. **`Bucket.update` (`sql/…/query/GroupBy.scala`)** — when the statement has no `LIMIT`, the
   bucket size is now `Bucket.DefaultSize = 65536` (Elasticsearch's own `search.max_buckets`
   ceiling) instead of `None`. The generated `terms` aggregation always carries an explicit
   `size`, so the default matches SQL semantics; a cardinality beyond 65536 fails loudly
   server-side (`too_many_buckets_exception`) rather than truncating silently. An explicit
   `LIMIT n` still maps to `size = n` (the existing top-N push-down), unchanged.

2. **Terms-emission discard chain (`bridge/…/ElasticAggregation.scala`, both the template and the
   hand-maintained es6 copy)** — latent value-discard bug surfaced by (1): `size`, HAVING-derived
   `include`, and `exclude` were each applied to the *original* `termsAgg` binding, so each
   assignment silently discarded the previous one (an exclude dropped the size just applied; an
   exclude also dropped an include). The steps now chain. This is why exclude-bearing GROUP BY
   tests initially kept passing with no `size` — the bug was masking the fix.

## Tests

- `SQLQuerySpec` (template + es6): 18 expected JSONs updated per bridge — every GROUP BY `terms`
  now asserts `"size": 65536` (or the LIMIT-derived size). 118/118 green on the template,
  es6, es7, es8 and es9 bridges; `sql` module 395/395 green.
- **New `GroupByCompletenessSpec`** (testkit template + concrete subclasses for es6 rest, es6
  jest, es7 rest, es8 java, es9 java): 3-shard index, **37 categories** (`cat_i` holds exactly
  `i` docs, so group count *and* per-group counts *and* total doc coverage are exact oracles):
  - no `LIMIT` → 37 groups, every per-group count exact, sum = all 703 docs (the #205 guard);
  - `LIMIT 5` → 5 groups (push-down preserved);
  - `ORDER BY category DESC LIMIT 3` → exact top keys/counts. Ordered on the **key**, not the
    metric: a metric-ordered terms top-N is shard-approximate by design (`doc_count_error`) and
    the first run of this spec actually caught it returning `cat_34` instead of `cat_35`.
  - Green on real ES 6.8, 7.17, 8.18, 9.0 (Docker).

## Not in this PR (follow-ups)

- **Window `PARTITION BY` has the same defect** (partition `terms` gets no `size`; >10 partitions
  silently lose window values). Deliberately not folded in — it interacts with the `top_hits`
  caps and the inline `OVER LIMIT` push-down. Filed separately.
- `sum_other_doc_count`-based truncation warning (issue option 3) — defense-in-depth for the
  >65536-cardinality edge, needs per-client response plumbing.
- Downstream repos (extensions/jdbc/arrow) that pin generated GROUP BY JSON in their own tests
  will need the same `"size": 65536` expectation update when they bump core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
