### PR TITLE
fix(search): route un-LIMITed row queries through scroll so SELECT returns every row (#209)

### DIFF
--- a/core/src/main/scala/app/softnetwork/elastic/client/SearchApi.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/SearchApi.scala
@@ -16,12 +16,15 @@
 
 package app.softnetwork.elastic.client
 
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Sink
 import app.softnetwork.elastic.client.result.{
   ElasticError,
   ElasticFailure,
   ElasticResult,
   ElasticSuccess
 }
+import app.softnetwork.elastic.client.scroll.ScrollConfig
 import app.softnetwork.elastic.sql.PainlessContextType
 import app.softnetwork.elastic.sql.function.aggregate.{PercentileAgg, RankingWindow}
 import app.softnetwork.elastic.sql.macros.SQLQueryMacros
@@ -33,10 +36,12 @@ import app.softnetwork.elastic.sql.query.{
   SingleSearch
 }
 import com.google.gson.{Gson, JsonElement, JsonObject, JsonParser}
+import com.typesafe.config.ConfigFactory
 import org.json4s.Formats
 
 import scala.collection.immutable.ListMap
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.language.experimental.macros
 import scala.reflect.{classTag, ClassTag}
@@ -108,22 +113,26 @@ trait SearchApi extends ElasticConversion with ElasticClientHelpers {
           sql = Some(query),
           explodeNested = single.explodeNested
         )
-        if (
-          single.windowFunctions.exists(
-            _.isWindowing
-          ) && single.groupBy.isEmpty && (!single.select.fields.forall(
-            _.isAggregation
-          ) || single.scriptFields.nonEmpty)
-        )
-          searchWithWindowEnrichment(single)
-        else
-          singleSearch(
-            elasticQuery,
-            single.fieldAliases,
-            single.sqlAggregations,
-            extractOutputFieldNames(single),
-            single.nestedHitsMappings
-          )
+        this match {
+          case scrollApi: ScrollApi if single.limit.isEmpty && single.returnsRows =>
+            // A row query is data-bound, not time-bound: every page request below
+            // carries its own timeout, so the stream always terminates.
+            Await.result(
+              scrollAllRows(scrollApi, single, elasticQuery),
+              Duration.Inf
+            )
+          case _ =>
+            if (single.windowRowQuery)
+              searchWithWindowEnrichment(single)
+            else
+              singleSearch(
+                elasticQuery,
+                single.fieldAliases,
+                single.sqlAggregations,
+                extractOutputFieldNames(single),
+                single.nestedHitsMappings
+              )
+        }
 
       case multiple: MultiSearch =>
         val elasticQueries = ElasticQueries(
@@ -432,22 +441,21 @@ trait SearchApi extends ElasticConversion with ElasticClientHelpers {
           single,
           collection.immutable.Seq(single.sources: _*)
         )
-        if (
-          single.windowFunctions.exists(
-            _.isWindowing
-          ) && single.groupBy.isEmpty && (!single.select.fields.forall(
-            _.isAggregation
-          ) || single.scriptFields.nonEmpty)
-        )
-          Future.successful(searchWithWindowEnrichment(single))
-        else
-          singleSearchAsync(
-            elasticQuery,
-            single.fieldAliases,
-            single.sqlAggregations,
-            extractOutputFieldNames(single),
-            single.nestedHitsMappings
-          )
+        this match {
+          case scrollApi: ScrollApi if single.limit.isEmpty && single.returnsRows =>
+            scrollAllRows(scrollApi, single, elasticQuery)
+          case _ =>
+            if (single.windowRowQuery)
+              Future.successful(searchWithWindowEnrichment(single))
+            else
+              singleSearchAsync(
+                elasticQuery,
+                single.fieldAliases,
+                single.sqlAggregations,
+                extractOutputFieldNames(single),
+                single.nestedHitsMappings
+              )
+        }
 
       case multiple: MultiSearch =>
         val elasticQueries = ElasticQueries(
@@ -1658,4 +1666,71 @@ trait SearchApi extends ElasticConversion with ElasticClientHelpers {
     def size: Int = cache.size
   }
 
+  // ========================================================================
+  // ROW COMPLETENESS — SCROLL ROUTING (issue #209)
+  // ========================================================================
+
+  /** Collect EVERY row of an un-LIMITed row query through the scroll path.
+    *
+    * A one-shot search cannot honor "no LIMIT means every row": with no `size` Elasticsearch
+    * returns its default 10 hits, and any explicit `size` is bounded by `index.max_result_window`.
+    * The scroll path pages completely (PIT / search_after) and already handles window enrichment
+    * and script fields, so `search` / `searchAsync` route row-shaped queries with no LIMIT here.
+    * Aggregation-shaped queries must never be routed — their result is the aggregation itself,
+    * already bounded by an explicit `terms` size.
+    */
+  private[client] def scrollAllRows(
+    scrollApi: ScrollApi,
+    single: SingleSearch,
+    elasticQuery: ElasticQuery
+  )(implicit context: ConversionContext): Future[ElasticResult[ElasticResponse]] = {
+    implicit val system: ActorSystem = SearchApi.scrollRoutingSystem
+    implicit val ec: ExecutionContext = system.dispatcher
+    val sql = elasticQuery.sql.orElse(Option(single.sql))
+    logger.info(
+      s"▶ Row query without LIMIT — routing through scroll for row completeness:\n${sql.getOrElse(elasticQuery.query)}"
+    )
+    scrollApi
+      .scroll(single, ScrollConfig())
+      .map(_._1)
+      .runWith(Sink.seq)
+      .map { rows =>
+        logger.info(s"✅ Scroll-routed search returned ${rows.size} rows")
+        ElasticResult.success(
+          ElasticResponse(
+            sql,
+            elasticQuery.query,
+            rows,
+            single.fieldAliases,
+            ListMap.empty
+          )
+        )
+      }
+      .recover { case t =>
+        logger.error(
+          s"❌ Scroll-routed search failed for query \n${sql.getOrElse(elasticQuery.query)} -> ${t.getMessage}"
+        )
+        ElasticResult.failure(
+          ElasticError(
+            message = s"Scroll-routed search failed: ${t.getMessage}",
+            cause = Some(t),
+            index = Some(elasticQuery.indices.mkString(",")),
+            operation = Some("searchAsync")
+          )
+        )
+      }
+  }
+
+}
+
+object SearchApi {
+
+  /** JVM-shared materializer for [[SearchApi.scrollAllRows]]. Daemonic so an un-terminated system
+    * can never keep the JVM alive — clients don't own it, so no `close()` reaches it.
+    */
+  private[client] lazy val scrollRoutingSystem: ActorSystem =
+    ActorSystem(
+      "softclient4es-scroll-routing",
+      ConfigFactory.parseString("akka.daemonic = on")
+    )
 }

--- a/core/src/main/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtension.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtension.scala
@@ -237,18 +237,19 @@ class CoreDqlExtension extends ExtensionSpi {
           )
         )
 
-      // (2) No LIMIT, finite quota, the query would take the UNBOUNDED scroll branch, and NOT a
-      //     JOIN leg → cap the scroll stream at `max` via ScrollConfig.maxDocuments (enforced by
-      //     ScrollApi's `.take`) and flag truncation.
+      // (2) No LIMIT, finite quota, a ROW-shaped query, and NOT a JOIN leg → cap the scroll
+      //     stream at `max` via ScrollConfig.maxDocuments (enforced by ScrollApi's `.take`) and
+      //     flag truncation.
       //
-      //     `single.fields.nonEmpty` MIRRORS `SearchExecutor` (GatewayApi.scala:146): only a
-      //     no-LIMIT query with explicit projection fields takes the unbounded `scroll` branch —
-      //     the ONLY over-quota path. A no-LIMIT query with empty `fields` (aggregations / GROUP BY
-      //     / `SELECT *`) takes the `searchAsync` branch, which ES bounds by
-      //     `index.max_result_window` (≤10k ≤ every tier quota) → can never exceed, needs no cap,
-      //     and must NOT be re-routed to scroll (it would mishandle aggregation buckets). JOIN legs
+      //     `single.returnsRows` covers every unbounded path: the gateway's `scroll` branch
+      //     (plain projections) AND the row queries that reach `searchAsync` (windowed /
+      //     script-field-only projections), which since issue #209 routes them through scroll
+      //     internally and therefore returns EVERY row — so they must be capped here too.
+      //     Aggregation-shaped queries (`returnsRows` false: GROUP BY / metric-only SELECT) are
+      //     bounded by the aggregation sizes, need no row cap, and must NOT be re-routed to
+      //     scroll (it would mishandle aggregation buckets). JOIN legs
       //     (ResultCapContext.isSuppressed) also skip the cap so the join input is not truncated.
-      case (None, Some(max)) if single.fields.nonEmpty && !ResultCapContext.isSuppressed =>
+      case (None, Some(max)) if single.returnsRows && !ResultCapContext.isSuppressed =>
         // Story P0.6 (OQ-2) — the no-LIMIT truncation IS the meter biting (non-fatally): count it
         // as a QueryResults cap-hit, the SAME kind as the explicit-LIMIT 402 above. The cap is
         // suppressed for JOIN legs (the `!isSuppressed` guard), so a per-leg input truncation is

--- a/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestClientSelectCompletenessSpec.scala
+++ b/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestClientSelectCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JestClientSelectCompletenessSpec extends SelectCompletenessSpec

--- a/es6/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientSelectCompletenessSpec.scala
+++ b/es6/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientSelectCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class RestHighLevelClientSelectCompletenessSpec extends SelectCompletenessSpec

--- a/es7/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientSelectCompletenessSpec.scala
+++ b/es7/rest/src/test/scala/app/softnetwork/elastic/client/RestHighLevelClientSelectCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class RestHighLevelClientSelectCompletenessSpec extends SelectCompletenessSpec

--- a/es8/java/src/test/scala/app/softnetwork/elastic/client/JavaClientSelectCompletenessSpec.scala
+++ b/es8/java/src/test/scala/app/softnetwork/elastic/client/JavaClientSelectCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JavaClientSelectCompletenessSpec extends SelectCompletenessSpec

--- a/es9/java/src/test/scala/app/softnetwork/elastic/client/JavaClientSelectCompletenessSpec.scala
+++ b/es9/java/src/test/scala/app/softnetwork/elastic/client/JavaClientSelectCompletenessSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+class JavaClientSelectCompletenessSpec extends SelectCompletenessSpec

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/query/package.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/query/package.scala
@@ -244,6 +244,21 @@ package object query {
 
     lazy val windowFunctions: Seq[WindowFunction] = windowFields.flatMap(_.identifier.windows)
 
+    /** Window-enriched ROW query: window functions present, no GROUP BY, and the SELECT projects at
+      * least one non-aggregation column (or computes script fields). The canonical dispatch
+      * condition shared by the search and scroll paths.
+      */
+    lazy val windowRowQuery: Boolean =
+      windowFunctions.exists(_.isWindowing) && groupBy.isEmpty &&
+      (!select.fields.forall(_.isAggregation) || scriptFields.nonEmpty)
+
+    /** Response shape: true when the query returns DOCUMENT ROWS (plain, script-field or
+      * window-enriched projections), false when it returns aggregation results (GROUP BY /
+      * metric-only SELECT). A row query with no LIMIT means EVERY matching row (issue #209) —
+      * consumers use this to route such queries through a paging-complete path.
+      */
+    lazy val returnsRows: Boolean = windowRowQuery || sqlAggregations.isEmpty
+
     private lazy val selectAggs: Seq[Field] =
       select.fieldsWithComputedAliases
         .filter(f => f.isAggregation || f.isBucketScript)

--- a/sql/src/test/scala/app/softnetwork/elastic/sql/query/ReturnsRowsSpec.scala
+++ b/sql/src/test/scala/app/softnetwork/elastic/sql/query/ReturnsRowsSpec.scala
@@ -22,8 +22,8 @@ import org.scalatest.matchers.should.Matchers
 
 /** Issue #209 — `SingleSearch.returnsRows` is the canonical response-shape discriminator: row
   * queries with no LIMIT are routed through the scroll path (row completeness), while
-  * aggregation-shaped queries must never be. A wrong `true` would scroll-route an aggregation
-  * query (mishandling buckets); a wrong `false` would silently truncate rows at the ES default.
+  * aggregation-shaped queries must never be. A wrong `true` would scroll-route an aggregation query
+  * (mishandling buckets); a wrong `false` would silently truncate rows at the ES default.
   */
 class ReturnsRowsSpec extends AnyFlatSpec with Matchers {
 

--- a/sql/src/test/scala/app/softnetwork/elastic/sql/query/ReturnsRowsSpec.scala
+++ b/sql/src/test/scala/app/softnetwork/elastic/sql/query/ReturnsRowsSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.sql.query
+
+import app.softnetwork.elastic.sql.parser.Parser
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Issue #209 — `SingleSearch.returnsRows` is the canonical response-shape discriminator: row
+  * queries with no LIMIT are routed through the scroll path (row completeness), while
+  * aggregation-shaped queries must never be. A wrong `true` would scroll-route an aggregation
+  * query (mishandling buckets); a wrong `false` would silently truncate rows at the ES default.
+  */
+class ReturnsRowsSpec extends AnyFlatSpec with Matchers {
+
+  private def single(sql: String): SingleSearch =
+    Parser(sql) match {
+      case Right(select: SelectStatement) =>
+        select.statement match {
+          case Some(s: SingleSearch) => s
+          case other                 => fail(s"Not a SingleSearch: $other")
+        }
+      case Right(s: SingleSearch) => s
+      case other                  => fail(s"Failed to parse '$sql': $other")
+    }
+
+  "returnsRows" should "be true for a plain projection" in {
+    single("SELECT id, amount FROM t").returnsRows shouldBe true
+  }
+
+  it should "be true for SELECT *" in {
+    single("SELECT * FROM t").returnsRows shouldBe true
+  }
+
+  it should "be true for a script-field-only projection" in {
+    single("SELECT UPPER(name) AS n FROM t").returnsRows shouldBe true
+  }
+
+  it should "be true for a window-enriched row projection" in {
+    val s = single(
+      "SELECT category, amount, ROW_NUMBER() OVER (PARTITION BY category ORDER BY amount DESC) AS rnum FROM t"
+    )
+    s.windowRowQuery shouldBe true
+    s.returnsRows shouldBe true
+  }
+
+  it should "be false for a metric-only SELECT" in {
+    single("SELECT COUNT(*) AS cnt FROM t").returnsRows shouldBe false
+  }
+
+  it should "be false for a GROUP BY query" in {
+    single("SELECT category, COUNT(*) AS cnt FROM t GROUP BY category").returnsRows shouldBe false
+  }
+
+  it should "be false for a GROUP BY combined with window functions" in {
+    val s = single(
+      """SELECT department, AVG(salary) AS avg_salary, MAX(salary) AS max_salary
+        |FROM emp
+        |GROUP BY department""".stripMargin
+    )
+    s.windowRowQuery shouldBe false
+    s.returnsRows shouldBe false
+  }
+
+  it should "not depend on LIMIT" in {
+    single("SELECT id FROM t LIMIT 5").returnsRows shouldBe true
+    single("SELECT COUNT(*) AS cnt FROM t LIMIT 5").returnsRows shouldBe false
+  }
+}

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/SelectCompletenessSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/SelectCompletenessSpec.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
+import app.softnetwork.elastic.client.bulk._
+import app.softnetwork.elastic.client.result.{ElasticFailure, ElasticSuccess}
+import app.softnetwork.elastic.client.spi.ElasticClientFactory
+import app.softnetwork.elastic.scalatest.ElasticDockerTestKit
+import app.softnetwork.elastic.sql.query.SelectStatement
+import app.softnetwork.persistence.generateUUID
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.language.implicitConversions
+
+case class SelectRow(category: String, amount: Int, rnum: Option[Long] = None)
+
+/** Regression test for issue #209: a row query with no `LIMIT` must return EVERY matching row.
+  *
+  * Same silent failure class as #205/#207, on the base hits: the one-shot search path emitted no
+  * top-level `size`, so Elasticsearch returned its default 10 hits with HTTP 200 and no
+  * truncation flag — a 45-row index reported 10 arbitrary rows. Un-LIMITed row queries are now
+  * routed through the scroll path (which pages completely); this spec asserts full row counts on
+  * a multi-shard index across the projection shapes that route: plain columns, `SELECT *`,
+  * script-field-only, and window-enriched. An explicit LIMIT must keep its one-shot bound.
+  */
+trait SelectCompletenessSpec extends AnyFlatSpecLike with ElasticDockerTestKit with Matchers {
+
+  lazy val log: Logger = LoggerFactory.getLogger(getClass.getName)
+
+  implicit val system: ActorSystem = ActorSystem(generateUUID())
+
+  lazy val client: ElasticClientApi = ElasticClientFactory.create(elasticConfig)
+
+  private val index = "select_completeness"
+
+  /** 45 docs — far above the ES default of 10 hits. Category `cat_i` holds 3 docs with amounts
+    * i*100 + 1..3, so row counts and contents are exact oracles.
+    */
+  private val categories = 15
+
+  private val docsPerCategory = 3
+
+  private val totalDocs = categories * docsPerCategory
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val settings = """{"number_of_shards": 3, "number_of_replicas": 0}"""
+    val mapping =
+      """{
+        |  "properties": {
+        |    "id":       { "type": "keyword" },
+        |    "category": { "type": "keyword" },
+        |    "amount":   { "type": "integer" }
+        |  }
+        |}""".stripMargin
+
+    client.createIndex(index, settings = settings).get shouldBe true
+    client.setMapping(index, mapping).get shouldBe true
+
+    val docs = (for {
+      c <- 1 to categories
+      d <- 1 to docsPerCategory
+    } yield {
+      val category = f"cat_$c%02d"
+      s"""{"id":"${category}_$d","category":"$category","amount":${c * 100 + d}}"""
+    }).toList
+
+    implicit val bulkOptions: BulkOptions = BulkOptions(
+      defaultIndex = index,
+      logEvery = 1000
+    )
+
+    implicit def listToSource[T](list: List[T]): Source[T, NotUsed] =
+      Source.fromIterator(() => list.iterator)
+
+    client.bulk[String](docs, identity, idKey = Some(Set("id"))) match {
+      case ElasticSuccess(_) => // ok
+      case ElasticFailure(error) =>
+        error.cause.foreach(_.printStackTrace())
+        fail(s"Bulk indexing failed: ${error.message}")
+    }
+
+    client.refresh(index)
+  }
+
+  override def afterAll(): Unit = {
+    client.deleteIndex(index)
+    super.afterAll()
+  }
+
+  "SELECT without LIMIT" should "return every row" in {
+    client.searchAs[SelectRow](
+      "SELECT category, amount FROM select_completeness"
+    ) match {
+      case ElasticSuccess(rows) =>
+        rows should have size totalDocs.toLong
+        rows.map(r => (r.category, r.amount)).toSet should have size totalDocs.toLong
+
+        log.info(s"✓ ${rows.size} rows from $index without LIMIT")
+
+      case ElasticFailure(error) =>
+        fail(s"Query failed: ${error.message}")
+    }
+  }
+
+  "SELECT * without LIMIT" should "return every row" in {
+    // searchAsUnchecked: the searchAs macro rejects SELECT * at compile time by design.
+    client.searchAsUnchecked[SelectRow](
+      SelectStatement("SELECT * FROM select_completeness")
+    ) match {
+      case ElasticSuccess(rows) =>
+        rows should have size totalDocs.toLong
+
+      case ElasticFailure(error) =>
+        fail(s"Query failed: ${error.message}")
+    }
+  }
+
+  "script-field-only SELECT without LIMIT" should "return every row" in {
+    // Raw `search` (no entity conversion): script_fields values come back wrapped in
+    // Elasticsearch's per-field array on EVERY path (pre-existing — breaks searchAs
+    // conversion of a script field to a scalar; tracked separately from #209), so this
+    // asserts row completeness only.
+    implicit val context: ConversionContext = NativeContext
+    client.search(SelectStatement("SELECT UPPER(category) AS n FROM select_completeness")) match {
+      case ElasticSuccess(response) =>
+        response.results should have size totalDocs.toLong
+
+      case ElasticFailure(error) =>
+        fail(s"Query failed: ${error.message}")
+    }
+  }
+
+  "window-enriched SELECT without LIMIT" should "return every base row" in {
+    // Base-row completeness only — per-partition window coverage is #207's
+    // WindowPartitionCompletenessSpec.
+    client.searchAs[SelectRow](
+      """SELECT
+           category,
+           amount,
+           ROW_NUMBER() OVER (PARTITION BY category ORDER BY amount DESC) AS rnum
+         FROM select_completeness"""
+    ) match {
+      case ElasticSuccess(rows) =>
+        rows should have size totalDocs.toLong
+
+      case ElasticFailure(error) =>
+        fail(s"Query failed: ${error.message}")
+    }
+  }
+
+  "SELECT with LIMIT" should "still bound the returned rows" in {
+    client.searchAs[SelectRow](
+      "SELECT category, amount FROM select_completeness LIMIT 7"
+    ) match {
+      case ElasticSuccess(rows) =>
+        rows should have size 7
+
+      case ElasticFailure(error) =>
+        fail(s"Query failed: ${error.message}")
+    }
+  }
+}

--- a/testkit/src/main/scala/app/softnetwork/elastic/client/SelectCompletenessSpec.scala
+++ b/testkit/src/main/scala/app/softnetwork/elastic/client/SelectCompletenessSpec.scala
@@ -36,11 +36,11 @@ case class SelectRow(category: String, amount: Int, rnum: Option[Long] = None)
 /** Regression test for issue #209: a row query with no `LIMIT` must return EVERY matching row.
   *
   * Same silent failure class as #205/#207, on the base hits: the one-shot search path emitted no
-  * top-level `size`, so Elasticsearch returned its default 10 hits with HTTP 200 and no
-  * truncation flag — a 45-row index reported 10 arbitrary rows. Un-LIMITed row queries are now
-  * routed through the scroll path (which pages completely); this spec asserts full row counts on
-  * a multi-shard index across the projection shapes that route: plain columns, `SELECT *`,
-  * script-field-only, and window-enriched. An explicit LIMIT must keep its one-shot bound.
+  * top-level `size`, so Elasticsearch returned its default 10 hits with HTTP 200 and no truncation
+  * flag — a 45-row index reported 10 arbitrary rows. Un-LIMITed row queries are now routed through
+  * the scroll path (which pages completely); this spec asserts full row counts on a multi-shard
+  * index across the projection shapes that route: plain columns, `SELECT *`, script-field-only, and
+  * window-enriched. An explicit LIMIT must keep its one-shot bound.
   */
 trait SelectCompletenessSpec extends AnyFlatSpecLike with ElasticDockerTestKit with Matchers {
 


### PR DESCRIPTION
Fixes #209 — implements the decided **option 2: route un-LIMITed SELECTs to the scroll path internally**.

## What

A row query with no `LIMIT` through the one-shot search path emitted no top-level `size`, so
Elasticsearch returned its default **10 hits** silently (45-row index → 10 arbitrary rows,
HTTP 200, no flag). The gateway executor already routed *plain* projections to scroll — which is
why the REPL rarely showed it — but the programmatic surface (`search`/`searchAs`/`searchAsync`)
always truncated, and so did the row shapes the gateway predicate misses (windowed and
script-field-only projections, whose `SingleSearch.fields` is empty).

## How

- **`SingleSearch` (sql)** gains the canonical response-shape discriminators:
  - `windowRowQuery` — the window-dispatch condition previously duplicated inline in `search`
    and `searchAsync`;
  - `returnsRows` — row-shaped (plain / script-field / window-enriched) vs aggregation-shaped
    (GROUP BY / metric-only).
- **`SearchApi` (core)** — `search` and `searchAsync` route `limit.isEmpty && returnsRows`
  queries through the public `scroll` (complete paging via PIT/search_after per #197; window
  enrichment and script fields already handled there), collecting rows into the same
  `ElasticResponse`. Aggregation-shaped queries are **never** routed — their result is the
  aggregation itself, bounded by explicit `terms` sizes since #205/#207. The materializer is a
  JVM-shared **daemonic** ActorSystem (cannot keep the JVM alive; clients don't own it). The
  interception is a runtime `this match { case s: ScrollApi => … }` so no trait signature
  changes reach downstream repos.
- **`CoreDqlExtension` (core)** — the licensed `maxQueryResults` cap (ADR D4 rule 2) widens
  from `fields.nonEmpty` to `returnsRows`: windowed/script-only no-LIMIT queries previously hit
  the "ES-bounded" searchAsync branch; now that they return every row they are capped at the
  quota with the truncation flag, exactly like plain projections. Without this, the routing
  would have opened a quota bypass.

## Tests

- **`ReturnsRowsSpec`** (sql): pins the discriminator on 8 statement shapes (plain, `SELECT *`,
  script-only, windowed, metric-only, GROUP BY, GROUP BY+window, LIMIT-independence).
- **New `SelectCompletenessSpec`** (testkit + es6 rest, es6 jest, es7 rest, es8 java, es9 java):
  3-shard, 45-doc index (15 categories × 3, exact oracles):
  - plain projection, `SELECT *` (via `searchAsUnchecked` — the `searchAs` macro rejects
    `SELECT *` at compile time), script-field-only, and window-enriched projections **without
    LIMIT** → all 45 rows;
  - `LIMIT 7` → exactly 7 (one-shot preserved).
  - Green on real ES 6.8, 7.17, 8.18, 9.0, plus a combined ES8 run with the #205/#207 guards
    (`GroupByCompletenessSpec`, `WindowPartitionCompletenessSpec`) — 10/10.
- sql 403, core 724, bridge 118 green; cross-compiled 2.12 + 2.13.

## Found while validating (separate issue to propose)

`script_fields` values come back wrapped in Elasticsearch's per-field **array** on every path
(`n -> List("CAT_02")`): `searchAs` conversion of a script field to a scalar has always failed,
and no existing test ever content-asserted a script-field value. Pre-existing, independent of
the routing; the spec asserts the script-only case via the raw `search` API and the defect will
be filed separately.

## Notes

- `MultiSearch` (UNION ALL) without LIMIT is out of scope (multi-index; scroll does not support
  it) — unchanged behavior.
- Un-LIMITed row queries that SELECT `score()` now ride scroll like the gateway already did for
  plain projections (no `_score` relevance on the PIT/`_doc` path) — consistent with the
  established gateway semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
