### PR TITLE
fix(window): size the partition terms so PARTITION BY covers every partition (#207)

### DIFF
--- a/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLQuerySpec.scala
+++ b/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLQuerySpec.scala
@@ -2111,7 +2111,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
     val query = select.query
     println(query)
     query shouldBe
-    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","min_doc_count":1},"aggs":{"rn":{"top_hits":{"size":100,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
+    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","size":65536,"min_doc_count":1},"aggs":{"rn":{"top_hits":{"size":100,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
   }
 
   it should "emit top_hits for ROW_NUMBER without PARTITION BY" in {
@@ -2127,7 +2127,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
     val query = select.query
     println(query)
     query shouldBe
-    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","min_doc_count":1},"aggs":{"r":{"top_hits":{"size":100,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
+    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","size":65536,"min_doc_count":1},"aggs":{"r":{"top_hits":{"size":100,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
   }
 
   it should "emit top_hits for DENSE_RANK per-department" in {
@@ -2135,7 +2135,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
     val query = select.query
     println(query)
     query shouldBe
-    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","min_doc_count":1},"aggs":{"dr":{"top_hits":{"size":100,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
+    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","size":65536,"min_doc_count":1},"aggs":{"dr":{"top_hits":{"size":100,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
   }
 
   it should "push LIMIT N inside OVER into top_hits.size for ranking (top-N per group)" in {
@@ -2143,7 +2143,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
     val query = select.query
     println(query)
     query shouldBe
-    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","min_doc_count":1},"aggs":{"r":{"top_hits":{"size":3,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
+    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","size":65536,"min_doc_count":1},"aggs":{"r":{"top_hits":{"size":3,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
   }
 
   it should "handle GREATEST 2-arg as script field" in {
@@ -2961,6 +2961,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
         |    "dept": {
         |      "terms": {
         |        "field": "department",
+        |        "size": 65536,
         |        "min_doc_count": 1
         |      },
         |      "aggs": {

--- a/es6/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLQuerySpec.scala
+++ b/es6/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLQuerySpec.scala
@@ -2111,7 +2111,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
     val query = select.query
     println(query)
     query shouldBe
-    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","min_doc_count":1},"aggs":{"rn":{"top_hits":{"size":100,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
+    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","size":65536,"min_doc_count":1},"aggs":{"rn":{"top_hits":{"size":100,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
   }
 
   it should "emit top_hits for ROW_NUMBER without PARTITION BY" in {
@@ -2127,7 +2127,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
     val query = select.query
     println(query)
     query shouldBe
-    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","min_doc_count":1},"aggs":{"r":{"top_hits":{"size":100,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
+    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","size":65536,"min_doc_count":1},"aggs":{"r":{"top_hits":{"size":100,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
   }
 
   it should "emit top_hits for DENSE_RANK per-department" in {
@@ -2135,7 +2135,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
     val query = select.query
     println(query)
     query shouldBe
-    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","min_doc_count":1},"aggs":{"dr":{"top_hits":{"size":100,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
+    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","size":65536,"min_doc_count":1},"aggs":{"dr":{"top_hits":{"size":100,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
   }
 
   it should "push LIMIT N inside OVER into top_hits.size for ranking (top-N per group)" in {
@@ -2143,7 +2143,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
     val query = select.query
     println(query)
     query shouldBe
-    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","min_doc_count":1},"aggs":{"r":{"top_hits":{"size":3,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
+    """{"query":{"match_all":{}},"size":0,"_source":false,"aggs":{"department":{"terms":{"field":"department","size":65536,"min_doc_count":1},"aggs":{"r":{"top_hits":{"size":3,"sort":[{"salary":{"order":"desc"}}],"_source":{"includes":["salary"]}}}}}}}"""
   }
 
   it should "handle GREATEST 2-arg as script field" in {
@@ -2952,6 +2952,7 @@ class SQLQuerySpec extends AnyFlatSpec with Matchers {
       |    "dept": {
       |      "terms": {
       |        "field": "department",
+      |        "size": 65536,
       |        "min_doc_count": 1
       |      },
       |      "aggs": {

--- a/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestClientWindowPartitionCompletenessSpec.scala
+++ b/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestClientWindowPartitionCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JestClientWindowPartitionCompletenessSpec extends WindowPartitionCompletenessSpec

--- a/es6/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientWindowPartitionCompletenessSpec.scala
+++ b/es6/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientWindowPartitionCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class RestHighLevelClientWindowPartitionCompletenessSpec extends WindowPartitionCompletenessSpec

--- a/es7/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientWindowPartitionCompletenessSpec.scala
+++ b/es7/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientWindowPartitionCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class RestHighLevelClientWindowPartitionCompletenessSpec extends WindowPartitionCompletenessSpec

--- a/es8/java/src/test/scala/app/softnetwork/elastic/client/JavaClientWindowPartitionCompletenessSpec.scala
+++ b/es8/java/src/test/scala/app/softnetwork/elastic/client/JavaClientWindowPartitionCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JavaClientWindowPartitionCompletenessSpec extends WindowPartitionCompletenessSpec

--- a/es9/java/src/test/scala/app/softnetwork/elastic/client/JavaClientWindowPartitionCompletenessSpec.scala
+++ b/es9/java/src/test/scala/app/softnetwork/elastic/client/JavaClientWindowPartitionCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JavaClientWindowPartitionCompletenessSpec extends WindowPartitionCompletenessSpec

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/function/aggregate/package.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/function/aggregate/package.scala
@@ -135,7 +135,12 @@ package object aggregate {
 
     override def isWindowing: Boolean = buckets.nonEmpty || orderBy.isDefined
 
-    lazy val buckets: Seq[Bucket] = partitionBy.map(identifier => Bucket(identifier, None))
+    // Partition buckets never pass Bucket.update (no LIMIT applies to the partition
+    // count), so the explicit size must be set here — without it the partition terms
+    // falls back to Elasticsearch's default 10 buckets and every partition beyond the
+    // tenth silently loses its window values (issue #207).
+    lazy val buckets: Seq[Bucket] =
+      partitionBy.map(identifier => Bucket(identifier, Some(Bucket.DefaultSize)))
 
     override lazy val bucketPath: String = BucketPath(buckets).path
 

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/WindowPartitionCompletenessSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/WindowPartitionCompletenessSpec.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
+import app.softnetwork.elastic.client.bulk._
+import app.softnetwork.elastic.client.result.{ElasticFailure, ElasticSuccess}
+import app.softnetwork.elastic.client.spi.ElasticClientFactory
+import app.softnetwork.elastic.scalatest.ElasticDockerTestKit
+import app.softnetwork.persistence.generateUUID
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.language.implicitConversions
+
+case class PartitionRow(
+  category: String,
+  amount: Int,
+  rnum: Option[Long] = None,
+  top_amount: Option[Int] = None
+)
+
+/** Regression test for issue #207: a window `PARTITION BY` must cover EVERY partition.
+  *
+  * Same silent failure class as #205, on the window path: the partition `terms` aggregation had no
+  * explicit `size`, so Elasticsearch computed only its default 10 partition buckets — with more
+  * than 10 distinct partition values, rows in partitions 11+ silently got no window value. Every
+  * other window fixture has <= 5 partitions, which is why this went unnoticed — this spec asserts
+  * window-value coverage across 15 partitions, on a multi-shard index.
+  */
+trait WindowPartitionCompletenessSpec
+    extends AnyFlatSpecLike
+    with ElasticDockerTestKit
+    with Matchers {
+
+  lazy val log: Logger = LoggerFactory.getLogger(getClass.getName)
+
+  implicit val system: ActorSystem = ActorSystem(generateUUID())
+
+  lazy val client: ElasticClientApi = ElasticClientFactory.create(elasticConfig)
+
+  private val index = "window_partition_completeness"
+
+  /** 15 partitions — above the ES `terms` default of 10 buckets. Category `cat_i` holds 3 docs
+    * with amounts i*100 + 1..3, so every per-partition window value is an exact oracle.
+    */
+  private val categories = 15
+
+  private val docsPerCategory = 3
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val settings = """{"number_of_shards": 3, "number_of_replicas": 0}"""
+    val mapping =
+      """{
+        |  "properties": {
+        |    "id":       { "type": "keyword" },
+        |    "category": { "type": "keyword" },
+        |    "amount":   { "type": "integer" }
+        |  }
+        |}""".stripMargin
+
+    client.createIndex(index, settings = settings).get shouldBe true
+    client.setMapping(index, mapping).get shouldBe true
+
+    val docs = (for {
+      c <- 1 to categories
+      d <- 1 to docsPerCategory
+    } yield {
+      val category = f"cat_$c%02d"
+      s"""{"id":"${category}_$d","category":"$category","amount":${c * 100 + d}}"""
+    }).toList
+
+    implicit val bulkOptions: BulkOptions = BulkOptions(
+      defaultIndex = index,
+      logEvery = 1000
+    )
+
+    implicit def listToSource[T](list: List[T]): Source[T, NotUsed] =
+      Source.fromIterator(() => list.iterator)
+
+    client.bulk[String](docs, identity, idKey = Some(Set("id"))) match {
+      case ElasticSuccess(_) => // ok
+      case ElasticFailure(error) =>
+        error.cause.foreach(_.printStackTrace())
+        fail(s"Bulk indexing failed: ${error.message}")
+    }
+
+    client.refresh(index)
+  }
+
+  override def afterAll(): Unit = {
+    client.deleteIndex(index)
+    super.afterAll()
+  }
+
+  // Both queries carry an explicit statement LIMIT: without one, the non-scroll search
+  // path emits no top-level `size` and Elasticsearch returns its default 10 base hits —
+  // a separate, pre-existing truncation this spec must not conflate with the partition
+  // coverage under test (the statement LIMIT does NOT shrink the partition terms).
+
+  "ROW_NUMBER over more than 10 partitions" should "rank rows in every partition" in {
+    client.searchAs[PartitionRow](
+      """SELECT
+           category,
+           amount,
+           ROW_NUMBER() OVER (PARTITION BY category ORDER BY amount DESC) AS rnum
+         FROM window_partition_completeness
+         LIMIT 100"""
+    ) match {
+      case ElasticSuccess(rows) =>
+        rows should have size (categories * docsPerCategory).toLong
+
+        val ranked = rows.filter(_.rnum.isDefined)
+        ranked.map(_.category).distinct should have size categories.toLong
+
+        ranked.groupBy(_.category).foreach { case (category, group) =>
+          group.flatMap(_.rnum).sorted shouldBe (1L to docsPerCategory.toLong)
+          val c = category.stripPrefix("cat_").toInt
+          group.find(_.rnum.contains(1L)).map(_.amount) shouldBe Some(c * 100 + docsPerCategory)
+        }
+
+        log.info(s"✓ ${ranked.map(_.category).distinct.size} partitions ranked from $index")
+
+      case ElasticFailure(error) =>
+        fail(s"Query failed: ${error.message}")
+    }
+  }
+
+  "FIRST_VALUE over more than 10 partitions" should "enrich rows in every partition" in {
+    client.searchAs[PartitionRow](
+      """SELECT
+           category,
+           amount,
+           FIRST_VALUE(amount) OVER (PARTITION BY category ORDER BY amount DESC) AS top_amount
+         FROM window_partition_completeness
+         LIMIT 100"""
+    ) match {
+      case ElasticSuccess(rows) =>
+        rows should have size (categories * docsPerCategory).toLong
+
+        rows.foreach { row =>
+          val c = row.category.stripPrefix("cat_").toInt
+          withClue(s"row ${row.category}/${row.amount}: ") {
+            row.top_amount shouldBe Some(c * 100 + docsPerCategory)
+          }
+        }
+
+      case ElasticFailure(error) =>
+        fail(s"Query failed: ${error.message}")
+    }
+  }
+}

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/WindowPartitionCompletenessSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/WindowPartitionCompletenessSpec.scala
@@ -58,8 +58,8 @@ trait WindowPartitionCompletenessSpec
 
   private val index = "window_partition_completeness"
 
-  /** 15 partitions — above the ES `terms` default of 10 buckets. Category `cat_i` holds 3 docs
-    * with amounts i*100 + 1..3, so every per-partition window value is an exact oracle.
+  /** 15 partitions — above the ES `terms` default of 10 buckets. Category `cat_i` holds 3 docs with
+    * amounts i*100 + 1..3, so every per-partition window value is an exact oracle.
     */
   private val categories = 15
 


### PR DESCRIPTION
Fixes #207.

## What

Same silent-wrong-answer class as #205, on the window path: the `terms` aggregation wrapping
every `OVER (PARTITION BY ...)` window had no explicit `size`, so Elasticsearch computed only its
default **10** partition buckets. With more than 10 distinct partition values, rows in partitions
11+ silently got no window value (`ROW_NUMBER`/`RANK`/`DENSE_RANK`: those rows are missing from
the ranking enrichment entirely; `FIRST_VALUE`/`LAST_VALUE`/`STDDEV`/`PERCENTILE_CONT` OVER:
enrichment `null`).

## Fix

One line in the version-agnostic sql module — `WindowFunction.buckets`
(`sql/…/function/aggregate/package.scala`) now creates partition buckets with
`Some(Bucket.DefaultSize)` (the 65536 = `search.max_buckets` ceiling introduced by #205) instead
of `None`. Partition buckets never pass `Bucket.update` (no statement `LIMIT` applies to the
partition *count* — the inline `OVER LIMIT` bounds `top_hits` rows *per* partition, which is
unchanged), so the size must be set at construction.

The `top_hits` interplay that kept this out of PR #206 is bounded per partition, not per query:
partition count is capped by actual data cardinality (and `search.max_buckets`), and each
partition still carries at most its existing `top_hits` size (100 default / inline `OVER LIMIT`).
The old behavior wasn't a smaller response — it was a wrong one.

## Tests

- `SQLQuerySpec` (template + es6): the 5 window expected JSONs per bridge now assert
  `"size": 65536` on the partition terms (4 ranking + the top-hits aggregation test). All five
  bridges 118/118 (es9 under `sbt17` — its elastic4s is Java-17 bytecode), `sql` 395/395,
  `core` 724/724, macros green, cross-compiled 2.12 + 2.13.
- **New `WindowPartitionCompletenessSpec`** (testkit template + concrete subclasses for es6
  rest, es6 jest, es7 rest, es8 java, es9 java): 3-shard index, **15 partitions** (`cat_i` holds
  3 docs with amounts `i*100+1..3`, exact per-partition oracles):
  - `ROW_NUMBER OVER (PARTITION BY category ORDER BY amount DESC)` → all 15 partitions ranked,
    ranks 1..3 each, rank-1 row is the per-partition max;
  - `FIRST_VALUE(amount) OVER (...)` → every row of every partition enriched with the exact
    partition max.
  - Green on real ES 6.8, 7.17, 8.18, 9.0 (Docker).

Existing window fixtures (emp: 5 departments) could never catch this — same cardinality-≤10
blind spot documented in #205.

## Found while validating (filed as #209)

The spec's first live run exposed a **third** member of the truncation family, pre-existing and
out of scope here: a plain SELECT with no `LIMIT` on the non-scroll search path emits no
top-level `size`, so Elasticsearch returns its default **10 base hits** (45-row index → 10
arbitrary rows; the window enrichment itself was complete). Every row-count-asserting
`WindowFunctionSpec` query carries an explicit `LIMIT`, which is why it never surfaced. The new
spec uses `LIMIT 100` with a comment pointing at that behavior, keeping the two truncations
separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
