### PR TITLE
fix(sql,jest): close the silent-wrong-answer family in watchers, DML, the parser and the es6 jest client (#191, #204, #211, #212, #213, #215, #216)

### DIFF
--- a/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLCriteriaSpec.scala
+++ b/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLCriteriaSpec.scala
@@ -902,4 +902,38 @@ class SQLCriteriaSpec extends AnyFlatSpec with Matchers {
         |""".stripMargin.replaceAll("\\s", "")
   }
 
+  /** #212 — a watcher search input flattens its FROM to bare index names, so an alias-qualified
+    * WHERE must be resolved or the emitted query names a field that exists in no index. This is the
+    * observable half of the ParserSpec assertions: what actually reaches Elasticsearch.
+    */
+  it should "emit the bare field name for an alias-qualified watcher search input" in {
+    implicit def timestamp: Long =
+      ZonedDateTime.parse("2025-12-31T00:00:00Z").toInstant.toEpochMilli
+    val criteria: Option[Criteria] = parser
+      .Parser("""CREATE OR REPLACE WATCHER my_watcher AS
+                | EVERY 5 MINUTES
+                | FROM orders o WHERE o.status = 'FAILED' WITHIN 2 MINUTES
+                | ALWAYS DO
+                | log_action AS LOG "x" AT INFO
+                | END""".stripMargin)
+      .toOption
+      .collect { case c: query.CreateWatcher => c.input }
+      .collect { case s: watcher.SearchWatcherInput => s.query }
+      .flatten
+    val result = SearchBodyBuilderFn(
+      SearchRequest("*") query criteria.map(_.asQuery()).getOrElse(matchAllQuery())
+    ).string
+    println(result)
+    result.replaceAll("\\s", "") shouldBe
+    """{
+        |"query":{
+        |  "bool":{"filter":[{"term":{
+        |    "status":{
+        |      "value":"FAILED"
+        |    }
+        |  }
+        |}
+        |]}}}""".stripMargin.replaceAll("\\s", "")
+  }
+
 }

--- a/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLCriteriaSpec.scala
+++ b/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLCriteriaSpec.scala
@@ -2,6 +2,7 @@ package app.softnetwork.elastic.sql
 
 import app.softnetwork.elastic.sql.bridge._
 import app.softnetwork.elastic.sql.query.Criteria
+import com.fasterxml.jackson.databind.JsonNode
 import com.sksamuel.elastic4s.ElasticApi.matchAllQuery
 import com.sksamuel.elastic4s.requests.searches.{SearchBodyBuilderFn, SearchRequest}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -934,6 +935,31 @@ class SQLCriteriaSpec extends AnyFlatSpec with Matchers {
         |  }
         |}
         |]}}}""".stripMargin.replaceAll("\\s", "")
+  }
+
+  /** #211 + #212 together, through the real criteria conversion: building a watcher that carries a
+    * WHERE used to throw `ClassCastException` (value discard on the generic `ObjectNode.set`), and
+    * the alias-qualified column used to reach Elasticsearch as `o.status`, a field in no index.
+    */
+  it should "build the watcher JSON for an alias-qualified search input" in {
+    implicit def timestamp: Long =
+      ZonedDateTime.parse("2025-12-31T00:00:00Z").toInstant.toEpochMilli
+    implicit val toNode: Criteria => JsonNode = c => criteriaToNode(c)
+    val watcher = parser
+      .Parser("""CREATE OR REPLACE WATCHER my_watcher AS
+                | EVERY 5 MINUTES
+                | FROM orders o WHERE o.status = 'FAILED' WITHIN 2 MINUTES
+                | ALWAYS DO
+                | log_action AS LOG "x" AT INFO
+                | END""".stripMargin)
+      .toOption
+      .collect { case c: query.CreateWatcher => c.watcher }
+      .getOrElse(fail("expected a CreateWatcher"))
+    val json = watcher.node.toString
+    println(json)
+    json should include("\"indices\":[\"orders\"]")
+    json should include("\"term\":{\"status\":{\"value\":\"FAILED\"}}")
+    json should not include "o.status"
   }
 
 }

--- a/core/src/main/resources/help/commands/dml/copy_into.json
+++ b/core/src/main/resources/help/commands/dml/copy_into.json
@@ -8,7 +8,7 @@
     "[FILE_FORMAT = {PARQUET | JSON | JSON_ARRAY | DELTA_LAKE}]",
     "[ON CONFLICT DO {NOTHING | UPDATE}]"
   ],
-  "description": "Bulk load data from a file into an Elasticsearch index. Supports JSON Lines (JSONL), JSON arrays, and CSV formats. The file format is auto-detected from extension if not specified.",
+  "description": "Bulk load data from a file into an Elasticsearch index. Supports JSON Lines, JSON arrays, PARQUET and DELTA_LAKE formats. The file format is auto-detected from the extension (and file content for .json) if not specified.",
   "clauses": [
     {
       "name": "FROM",
@@ -19,7 +19,7 @@
       "name": "FILE_FORMAT",
       "description": "Format of the source file",
       "optional": true,
-      "variants": ["JSONL (default for .jsonl)", "JSON_ARRAY (default for .json)", "CSV (default for .csv)"]
+      "variants": ["PARQUET (auto-detected for .parquet/.parq)", "JSON (JSON Lines; auto-detected for .jsonl/.ndjson)", "JSON_ARRAY (a .json file is content-sniffed as JSON or JSON_ARRAY)", "DELTA_LAKE (auto-detected from a _delta_log directory)"]
     },
     {
       "name": "ON CONFLICT DO NOTHING",
@@ -65,7 +65,7 @@
     "Document IDs are determined by PRIMARY KEY if defined"
   ],
   "limitations": [
-    "Only local file paths supported (no URLs)"
+    "Remote filesystems (e.g. s3://) require the matching Hadoop filesystem jars on the classpath"
   ],
   "seeAlso": ["INSERT"],
   "minVersion": null,

--- a/core/src/main/scala/app/softnetwork/elastic/client/GatewayApi.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/GatewayApi.scala
@@ -1798,13 +1798,11 @@ trait GatewayApi extends IndicesApi with ElasticClientHelpers {
 
   def run(sql: String)(implicit system: ActorSystem): Future[ElasticResult[QueryResult]] = {
     logger.info(s"📥 SQL: $sql")
-    val normalizedQuery =
-      sql
-        .split("\n")
-        .map(_.split("--")(0).trim)
-        .filterNot(w => w.isEmpty || w.startsWith("--"))
-        .mkString(" ")
-    GatewayApi.splitStatements(normalizedQuery) match {
+    // Raw input goes straight to the quote- and comment-aware splitter: a line-based
+    // pre-normalization here (`split("\n").map(_.split("--")(0))`) used to sever literals
+    // containing `--` before the splitter could protect them. Comment stripping and newline
+    // collapsing happen inside splitStatements and Parser.apply, both literal-aware.
+    GatewayApi.splitStatements(sql) match {
       case Nil =>
         val error =
           ElasticError(

--- a/core/src/main/scala/app/softnetwork/elastic/client/GatewayApi.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/GatewayApi.scala
@@ -1804,7 +1804,7 @@ trait GatewayApi extends IndicesApi with ElasticClientHelpers {
         .map(_.split("--")(0).trim)
         .filterNot(w => w.isEmpty || w.startsWith("--"))
         .mkString(" ")
-    normalizedQuery.split(";\\s*$").toList match {
+    GatewayApi.splitStatements(normalizedQuery) match {
       case Nil =>
         val error =
           ElasticError(
@@ -1839,8 +1839,14 @@ trait GatewayApi extends IndicesApi with ElasticClientHelpers {
 
       case statements =>
         implicit val ec: ExecutionContext = system.dispatcher
-        // run each statement sequentially and return the result of the last one
-        val last = statements
+        // Run each statement sequentially and return the result of the last one; the first
+        // failure becomes the accumulated value and every later flatMap passes it through
+        // without running its statement. NOT a `return`: this closure executes asynchronously
+        // on the dispatcher once the previous Future completes, where a non-local return
+        // throws `NonLocalReturnControl` — which `NonFatal` excludes, so nothing completes
+        // the Future and the caller hangs. Unreachable while the old anchored split kept this
+        // branch dead; live now that the split is real.
+        statements
           .foldLeft(
             Future.successful[ElasticResult[QueryResult]](ElasticSuccess(QueryResult.empty))
           ) { (acc, statement) =>
@@ -1848,10 +1854,9 @@ trait GatewayApi extends IndicesApi with ElasticClientHelpers {
               case ElasticSuccess(_) =>
                 run(statement)
               case failure @ ElasticFailure(_) =>
-                return Future.successful(failure)
+                Future.successful(failure)
             }
           }
-        last
     }
   }
 
@@ -1899,4 +1904,64 @@ trait GatewayApi extends IndicesApi with ElasticClientHelpers {
     }
   }
 
+}
+
+object GatewayApi {
+
+  /** Split a normalized SQL string into statements on top-level `;`.
+    *
+    * This replaces `split(";\\s*$")`, which — `$` anchoring to the end of the whole (newline-free)
+    * string — could only ever strip a trailing semicolon, never separate statements: the
+    * multi-statement branch of `run` was unreachable and `run("a; b")` silently executed `a` alone
+    * under the old lenient parse. The documented contract ("splits multiple statements separated by
+    * `;`") is now real.
+    *
+    * Quote-aware: a `;` inside a single-quoted literal or a double-quoted identifier is not a
+    * boundary. Backslash escapes are honored inside quotes, matching the grammar's literal rule
+    * (`([^'\\]|\\.)*`). An unterminated quote consumes to the end of the input — the parser then
+    * reports the malformed statement itself, which beats guessing where it was meant to end. Empty
+    * fragments (`;;`, a trailing `;`) are dropped.
+    */
+  private[client] def splitStatements(sql: String): List[String] = {
+    val statements = scala.collection.mutable.ListBuffer.empty[String]
+    val current = new StringBuilder
+    var quote: Char = 0
+    var i = 0
+    while (i < sql.length) {
+      val c = sql.charAt(i)
+      if (quote != 0) {
+        current.append(c)
+        if (c == '\\' && i + 1 < sql.length) {
+          current.append(sql.charAt(i + 1))
+          i += 1
+        } else if (c == quote) {
+          quote = 0
+        }
+      } else if (c == '-' && i + 1 < sql.length && sql.charAt(i + 1) == '-') {
+        // A `--` comment (outside quotes) runs to the end of its line. Skipping it here — rather
+        // than relying on the line-based pre-normalization, which the REPL batch path does not
+        // apply — keeps an apostrophe in a comment (`-- don't split`) from opening a phantom
+        // quote and a `;` in a comment from splitting mid-comment. Inside quotes `--` is data.
+        // A space stands in for the comment so tokens on either side stay separated.
+        while (i < sql.length && sql.charAt(i) != '\n') {
+          i += 1
+        }
+        current.append(' ')
+      } else {
+        c match {
+          case '\'' | '"' =>
+            quote = c
+            current.append(c)
+          case ';' =>
+            statements += current.toString
+            current.clear()
+          case _ =>
+            current.append(c)
+        }
+      }
+      i += 1
+    }
+    statements += current.toString
+    statements.iterator.map(_.trim).filter(_.nonEmpty).toList
+  }
 }

--- a/core/src/main/scala/app/softnetwork/elastic/client/repl/Repl.scala
+++ b/core/src/main/scala/app/softnetwork/elastic/client/repl/Repl.scala
@@ -18,6 +18,7 @@ package app.softnetwork.elastic.client.repl
 
 import akka.actor.ActorSystem
 import app.softnetwork.elastic.SoftClient4esCoreBuildInfo
+import app.softnetwork.elastic.client.GatewayApi
 import app.softnetwork.elastic.client.help.{HelpCategory, HelpRegistry, HelpRenderer}
 import app.softnetwork.elastic.client.result.{OutputFormat, QueryRows, ResultRenderer}
 import org.jline.reader._
@@ -277,7 +278,9 @@ class Repl(
   }
 
   private def executeBatch(sql: String): Unit = {
-    val statements = sql.split(";").map(_.trim).filter(_.nonEmpty)
+    // Quote-aware, not a bare split(";") — a `;` inside a string literal is not a statement
+    // boundary, and used to break batch scripts mid-literal.
+    val statements = GatewayApi.splitStatements(sql)
 
     statements.foreach { stmt =>
       println(s"\n${cyan("=>")} ${gray(stmt)}")

--- a/core/src/test/scala/app/softnetwork/elastic/client/SplitStatementsSpec.scala
+++ b/core/src/test/scala/app/softnetwork/elastic/client/SplitStatementsSpec.scala
@@ -19,10 +19,10 @@ package app.softnetwork.elastic.client
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-/** `GatewayApi.run`'s multi-statement contract was documented but dead: the old
-  * `split(";\\s*$")` anchors to the end of the (newline-free) input, so it could only strip a
-  * trailing `;` — measured: `"SELECT 1; SELECT 2".split(";\\s*$")` yields ONE element with the
-  * interior `;` intact, and the lenient parser then silently executed only the first statement.
+/** `GatewayApi.run`'s multi-statement contract was documented but dead: the old `split(";\\s*$")`
+  * anchors to the end of the (newline-free) input, so it could only strip a trailing `;` —
+  * measured: `"SELECT 1; SELECT 2".split(";\\s*$")` yields ONE element with the interior `;`
+  * intact, and the lenient parser then silently executed only the first statement.
   * `splitStatements` makes the documented behaviour real, and quote-aware.
   */
 class SplitStatementsSpec extends AnyFlatSpec with Matchers {

--- a/core/src/test/scala/app/softnetwork/elastic/client/SplitStatementsSpec.scala
+++ b/core/src/test/scala/app/softnetwork/elastic/client/SplitStatementsSpec.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** `GatewayApi.run`'s multi-statement contract was documented but dead: the old
+  * `split(";\\s*$")` anchors to the end of the (newline-free) input, so it could only strip a
+  * trailing `;` — measured: `"SELECT 1; SELECT 2".split(";\\s*$")` yields ONE element with the
+  * interior `;` intact, and the lenient parser then silently executed only the first statement.
+  * `splitStatements` makes the documented behaviour real, and quote-aware.
+  */
+class SplitStatementsSpec extends AnyFlatSpec with Matchers {
+
+  "splitStatements" should "split two statements on a top-level semicolon" in {
+    GatewayApi.splitStatements("SELECT 1; SELECT 2") shouldBe List("SELECT 1", "SELECT 2")
+  }
+
+  it should "return a single statement unchanged" in {
+    GatewayApi.splitStatements("SELECT * FROM t WHERE a = 1") shouldBe
+    List("SELECT * FROM t WHERE a = 1")
+  }
+
+  it should "drop trailing and doubled semicolons" in {
+    GatewayApi.splitStatements("SELECT 1;") shouldBe List("SELECT 1")
+    GatewayApi.splitStatements("SELECT 1;;") shouldBe List("SELECT 1")
+    GatewayApi.splitStatements("SELECT 1; ; SELECT 2 ;") shouldBe List("SELECT 1", "SELECT 2")
+  }
+
+  it should "not split on a semicolon inside a single-quoted literal" in {
+    GatewayApi.splitStatements("SELECT * FROM t WHERE x = 'a;b'; SELECT 2") shouldBe
+    List("SELECT * FROM t WHERE x = 'a;b'", "SELECT 2")
+  }
+
+  it should "not split on a semicolon inside a double-quoted identifier" in {
+    GatewayApi.splitStatements("""SELECT "a;b" FROM t; SELECT 2""") shouldBe
+    List("""SELECT "a;b" FROM t""", "SELECT 2")
+  }
+
+  // The grammar's literal rule is `([^'\\]|\\.)*` — backslash escapes a quote, so the literal
+  // below is `a'b` and the quote does NOT close at the escaped `'`.
+  it should "honor a backslash-escaped quote inside a literal" in {
+    GatewayApi.splitStatements("""SELECT * FROM t WHERE x = 'a\'b;c'; SELECT 2""") shouldBe
+    List("""SELECT * FROM t WHERE x = 'a\'b;c'""", "SELECT 2")
+  }
+
+  it should "treat an escaped backslash before the closing quote as closing" in {
+    // `'a\\'` is the one-character-plus-backslash literal, properly closed: the `;` splits.
+    GatewayApi.splitStatements("""SELECT '<a\\'; SELECT 2""".replace("<", "")) shouldBe
+    List("""SELECT 'a\\'""", "SELECT 2")
+  }
+
+  it should "consume to the end on an unterminated quote and let the parser report it" in {
+    GatewayApi.splitStatements("SELECT * FROM t WHERE x = 'oops; SELECT 2") shouldBe
+    List("SELECT * FROM t WHERE x = 'oops; SELECT 2")
+  }
+
+  it should "return Nil for empty or semicolon-only input" in {
+    GatewayApi.splitStatements("") shouldBe Nil
+    GatewayApi.splitStatements("  ;;  ; ") shouldBe Nil
+  }
+
+  // ── `--` comments: the REPL batch path feeds RAW script text, with comments and newlines ──
+
+  it should "not let an apostrophe in a comment open a phantom quote" in {
+    GatewayApi.splitStatements("-- don't split here\nSELECT 1;\nSELECT 2;") shouldBe
+    List("SELECT 1", "SELECT 2")
+  }
+
+  it should "not split on a semicolon inside a comment" in {
+    GatewayApi.splitStatements("SELECT 1; -- note; not a boundary\nSELECT 2;") shouldBe
+    List("SELECT 1", "SELECT 2")
+  }
+
+  it should "keep a double dash inside a literal as data" in {
+    // The line-based pre-normalization truncates this literal; the scanner must not.
+    GatewayApi.splitStatements("SELECT * FROM t WHERE sku = 'AB--12'; SELECT 2") shouldBe
+    List("SELECT * FROM t WHERE sku = 'AB--12'", "SELECT 2")
+  }
+
+  it should "handle a comment on the last line without a trailing newline" in {
+    GatewayApi.splitStatements("SELECT 1; -- done") shouldBe List("SELECT 1")
+  }
+}

--- a/core/src/test/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtensionSpec.scala
+++ b/core/src/test/scala/app/softnetwork/elastic/client/extensions/CoreDqlExtensionSpec.scala
@@ -308,9 +308,13 @@ class CoreDqlExtensionSpec extends AnyFlatSpec with Matchers {
     client.searchedStatement.get() shouldBe null
   }
 
+  // `UNION ALL`, not `UNION`: the token is `Expr("UNION ALL")`, so a bare `UNION` never matched
+  // the separator. Until #213 made `Parser.apply` require the whole input, this statement parsed
+  // as its first leg alone and everything from `UNION` on was silently discarded — so the rejection
+  // asserted below was firing on a single-leg SELECT, not on a union.
   it should "reject a UNION whose leg carries a cross-index JOIN" in {
     val (client, res) = run(
-      "SELECT e.name FROM emp e JOIN dept d ON e.dept_id = d.dept_id UNION SELECT name FROM others",
+      "SELECT e.name FROM emp e JOIN dept d ON e.dept_id = d.dept_id UNION ALL SELECT name FROM others",
       Quota.Community
     )
     res shouldBe a[ElasticFailure]

--- a/documentation/client/gateway.md
+++ b/documentation/client/gateway.md
@@ -46,11 +46,15 @@ It routes SQL statements to the appropriate executor:
 
 The API automatically:
 
-- normalizes SQL (removes comments, trims whitespace)
-- splits multiple statements separated by `;`
-- parses SQL into AST nodes
+- normalizes SQL (removes comments, trims whitespace, drops a trailing `;`)
+- parses SQL into AST nodes — the **whole input must be one statement**: anything left over after
+  the statement is a parse error rather than being silently discarded
 - dispatches to the correct executor
 - returns a typed `QueryResult`
+
+> **One statement per call.** `run("stmt1; stmt2")` is a parse error — split multi-statement
+> input on `;` client-side and call `run` per statement, as the REPL does for scripts and
+> `source` files.
 
 ---
 

--- a/documentation/client/gateway.md
+++ b/documentation/client/gateway.md
@@ -46,15 +46,14 @@ It routes SQL statements to the appropriate executor:
 
 The API automatically:
 
-- normalizes SQL (removes comments, trims whitespace, drops a trailing `;`)
-- parses SQL into AST nodes — the **whole input must be one statement**: anything left over after
-  the statement is a parse error rather than being silently discarded
+- normalizes SQL (removes comments, trims whitespace)
+- splits multiple statements separated by `;` — quote-aware, so a `;` inside a string literal or a
+  quoted identifier is not a statement boundary
+- parses each statement into AST nodes — each must be **complete on its own**: anything left over
+  after a statement is a parse error rather than being silently discarded
 - dispatches to the correct executor
-- returns a typed `QueryResult`
-
-> **One statement per call.** `run("stmt1; stmt2")` is a parse error — split multi-statement
-> input on `;` client-side and call `run` per statement, as the REPL does for scripts and
-> `source` files.
+- runs the statements sequentially, stopping at the first failure, and returns the **last**
+  statement's typed `QueryResult`
 
 ---
 

--- a/documentation/client/gateway.md
+++ b/documentation/client/gateway.md
@@ -489,7 +489,7 @@ gateway.run("TRUNCATE TABLE dml_users")
 ```scala
 gateway.run("""
   COPY INTO dml_users
-  FROM 'classpath:/data/users.json'
+  FROM '/data/users.json'
 """)
 ```
 

--- a/documentation/sql/ddl_statements.md
+++ b/documentation/sql/ddl_statements.md
@@ -600,6 +600,19 @@ FROM my_index WITHIN 2 MINUTES
 FROM logs-*, metrics-* WHERE level = 'ERROR' WITHIN 5 MINUTES
 ```
 
+> **`JOIN` is not supported in a search input.** A watcher input maps to a single Elasticsearch
+> `search` request over a list of indices — there is no join engine behind it. A `FROM` clause
+> containing `JOIN` (or `JOIN UNNEST(...)`) is rejected at parse time:
+>
+> ```text
+> JOIN is not supported in a watcher input (JOIN customers AS c ON o.customer_id = c.id): a watcher
+> input can only search one or more indices (FROM index1, index2). Pre-join the sources with a
+> MATERIALIZED VIEW and have the watcher search the view.
+> ```
+>
+> Pre-join the sources with a [`MATERIALIZED VIEW`](materialized_views.md) and point the watcher
+> at the view instead.
+
 **Generates:**
 
 ```json

--- a/documentation/sql/ddl_statements.md
+++ b/documentation/sql/ddl_statements.md
@@ -612,6 +612,21 @@ FROM logs-*, metrics-* WHERE level = 'ERROR' WITHIN 5 MINUTES
 >
 > Pre-join the sources with a [`MATERIALIZED VIEW`](materialized_views.md) and point the watcher
 > at the view instead.
+>
+A table alias may be used and is resolved in the `WHERE`, so `FROM orders o WHERE o.status =
+'FAILED'` searches index `orders` for documents whose **`status`** field is `FAILED`.
+
+> **Qualifiers are single-index only.** `FROM a, b` is a legitimate multi-index search, but one
+> Elasticsearch search applies one query to *every* index it names — it can neither join them nor
+> scope a predicate to one of them. A table-qualified column over a multi-index `FROM` is therefore
+> rejected, whether it correlates the indices (a join in ANSI-89 clothing) or only looks like
+> scoping:
+>
+> ```sql
+> FROM orders o, customers c WHERE o.customer_id = c.id  -- rejected: a join
+> FROM orders, refunds WHERE orders.status = 'FAILED'    -- rejected: would filter refunds too
+> FROM logs-2025, logs-2024 WHERE level = 'ERROR'        -- fine: no qualifier
+> ```
 
 **Generates:**
 

--- a/documentation/sql/dml_statements.md
+++ b/documentation/sql/dml_statements.md
@@ -224,6 +224,14 @@ WHERE condition;
 - Only top-level scalar fields or entire nested objects can be replaced.
 - Updating a specific element inside an `ARRAY<STRUCT>` is not supported.
 - Fields not present in the mapping cannot be added unless dynamic mapping is enabled.
+- `UPDATE` targets exactly one table — the one named right after the `UPDATE` keyword. There is
+  no `FROM` clause; writing one is a parse error rather than being ignored:
+
+  ```text
+  UPDATE does not support a FROM clause (FROM customers): UPDATE targets exactly one table,
+  named right after the UPDATE keyword. Filter with WHERE, or pre-join the sources with a
+  MATERIALIZED VIEW.
+  ```
 
 ---
 
@@ -243,6 +251,19 @@ WHERE condition;
 	- If provided, only matching documents are deleted.
 	- If omitted, **all documents in the index are deleted** (equivalent to `TRUNCATE TABLE`).
 - Deleting a nested field or an element inside an array is not supported; only whole documents can be removed.
+- `DELETE` targets exactly one table. A table list or a `JOIN` is a parse error — precisely
+  because the omitted-`WHERE` rule above deletes everything, so a silently dropped clause is the
+  difference between removing one document and emptying the index:
+
+  ```sql
+  DELETE FROM orders, customers WHERE orders.id = 1  -- rejected: DELETE targets a single table
+  DELETE FROM orders JOIN customers ON orders.id = customers.id  -- rejected: JOIN is not supported in DELETE
+  ```
+
+  To delete across a relationship, `SELECT` the keys with a `JOIN` query first, then `DELETE` on
+  that key.
+- A table alias is allowed and is resolved in the `WHERE`: `DELETE FROM orders o WHERE o.status =
+  'FAILED'` filters on `status`.
 
 ---
 

--- a/documentation/sql/dql_statements.md
+++ b/documentation/sql/dql_statements.md
@@ -198,6 +198,9 @@ LIMIT 10 OFFSET 20;
 
 `UNION ALL` combines the results of multiple `SELECT` queries **without removing duplicates**.
 
+> Bare `UNION` (with row de-duplication) is **not supported** and is rejected at parse time — the
+> two are not synonyms. It used to be accepted silently, returning only the first leg's rows.
+
 All SELECT statements in a UNION ALL must be **strictly compatible**:
 
 - **same number of columns**

--- a/documentation/sql/joins.md
+++ b/documentation/sql/joins.md
@@ -329,6 +329,7 @@ For the full price matrix and editions, see the licensing & pricing page on the 
 
 - **Arbitrary subqueries and CTEs** inside a JOIN query — coming in **the next release (Quarter 4 2026)**.
 - **Heterogeneous Row-3 sources** (joining Elasticsearch with Postgres, MySQL, Snowflake, …) — coming in **the upcoming release (Quarter 1 2027)**; this release's Row 3 is multi-Elasticsearch only.
+- **JOIN inside a watcher input** (`CREATE WATCHER … FROM a JOIN b ON …`) — a watcher input is a single Elasticsearch `search` request over a list of indices, so the join is rejected at parse time. Pre-join the sources with a [materialized view](materialized_views.md) and have the watcher search the view.
 
 Full list: [Known limitations](known_limitations.md).
 

--- a/documentation/sql/materialized_views.md
+++ b/documentation/sql/materialized_views.md
@@ -417,8 +417,8 @@ CREATE TABLE IF NOT EXISTS customers (
 ### 2. Load data
 
 ```sql
-COPY INTO orders FROM '/data/orders.json' WITH (format = 'json');
-COPY INTO customers FROM '/data/customers.json' WITH (format = 'json');
+COPY INTO orders FROM '/data/orders.json' FILE_FORMAT = 'JSON';
+COPY INTO customers FROM '/data/customers.json' FILE_FORMAT = 'JSON';
 ```
 
 ### 3. Create the materialized view

--- a/documentation/sql/operators.md
+++ b/documentation/sql/operators.md
@@ -1453,10 +1453,12 @@ SELECT * FROM users
 WHERE first_name = 'John' OR last_name = 'Doe';
 -- May require full table scan
 
--- Alternative: UNION (if indexes exist)
+-- Alternative: UNION ALL (if indexes exist)
+-- Note: bare UNION (with de-duplication) is not supported and is rejected at
+-- parse time — a row matching BOTH predicates appears twice with UNION ALL.
 SELECT * FROM users WHERE first_name = 'John'
-UNION
-SELECT * FROM users WHERE last_name = 'Doe';
+UNION ALL
+SELECT * FROM users WHERE last_name = 'Doe' AND first_name <> 'John';
 ```
 
 ---

--- a/es6/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLCriteriaSpec.scala
+++ b/es6/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLCriteriaSpec.scala
@@ -903,4 +903,38 @@ class SQLCriteriaSpec extends AnyFlatSpec with Matchers {
         |""".stripMargin.replaceAll("\\s", "")
   }
 
+  /** #212 — a watcher search input flattens its FROM to bare index names, so an alias-qualified
+    * WHERE must be resolved or the emitted query names a field that exists in no index. This is the
+    * observable half of the ParserSpec assertions: what actually reaches Elasticsearch.
+    */
+  it should "emit the bare field name for an alias-qualified watcher search input" in {
+    implicit def timestamp: Long =
+      ZonedDateTime.parse("2025-12-31T00:00:00Z").toInstant.toEpochMilli
+    val criteria: Option[Criteria] = parser
+      .Parser("""CREATE OR REPLACE WATCHER my_watcher AS
+                | EVERY 5 MINUTES
+                | FROM orders o WHERE o.status = 'FAILED' WITHIN 2 MINUTES
+                | ALWAYS DO
+                | log_action AS LOG "x" AT INFO
+                | END""".stripMargin)
+      .toOption
+      .collect { case c: query.CreateWatcher => c.input }
+      .collect { case s: watcher.SearchWatcherInput => s.query }
+      .flatten
+    val result = SearchBodyBuilderFn(
+      SearchRequest("*") query criteria.map(_.asQuery()).getOrElse(matchAllQuery())
+    ).string
+    println(result)
+    result.replaceAll("\\s", "") shouldBe
+    """{
+        |"query":{
+        |  "bool":{"filter":[{"term":{
+        |    "status":{
+        |      "value":"FAILED"
+        |    }
+        |  }
+        |}
+        |]}}}""".stripMargin.replaceAll("\\s", "")
+  }
+
 }

--- a/es6/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLCriteriaSpec.scala
+++ b/es6/bridge/src/test/scala/app/softnetwork/elastic/sql/SQLCriteriaSpec.scala
@@ -2,6 +2,7 @@ package app.softnetwork.elastic.sql
 
 import app.softnetwork.elastic.sql.bridge._
 import app.softnetwork.elastic.sql.query.Criteria
+import com.fasterxml.jackson.databind.JsonNode
 import com.sksamuel.elastic4s.ElasticApi.matchAllQuery
 import com.sksamuel.elastic4s.http.search.SearchBodyBuilderFn
 import com.sksamuel.elastic4s.searches.SearchRequest
@@ -935,6 +936,31 @@ class SQLCriteriaSpec extends AnyFlatSpec with Matchers {
         |  }
         |}
         |]}}}""".stripMargin.replaceAll("\\s", "")
+  }
+
+  /** #211 + #212 together, through the real criteria conversion: building a watcher that carries a
+    * WHERE used to throw `ClassCastException` (value discard on the generic `ObjectNode.set`), and
+    * the alias-qualified column used to reach Elasticsearch as `o.status`, a field in no index.
+    */
+  it should "build the watcher JSON for an alias-qualified search input" in {
+    implicit def timestamp: Long =
+      ZonedDateTime.parse("2025-12-31T00:00:00Z").toInstant.toEpochMilli
+    implicit val toNode: Criteria => JsonNode = c => criteriaToNode(c)
+    val watcher = parser
+      .Parser("""CREATE OR REPLACE WATCHER my_watcher AS
+                | EVERY 5 MINUTES
+                | FROM orders o WHERE o.status = 'FAILED' WITHIN 2 MINUTES
+                | ALWAYS DO
+                | log_action AS LOG "x" AT INFO
+                | END""".stripMargin)
+      .toOption
+      .collect { case c: query.CreateWatcher => c.watcher }
+      .getOrElse(fail("expected a CreateWatcher"))
+    val json = watcher.node.toString
+    println(json)
+    json should include("\"indices\":[\"orders\"]")
+    json should include("\"term\":{\"status\":{\"value\":\"FAILED\"}}")
+    json should not include "o.status"
   }
 
 }

--- a/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestClientHelpers.scala
+++ b/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestClientHelpers.scala
@@ -23,9 +23,25 @@ import io.searchbox.client.JestResult
 
 import scala.concurrent.Promise
 import scala.reflect.ClassTag
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 trait JestClientHelpers extends ElasticClientHelpers { _: JestClientCompanion =>
+
+  /** `Try` with `LinkageError` folded in.
+    *
+    * `scala.util.control.NonFatal` — and therefore `Try` — does NOT cover `LinkageError`, yet
+    * `NoClassDefFoundError` is an observed failure mode in this repo (SoftClient4ES#168: the es6
+    * closure loses `org/apache/logging/log4j/LogManager`). Letting it escape would defeat the whole
+    * point of routing an action through a wrapper that returns failures as values. The other
+    * `VirtualMachineError`s still propagate: the JVM is already lost and swallowing them hides it.
+    */
+  private[client] final def tryAction[T](action: => T): Try[T] =
+    try Success(action)
+    catch {
+      case NonFatal(ex)     => Failure(ex)
+      case ex: LinkageError => Failure(ex)
+    }
 
   // ========================================================================
   // GENERIC METHODS FOR EXECUTIVE JEST ACTIONS
@@ -81,7 +97,7 @@ trait JestClientHelpers extends ElasticClientHelpers { _: JestClientCompanion =>
     logger.debug(s"Executing operation '$operation'$indexStr")
 
     // ✅ Execution with exception handling
-    val tryResult: Try[R] = Try {
+    val tryResult: Try[R] = tryAction {
       apply().execute(action)
     }
 
@@ -111,7 +127,7 @@ trait JestClientHelpers extends ElasticClientHelpers { _: JestClientCompanion =>
     elasticResult.flatMap { result =>
       if (result.isSucceeded) {
         // ✅ Success: applying the transformation
-        Try(transformer(result)) match {
+        tryAction(transformer(result)) match {
           case Success(transformed) =>
             logger.debug(s"Operation '$operation'$indexStr succeeded")
             ElasticResult.success(transformed)
@@ -321,64 +337,83 @@ trait JestClientHelpers extends ElasticClientHelpers { _: JestClientCompanion =>
 
     val promise: Promise[ElasticResult[T]] = Promise()
     import JestClientResultHandler._
-    apply().executeAsyncPromise(action) onComplete {
-      case Success(result) =>
-        if (result.isSucceeded) {
-          logger.debug(s"Operation '$operation'$indexStr succeeded asynchronously")
-          // ✅ Success: applying the transformation
-          Try(transformer(result)) match {
-            case Success(transformed) =>
-              promise.success(ElasticResult.success(transformed))
-            case Failure(ex) =>
-              logger.error(s"Transformation failed for operation '$operation'$indexStr", ex)
-              promise.success(
-                ElasticResult.failure(
-                  ElasticError(
-                    message = s"Failed to transform result: ${ex.getMessage}",
-                    cause = Some(ex),
-                    statusCode = Some(500),
-                    operation = Some(operation)
-                  )
-                )
-              )
-          }
-        } else {
-          // ✅ Failure: extract the error
-          val errorMessage = Option(result.getErrorMessage)
-            .filter(_.nonEmpty)
-            .getOrElse("Unknown error")
-          val statusCode = result.getResponseCode match {
-            case 0    => None // No HTTP response
-            case code => Some(code)
-          }
-          val error = ElasticError(
-            message = errorMessage,
-            cause = None,
-            statusCode = statusCode,
-            operation = Some(operation)
-          )
-          // ✅ Log according to severity
-          logError(operation, indexStr, error)
-          promise.success(ElasticResult.failure(error))
-        }
+    // Building the client (`apply()`) and submitting the action can throw *synchronously* — a bad
+    // scheme/host, or a LinkageError in a shaded jar. Outside a guard that throw escapes before
+    // the promise is completed, so the caller's Future never completes and the REPL hangs instead
+    // of reporting an error. Same hazard core's `statusOrServerError` documents.
+    tryAction(apply().executeAsyncPromise(action)) match {
       case Failure(ex) =>
         logger.error(s"Exception during operation '$operation'$indexStr: ${ex.getMessage}", ex)
-        val error = ElasticError(
-          message = s"Exception during $operation: ${ex.getMessage}",
-          cause = Some(ex),
-          // `JestClientResultHandler` turns a non-succeeded `JestResult` into an `ElasticError`
-          // carrying its `getResponseCode`, so the status survives the trip through this failed
-          // Future — core's default `statusOf` reads it back. A genuine transport failure is a
-          // plain IOException with no status and still yields `None`, which is honest and is what
-          // AD-5 requires here: Jest 6.3.1 exposes an HTTP status only on `JestResult`, never on a
-          // thrown exception. That is why there is deliberately NO `statusOf` override in this
-          // trait (SoftClient4ES#184, AD-6). Read through `Try` rather than `statusOrServerError`
-          // so the `None` is preserved, while still guaranteeing this `onComplete` callback cannot
-          // throw before `promise.success` below.
-          statusCode = Try(statusOf(ex)).toOption.flatten,
-          operation = Some(operation)
+        promise.success(
+          ElasticResult.failure(
+            ElasticError(
+              message = s"Exception during $operation: ${ex.getMessage}",
+              cause = Some(ex),
+              statusCode = None,
+              operation = Some(operation)
+            )
+          )
         )
-        promise.success(ElasticResult.failure(error))
+      case Success(future) =>
+        future onComplete {
+          case Success(result) =>
+            if (result.isSucceeded) {
+              logger.debug(s"Operation '$operation'$indexStr succeeded asynchronously")
+              // ✅ Success: applying the transformation
+              Try(transformer(result)) match {
+                case Success(transformed) =>
+                  promise.success(ElasticResult.success(transformed))
+                case Failure(ex) =>
+                  logger.error(s"Transformation failed for operation '$operation'$indexStr", ex)
+                  promise.success(
+                    ElasticResult.failure(
+                      ElasticError(
+                        message = s"Failed to transform result: ${ex.getMessage}",
+                        cause = Some(ex),
+                        statusCode = Some(500),
+                        operation = Some(operation)
+                      )
+                    )
+                  )
+              }
+            } else {
+              // ✅ Failure: extract the error
+              val errorMessage = Option(result.getErrorMessage)
+                .filter(_.nonEmpty)
+                .getOrElse("Unknown error")
+              val statusCode = result.getResponseCode match {
+                case 0    => None // No HTTP response
+                case code => Some(code)
+              }
+              val error = ElasticError(
+                message = errorMessage,
+                cause = None,
+                statusCode = statusCode,
+                operation = Some(operation)
+              )
+              // ✅ Log according to severity
+              logError(operation, indexStr, error)
+              promise.success(ElasticResult.failure(error))
+            }
+          case Failure(ex) =>
+            logger.error(s"Exception during operation '$operation'$indexStr: ${ex.getMessage}", ex)
+            val error = ElasticError(
+              message = s"Exception during $operation: ${ex.getMessage}",
+              cause = Some(ex),
+              // `JestClientResultHandler` turns a non-succeeded `JestResult` into an `ElasticError`
+              // carrying its `getResponseCode`, so the status survives the trip through this failed
+              // Future — core's default `statusOf` reads it back. A genuine transport failure is a
+              // plain IOException with no status and still yields `None`, which is honest and is what
+              // AD-5 requires here: Jest 6.3.1 exposes an HTTP status only on `JestResult`, never on a
+              // thrown exception. That is why there is deliberately NO `statusOf` override in this
+              // trait (SoftClient4ES#184, AD-6). Read through `Try` rather than `statusOrServerError`
+              // so the `None` is preserved, while still guaranteeing this `onComplete` callback cannot
+              // throw before `promise.success` below.
+              statusCode = Try(statusOf(ex)).toOption.flatten,
+              operation = Some(operation)
+            )
+            promise.success(ElasticResult.failure(error))
+        }
     }
 
     promise.future

--- a/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestClientHelpers.scala
+++ b/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestClientHelpers.scala
@@ -360,7 +360,10 @@ trait JestClientHelpers extends ElasticClientHelpers { _: JestClientCompanion =>
             if (result.isSucceeded) {
               logger.debug(s"Operation '$operation'$indexStr succeeded asynchronously")
               // ✅ Success: applying the transformation
-              Try(transformer(result)) match {
+              // `tryAction`, not `Try`: a LinkageError here would escape the callback without
+              // completing the promise, and the caller's Future would never complete — a hang
+              // rather than an error. That is the whole reason this callback exists.
+              tryAction(transformer(result)) match {
                 case Success(transformed) =>
                   promise.success(ElasticResult.success(transformed))
                 case Failure(ex) =>
@@ -406,10 +409,12 @@ trait JestClientHelpers extends ElasticClientHelpers { _: JestClientCompanion =>
               // plain IOException with no status and still yields `None`, which is honest and is what
               // AD-5 requires here: Jest 6.3.1 exposes an HTTP status only on `JestResult`, never on a
               // thrown exception. That is why there is deliberately NO `statusOf` override in this
-              // trait (SoftClient4ES#184, AD-6). Read through `Try` rather than `statusOrServerError`
-              // so the `None` is preserved, while still guaranteeing this `onComplete` callback cannot
-              // throw before `promise.success` below.
-              statusCode = Try(statusOf(ex)).toOption.flatten,
+              // trait (SoftClient4ES#184, AD-6). Read through `tryAction` rather than
+              // `statusOrServerError` so the `None` is preserved, while still guaranteeing this
+              // `onComplete` callback cannot throw before `promise.success` below — a `statusOf`
+              // override type-tests against client classes a shaded jar may have removed, and that
+              // is a LinkageError, which `Try` does not catch.
+              statusCode = tryAction(statusOf(ex)).toOption.flatten,
               operation = Some(operation)
             )
             promise.success(ElasticResult.failure(error))

--- a/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestLicenseApi.scala
+++ b/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestLicenseApi.scala
@@ -51,13 +51,27 @@ trait JestLicenseApi extends LicenseApi with JestClientHelpers {
 
   /** Activating a licence is not idempotent — `retryable = false` so a transient fault is reported
     * rather than replayed.
+    *
+    * The boolean is read from `<license>_was_started` in the body rather than from the HTTP status
+    * (SoftClient4ES#216). `executeJestBooleanAction` maps `_.isSucceeded`, but the transformer only
+    * runs when the result already succeeded, so it could return nothing but a constant `true`.
+    * Measured against Elasticsearch 8.18.3: a *state* refusal ("Current license is basic", "Trial
+    * was already activated") is an HTTP **403** and is therefore already a failure, but a refusal
+    * for want of acknowledgement is an HTTP **200** carrying `"basic_was_started": false` — and
+    * that is the response listing what the downgrade would disable, Watcher included. This client
+    * always sends `acknowledge=true`, so that case is not reachable today; reading the field costs
+    * nothing and stops it being one dropped parameter away from reporting a licence it never got.
     */
   private[this] def executeActivateLicense(license: String): ElasticResult[Boolean] =
-    executeJestBooleanAction[JestResult](
+    executeJestAction[JestResult, Boolean](
       operation = s"enable${license.capitalize}License",
       retryable = false
     )(
       new ActivateLicense.Builder(license = license, acknowledge = true).build
+    )(jestResult =>
+      Option(jestResult.getJsonObject)
+        .flatMap(json => Option(json.get(s"${license}_was_started")))
+        .exists(_.getAsBoolean)
     )
 
 }

--- a/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestLicenseApi.scala
+++ b/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestLicenseApi.scala
@@ -18,61 +18,46 @@ package app.softnetwork.elastic.client.jest
 
 import app.softnetwork.elastic.client.LicenseApi
 import app.softnetwork.elastic.client.jest.actions.{ActivateLicense, GetLicense}
-import app.softnetwork.elastic.client.result.{
-  ElasticError,
-  ElasticFailure,
-  ElasticResult,
-  ElasticSuccess
-}
+import app.softnetwork.elastic.client.result.ElasticResult
+import io.searchbox.client.JestResult
 
+/** All three operations route through [[JestClientHelpers.executeJestAction]] like the rest of the
+  * module. They used to call `apply().execute(...)` directly, so a network fault threw
+  * (`IOException` / `CouldNotConnectException`) instead of returning an `ElasticFailure` —
+  * `LicenseApi` documents no exception contract and consumers reasonably treat `ElasticResult` as
+  * total (SoftClient4ES#204). The wrapper also carries the HTTP status through and names the
+  * failing operation, which the hand-rolled message prefix could not.
+  */
 trait JestLicenseApi extends LicenseApi with JestClientHelpers {
   _: JestVersionApi with JestClientCompanion =>
 
-  override private[client] def executeLicenseInfo: ElasticResult[Option[String]] = {
-    apply().execute(new GetLicense.Builder().build) match {
-      case jestResult if jestResult.isSucceeded =>
-        val jsonString = jestResult.getJsonString
-        ElasticSuccess(Some(jsonString))
-      case jestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        ElasticFailure(
-          ElasticError(
-            s"Failed to fetch license info: $errorMessage"
-          )
-        )
-    }
-  }
+  override private[client] def executeLicenseInfo: ElasticResult[Option[String]] =
+    executeJestAction[JestResult, Option[String]](
+      operation = "licenseInfo",
+      retryable = true
+    )(
+      new GetLicense.Builder().build
+    )(
+      // `Option`, not `Some`: a succeeded JestResult can carry a null body, and callers — core's
+      // `enableBasicLicense` chains straight on to inspect the string — would NPE on `Some(null)`.
+      jestResult => Option(jestResult.getJsonString)
+    )
 
-  override private[client] def executeEnableBasicLicense(): ElasticResult[Boolean] = {
-    apply().execute(
-      new ActivateLicense.Builder(license = "basic", acknowledge = true).build
-    ) match {
-      case jestResult if jestResult.isSucceeded =>
-        ElasticSuccess(true)
-      case jestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        ElasticFailure(
-          ElasticError(
-            s"Failed to enable basic license: $errorMessage"
-          )
-        )
-    }
-  }
+  override private[client] def executeEnableBasicLicense(): ElasticResult[Boolean] =
+    executeActivateLicense("basic")
 
-  override private[client] def executeEnableTrialLicense(): ElasticResult[Boolean] = {
-    apply().execute(
-      new ActivateLicense.Builder(license = "trial", acknowledge = true).build
-    ) match {
-      case jestResult if jestResult.isSucceeded =>
-        ElasticSuccess(true)
-      case jestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        ElasticFailure(
-          ElasticError(
-            s"Failed to enable trial license: $errorMessage"
-          )
-        )
-    }
-  }
+  override private[client] def executeEnableTrialLicense(): ElasticResult[Boolean] =
+    executeActivateLicense("trial")
+
+  /** Activating a licence is not idempotent — `retryable = false` so a transient fault is reported
+    * rather than replayed.
+    */
+  private[this] def executeActivateLicense(license: String): ElasticResult[Boolean] =
+    executeJestBooleanAction[JestResult](
+      operation = s"enable${license.capitalize}License",
+      retryable = false
+    )(
+      new ActivateLicense.Builder(license = license, acknowledge = true).build
+    )
 
 }

--- a/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestPipelineApi.scala
+++ b/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestPipelineApi.scala
@@ -25,104 +25,91 @@ import io.searchbox.client.JestResult
 
 import scala.jdk.CollectionConverters._
 
+/** Every operation routes through [[JestClientHelpers.executeJestAction]]. They used to call
+  * `apply().execute(...)` directly, so a network fault threw instead of returning an
+  * `ElasticFailure` (SoftClient4ES#215, the same defect as #204 in the licence API). The wrapper
+  * also carries the HTTP status, names the failing operation, and guards the response-parsing
+  * transformers — several of which navigate the JSON with `get(...)` and could NPE.
+  *
+  * The absent-pipeline contract is unchanged: `Pipeline.Get` marks 404 as *succeeded* with no body,
+  * so a missing pipeline still reaches the transformer and yields `None` rather than a failure.
+  */
 trait JestPipelineApi extends PipelineApi with JestClientHelpers {
   _: JestVersionApi with JestClientCompanion =>
 
   override private[client] def executeCreatePipeline(
     pipelineName: String,
     pipelineDefinition: String
-  ): result.ElasticResult[Boolean] = {
+  ): result.ElasticResult[Boolean] =
     // There is no direct API to create a pipeline in Jest.
-    apply().execute(Pipeline.Create(pipelineName, pipelineDefinition)) match {
-      case jestResult: JestResult if jestResult.isSucceeded =>
-        result.ElasticSuccess(true)
-      case jestResult: JestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        result.ElasticFailure(
-          result.ElasticError(
-            s"Failed to create pipeline '$pipelineName': $errorMessage"
-          )
-        )
+    executeJestBooleanAction[JestResult](
+      operation = "createPipeline",
+      retryable = false // Creation can not be retried
+    ) {
+      Pipeline.Create(pipelineName, pipelineDefinition)
     }
-  }
 
   override private[client] def executeDeletePipeline(
     pipelineName: String,
     ifExists: Boolean
-  ): result.ElasticResult[Boolean] = {
+  ): result.ElasticResult[Boolean] =
     // There is no direct API to delete a pipeline in Jest.
-    apply().execute(Pipeline.Delete(pipelineName)) match {
-      case jestResult: JestResult if jestResult.isSucceeded =>
-        result.ElasticSuccess(true)
-      case jestResult: JestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        result.ElasticFailure(
-          result.ElasticError(
-            s"Failed to delete pipeline '$pipelineName': $errorMessage"
-          )
-        )
+    executeJestBooleanAction[JestResult](
+      operation = "deletePipeline",
+      retryable = false // Deletion can not be retried
+    ) {
+      Pipeline.Delete(pipelineName)
     }
-  }
 
   override private[client] def executeGetPipeline(
     pipelineName: String
-  ): result.ElasticResult[Option[String]] = {
+  ): result.ElasticResult[Option[String]] =
     // There is no direct API to get a pipeline in Jest.
-    apply().execute(Pipeline.Get(pipelineName)) match {
-      case jestResult: JestResult if jestResult.isSucceeded =>
-        val jsonString = jestResult.getJsonString
-        if (jsonString != null && jsonString.nonEmpty) {
-          val node: JsonNode = jsonString
-          node match {
-            case objectNode: ObjectNode if objectNode.has(pipelineName) =>
-              val pipelineNode = objectNode.get(pipelineName)
-              result.ElasticSuccess(Some(pipelineNode))
-            case _ =>
-              result.ElasticSuccess(None)
-          }
-        } else {
-          result.ElasticSuccess(None)
+    executeJestAction[JestResult, Option[String]](
+      operation = "getPipeline",
+      retryable = true
+    ) {
+      Pipeline.Get(pipelineName)
+    } { jestResult =>
+      val jsonString = jestResult.getJsonString
+      if (jsonString != null && jsonString.nonEmpty) {
+        val node: JsonNode = jsonString
+        node match {
+          case objectNode: ObjectNode if objectNode.has(pipelineName) =>
+            Some(objectNode.get(pipelineName))
+          case _ =>
+            None
         }
-      case jestResult: JestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        result.ElasticFailure(
-          result.ElasticError(
-            s"Failed to get pipeline '$pipelineName': $errorMessage"
-          )
-        )
+      } else {
+        None
+      }
     }
-  }
 
   override private[client] def executeListPipelines(): result.ElasticResult[Map[String, String]] =
     // There is no direct API to list pipelines in Jest.
-    apply().execute(Pipeline.List()) match {
-      case jestResult: JestResult if jestResult.isSucceeded =>
-        val jsonString = jestResult.getJsonString
-        if (jsonString != null && jsonString.nonEmpty) {
-          val node: JsonNode = jsonString
-          node match {
-            case objectNode: ObjectNode =>
-              val pipelines = objectNode
-                .fieldNames()
-                .asScala
-                .map { name =>
-                  val pipelineNode = objectNode.get(name)
-                  name -> pipelineNode.toString
-                }
-                .toMap
-              result.ElasticSuccess(pipelines)
-            case _ =>
-              result.ElasticSuccess(Map.empty)
-          }
-        } else {
-          result.ElasticSuccess(Map.empty)
+    executeJestAction[JestResult, Map[String, String]](
+      operation = "listPipelines",
+      retryable = true
+    ) {
+      Pipeline.List()
+    } { jestResult =>
+      val jsonString = jestResult.getJsonString
+      if (jsonString != null && jsonString.nonEmpty) {
+        val node: JsonNode = jsonString
+        node match {
+          case objectNode: ObjectNode =>
+            objectNode
+              .fieldNames()
+              .asScala
+              .map { name =>
+                name -> objectNode.get(name).toString
+              }
+              .toMap
+          case _ =>
+            Map.empty[String, String]
         }
-      case jestResult: JestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        result.ElasticFailure(
-          result.ElasticError(
-            s"Failed to list pipelines: $errorMessage"
-          )
-        )
+      } else {
+        Map.empty[String, String]
+      }
     }
 }

--- a/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestTemplateApi.scala
+++ b/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestTemplateApi.scala
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import io.searchbox.client.JestResult
 
 import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success}
 
 trait JestTemplateApi extends TemplateApi with JestClientHelpers {
   _: JestVersionApi with JestClientCompanion =>
@@ -97,19 +98,13 @@ trait JestTemplateApi extends TemplateApi with JestClientHelpers {
   override private[client] def executeCreateLegacyTemplate(
     templateName: String,
     templateDefinition: String
-  ): ElasticResult[Boolean] = {
-    apply().execute(Template.Create(templateName, templateDefinition)) match {
-      case jestResult: JestResult if jestResult.isSucceeded =>
-        ElasticSuccess(true)
-      case jestResult: JestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        ElasticFailure(
-          ElasticError(
-            s"Failed to create template '$templateName': $errorMessage"
-          )
-        )
+  ): ElasticResult[Boolean] =
+    executeJestBooleanAction[JestResult](
+      operation = "createLegacyTemplate",
+      retryable = false // Creation can not be retried
+    ) {
+      Template.Create(templateName, templateDefinition)
     }
-  }
 
   override private[client] def executeDeleteLegacyTemplate(
     templateName: String,
@@ -126,89 +121,105 @@ trait JestTemplateApi extends TemplateApi with JestClientHelpers {
           return failure
       }
     }
-    apply().execute(Template.Delete(templateName)) match {
-      case jestResult: JestResult if jestResult.isSucceeded =>
-        ElasticSuccess(true)
-      case jestResult: JestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        ElasticFailure(
-          ElasticError(
-            s"Failed to delete template '$templateName': $errorMessage"
-          )
-        )
+    executeJestBooleanAction[JestResult](
+      operation = "deleteLegacyTemplate",
+      retryable = false // Deletion can not be retried
+    ) {
+      Template.Delete(templateName)
     }
   }
 
   override private[client] def executeGetLegacyTemplate(
     templateName: String
-  ): ElasticResult[Option[String]] = {
-    apply().execute(Template.Get(templateName)) match {
-      case jestResult: JestResult if jestResult.isSucceeded =>
-        val jsonString = jestResult.getJsonString
-        if (jsonString != null && jsonString.nonEmpty) {
-          val node: JsonNode = jsonString
-          node match {
-            case objectNode: ObjectNode if objectNode.has(templateName) =>
-              val templateNode = objectNode.get(templateName)
-              ElasticSuccess(Some(templateNode))
-            case _ =>
-              ElasticSuccess(None)
-          }
-        } else {
-          ElasticSuccess(None)
+  ): ElasticResult[Option[String]] =
+    executeJestAction[JestResult, Option[String]](
+      operation = "getLegacyTemplate",
+      retryable = true
+    ) {
+      Template.Get(templateName)
+    } { jestResult =>
+      val jsonString = jestResult.getJsonString
+      if (jsonString != null && jsonString.nonEmpty) {
+        val node: JsonNode = jsonString
+        node match {
+          case objectNode: ObjectNode if objectNode.has(templateName) =>
+            Some(objectNode.get(templateName))
+          case _ =>
+            None
         }
-      case jestResult: JestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        ElasticFailure(
-          ElasticError(
-            s"Failed to get template '$templateName': $errorMessage"
-          )
-        )
+      } else {
+        None
+      }
     }
-  }
 
-  override private[client] def executeListLegacyTemplates(): ElasticResult[Map[String, String]] = {
-    apply().execute(Template.GetAll()) match {
-      case jestResult: JestResult if jestResult.isSucceeded =>
-        val jsonString = jestResult.getJsonString
-        if (jsonString != null && jsonString.nonEmpty) {
-          val node: JsonNode = jsonString
-          node match {
-            case objectNode: ObjectNode =>
-              val templates = objectNode
-                .fields()
-                .asScala
-                .map { entry =>
-                  entry.getKey -> entry.getValue.toString
-                }
-                .toMap
-              ElasticSuccess(templates)
-            case _ =>
-              ElasticSuccess(Map.empty[String, String])
-          }
-        } else {
-          ElasticSuccess(Map.empty[String, String])
+  override private[client] def executeListLegacyTemplates(): ElasticResult[Map[String, String]] =
+    executeJestAction[JestResult, Map[String, String]](
+      operation = "listLegacyTemplates",
+      retryable = true
+    ) {
+      Template.GetAll()
+    } { jestResult =>
+      val jsonString = jestResult.getJsonString
+      if (jsonString != null && jsonString.nonEmpty) {
+        val node: JsonNode = jsonString
+        node match {
+          case objectNode: ObjectNode =>
+            objectNode
+              .fields()
+              .asScala
+              .map { entry =>
+                entry.getKey -> entry.getValue.toString
+              }
+              .toMap
+          case _ =>
+            Map.empty[String, String]
         }
-      case jestResult: JestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        ElasticFailure(
-          ElasticError(
-            s"Failed to list templates: $errorMessage"
-          )
-        )
+      } else {
+        Map.empty[String, String]
+      }
     }
-  }
 
+  /** Deliberately NOT routed through `executeJestAction`: an existence probe answers "no" with a
+    * 404, and the wrapper would turn that into an `ElasticFailure` — which
+    * `executeDeleteLegacyTemplate(ifExists = true)` propagates, so `DROP … IF EXISTS` would start
+    * failing on the very case it exists to tolerate. `tryAction` supplies the half that #215 is
+    * about (a network fault becomes a value, not a throw) while any HTTP response stays a success
+    * carrying the boolean.
+    */
   override private[client] def executeLegacyTemplateExists(
     templateName: String
-  ): ElasticResult[Boolean] = {
-    apply().execute(Template.Exists(templateName)) match {
-      case jestResult: JestResult =>
-        val statusCode = jestResult.getResponseCode
-        ElasticSuccess(statusCode == 200)
-      case _ =>
+  ): ElasticResult[Boolean] =
+    tryAction(apply().execute(Template.Exists(templateName))) match {
+      case Success(jestResult) if jestResult.getResponseCode == 200 =>
+        ElasticSuccess(true)
+      case Success(jestResult) if jestResult.getResponseCode == 404 =>
         ElasticSuccess(false)
+      case Success(jestResult) =>
+        // Only 200 and 404 are answers to "does it exist". Anything else — 503 from an
+        // unavailable cluster, 401, a proxy's 502 — was previously read as `false`, so
+        // `DROP … IF EXISTS` reported success while the template was still there. An outage is
+        // not an absence.
+        val statusCode = jestResult.getResponseCode
+        ElasticFailure(
+          ElasticError(
+            message = Option(jestResult.getErrorMessage)
+              .filter(_.nonEmpty)
+              .getOrElse(s"Unexpected status $statusCode probing template '$templateName'"),
+            cause = None,
+            statusCode = if (statusCode == 0) None else Some(statusCode),
+            operation = Some("legacyTemplateExists")
+          )
+        )
+      case Failure(ex) =>
+        logger.error(s"Exception during templateExists for '$templateName': ${ex.getMessage}", ex)
+        ElasticFailure(
+          ElasticError(
+            message = s"Exception during legacyTemplateExists: ${ex.getMessage}",
+            cause = Some(ex),
+            statusCode = None,
+            operation = Some("legacyTemplateExists")
+          )
+        )
     }
-  }
 
 }

--- a/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestWatcherApi.scala
+++ b/es6/jest/src/main/scala/app/softnetwork/elastic/client/jest/JestWatcherApi.scala
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import io.searchbox.client.JestResult
 
 import java.time.ZonedDateTime
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 trait JestWatcherApi extends WatcherApi with JestClientHelpers {
   _: JestVersionApi with JestClientCompanion =>
@@ -58,10 +58,15 @@ trait JestWatcherApi extends WatcherApi with JestClientHelpers {
       })
       .node
     logger.info(s"Creating Watcher ${watcher.id} :\n${sanitizeWatcherJson(json)}")
-    apply().execute(JestWatcher.Create(watcher.id, json)) match {
-      case jestResult: JestResult if jestResult.isSucceeded =>
+    // Kept on the explicit shape rather than `executeJestBooleanAction` so the response-body
+    // diagnostic below survives — `logError` records the message and status but not the body, and
+    // watcher creation is the path extensions#49 was chased down. `tryAction` still supplies what
+    // #215 is about: a network fault becomes an ElasticFailure instead of a throw, and the status
+    // now reaches the caller rather than only the log.
+    tryAction(apply().execute(JestWatcher.Create(watcher.id, json))) match {
+      case Success(jestResult) if jestResult.isSucceeded =>
         result.ElasticSuccess(true)
-      case jestResult: JestResult =>
+      case Success(jestResult) =>
         val errorMessage = jestResult.getErrorMessage
         // FIXME: diagnostic logging for CI watcher creation failures — remove once root cause is identified
         val responseBody = Option(jestResult.getJsonString).getOrElse("")
@@ -72,135 +77,142 @@ trait JestWatcherApi extends WatcherApi with JestClientHelpers {
         // end FIXME
         result.ElasticFailure(
           result.ElasticError(
-            s"Failed to create watcher '${watcher.id}': $errorMessage"
+            message = s"Failed to create watcher '${watcher.id}': $errorMessage",
+            cause = None,
+            statusCode = if (statusCode == 0) None else Some(statusCode),
+            operation = Some("createWatcher")
+          )
+        )
+      case Failure(ex) =>
+        logger.error(
+          s"Exception during createWatcher '${watcher.id}': ${ex.getMessage}",
+          ex
+        )
+        result.ElasticFailure(
+          result.ElasticError(
+            message = s"Exception during createWatcher: ${ex.getMessage}",
+            cause = Some(ex),
+            statusCode = None,
+            operation = Some("createWatcher")
           )
         )
     }
   }
 
-  override private[client] def executeDeleteWatcher(id: String): result.ElasticResult[Boolean] = {
+  override private[client] def executeDeleteWatcher(id: String): result.ElasticResult[Boolean] =
     // There is no direct API to delete a watcher in Jest.
-    apply().execute(JestWatcher.Delete(id)) match {
-      case jestResult: JestResult if jestResult.isSucceeded =>
-        result.ElasticSuccess(true)
-      case jestResult: JestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        result.ElasticFailure(
-          result.ElasticError(
-            s"Failed to delete watcher '$id': $errorMessage"
-          )
-        )
+    executeJestBooleanAction[JestResult](
+      operation = "deleteWatcher",
+      retryable = false // Deletion can not be retried
+    ) {
+      JestWatcher.Delete(id)
     }
-  }
 
   override private[client] def executeGetWatcherStatus(
     id: String
-  ): result.ElasticResult[Option[WatcherStatus]] = {
+  ): result.ElasticResult[Option[WatcherStatus]] =
     // There is no direct API to get a watcher in Jest.
-    apply().execute(JestWatcher.Get(id)) match {
-      case jestResult: JestResult if jestResult.isSucceeded =>
-        val jsonString = jestResult.getJsonString
-        if (jsonString != null && jsonString.nonEmpty) {
-          val node: JsonNode = jsonString
-          node match {
-            case watcherNode: ObjectNode
-                if watcherNode.has("found") && watcherNode.get("found").asBoolean() =>
-              // extract interval
-              val interval: Option[TransformTimeInterval] =
-                if (watcherNode.has("watch")) {
-                  val watchNode = watcherNode.get("watch")
-                  val triggerNode = watchNode.get("trigger")
-                  if (triggerNode.has("schedule")) {
-                    val scheduleNode = triggerNode.get("schedule")
-                    if (scheduleNode.has("cron")) {
-                      val cron = scheduleNode.get("cron").asText()
-                      logger.info(s"Watcher $id has cron schedule: $cron")
-                      CronIntervalCalculator.validateAndCalculate(cron) match {
-                        case Right(interval) =>
-                          val tuple = TransformTimeInterval.fromSeconds(interval._2)
-                          Some(
-                            Delay(
-                              timeUnit = tuple._1,
-                              interval = tuple._2
-                            )
+    // The transformer walks the response with bare `get(...)` calls; routing through the wrapper
+    // means a shape it does not expect becomes an ElasticFailure rather than an NPE escaping the
+    // ElasticResult protocol.
+    executeJestAction[JestResult, Option[WatcherStatus]](
+      operation = "getWatcherStatus",
+      retryable = true
+    ) {
+      JestWatcher.Get(id)
+    } { jestResult =>
+      val jsonString = jestResult.getJsonString
+      if (jsonString != null && jsonString.nonEmpty) {
+        val node: JsonNode = jsonString
+        node match {
+          case watcherNode: ObjectNode
+              if watcherNode.has("found") && watcherNode.get("found").asBoolean() =>
+            // extract interval
+            val interval: Option[TransformTimeInterval] =
+              if (watcherNode.has("watch")) {
+                val watchNode = watcherNode.get("watch")
+                val triggerNode = watchNode.get("trigger")
+                if (triggerNode.has("schedule")) {
+                  val scheduleNode = triggerNode.get("schedule")
+                  if (scheduleNode.has("cron")) {
+                    val cron = scheduleNode.get("cron").asText()
+                    logger.info(s"Watcher $id has cron schedule: $cron")
+                    CronIntervalCalculator.validateAndCalculate(cron) match {
+                      case Right(interval) =>
+                        val tuple = TransformTimeInterval.fromSeconds(interval._2)
+                        Some(
+                          Delay(
+                            timeUnit = tuple._1,
+                            interval = tuple._2
                           )
-                        case _ =>
-                          logger.warn(
-                            s"Watcher [$id] has invalid cron expression: $cron"
-                          )
-                          None
-                      }
-                    } else if (scheduleNode.has("interval")) {
-                      val interval = scheduleNode.get("interval").asText()
-                      logger.info(s"Watcher $id has interval schedule: $interval")
-                      TransformTimeInterval(interval) match {
-                        case Some(ti) => Some(ti)
-                        case _ =>
-                          logger.warn(
-                            s"Watcher [$id] has invalid interval: $interval"
-                          )
-                          None
-                      }
-                    } else {
-                      logger.info(s"Watcher $id has unknown schedule")
-                      None
+                        )
+                      case _ =>
+                        logger.warn(
+                          s"Watcher [$id] has invalid cron expression: $cron"
+                        )
+                        None
+                    }
+                  } else if (scheduleNode.has("interval")) {
+                    val interval = scheduleNode.get("interval").asText()
+                    logger.info(s"Watcher $id has interval schedule: $interval")
+                    TransformTimeInterval(interval) match {
+                      case Some(ti) => Some(ti)
+                      case _ =>
+                        logger.warn(
+                          s"Watcher [$id] has invalid interval: $interval"
+                        )
+                        None
                     }
                   } else {
-                    logger.info(s"Watcher $id has no schedule")
+                    logger.info(s"Watcher $id has unknown schedule")
                     None
                   }
                 } else {
-                  logger.info(s"Watcher $id has no watch node")
+                  logger.info(s"Watcher $id has no schedule")
                   None
                 }
-
-              interval match {
-                case None =>
-                  logger.warn(s"Watcher [$id] does not have a valid schedule interval")
-                case Some(t) => // valid interval
-                  logger.info(s"Watcher [$id] has schedule interval: $t")
+              } else {
+                logger.info(s"Watcher $id has no watch node")
+                None
               }
 
-              // extract status
-              val statusNode = watcherNode.get("status")
-              val version = statusNode.get("version").asLong()
-              statusNode.get("state") match {
-                case stateNode: ObjectNode if stateNode.has("active") =>
-                  val active = stateNode.get("active").asBoolean()
-                  val updatedTime = stateNode.get("timestamp").asText()
-                  val timestamp =
-                    Try(ZonedDateTime.parse(updatedTime)).toOption.getOrElse(ZonedDateTime.now())
-                  result.ElasticSuccess(
-                    Some(
-                      WatcherStatus(
-                        id = id,
-                        version = version,
-                        activationState = WatcherActivationState(
-                          active = active,
-                          timestamp = timestamp
-                        ),
-                        interval = interval
-                      )
-                    )
+            interval match {
+              case None =>
+                logger.warn(s"Watcher [$id] does not have a valid schedule interval")
+              case Some(t) => // valid interval
+                logger.info(s"Watcher [$id] has schedule interval: $t")
+            }
+
+            // extract status
+            val statusNode = watcherNode.get("status")
+            val version = statusNode.get("version").asLong()
+            statusNode.get("state") match {
+              case stateNode: ObjectNode if stateNode.has("active") =>
+                val active = stateNode.get("active").asBoolean()
+                val updatedTime = stateNode.get("timestamp").asText()
+                val timestamp =
+                  Try(ZonedDateTime.parse(updatedTime)).toOption.getOrElse(ZonedDateTime.now())
+                Some(
+                  WatcherStatus(
+                    id = id,
+                    version = version,
+                    activationState = WatcherActivationState(
+                      active = active,
+                      timestamp = timestamp
+                    ),
+                    interval = interval
                   )
-                case _ => // do nothing
-                  result.ElasticSuccess(None)
-              }
-            case _ =>
-              result.ElasticSuccess(None)
-          }
-        } else {
-          result.ElasticSuccess(None)
+                )
+              case _ => // do nothing
+                None
+            }
+          case _ =>
+            None
         }
-      case jestResult: JestResult =>
-        val errorMessage = jestResult.getErrorMessage
-        result.ElasticFailure(
-          result.ElasticError(
-            s"Failed to get watcher '$id': $errorMessage"
-          )
-        )
+      } else {
+        None
+      }
     }
-  }
 
   override private[client] def executeListWatchers(): result.ElasticResult[Seq[WatcherStatus]] =
     ElasticFailure(

--- a/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestLicenseApiFaultSpec.scala
+++ b/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestLicenseApiFaultSpec.scala
@@ -17,12 +17,16 @@
 package app.softnetwork.elastic.client
 
 import app.softnetwork.elastic.client.jest.JestClientHelpers
+import app.softnetwork.elastic.client.result.ElasticSuccess
 import app.softnetwork.elastic.client.spi.JestClientSpi
+import app.softnetwork.elastic.sql.watcher.Watcher
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.net.ServerSocket
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+
+import java.net.{InetSocketAddress, ServerSocket}
 import scala.util.Failure
 
 /** SoftClient4ES#204 — `JestLicenseApi` called `apply().execute(...)` directly instead of routing
@@ -32,8 +36,8 @@ import scala.util.Failure
   * own `enableBasicLicense`, which chains `licenseInfo` first — treat `ElasticResult` as total.
   *
   * No Docker: the point is precisely that nothing is listening. The port is obtained by opening a
-  * `ServerSocket` on an ephemeral port and closing it, so the number is real and free rather than
-  * a guess that some other process might occupy.
+  * `ServerSocket` on an ephemeral port and closing it, so the number is real and free rather than a
+  * guess that some other process might occupy.
   */
 class JestLicenseApiFaultSpec extends AnyFlatSpec with Matchers {
 
@@ -71,6 +75,160 @@ class JestLicenseApiFaultSpec extends AnyFlatSpec with Matchers {
     result.isFailure shouldBe true
   }
 
+  // ── SoftClient4ES#215 — the same defect in the Pipeline, Template and Watcher APIs ──
+  //
+  // #204 called `executeLicenseInfo` "the odd man out" and said every other jest API already
+  // routed through the wrapper. It did not: twelve more sites called `apply().execute(...)`
+  // directly. `JestWatcherApi` is the one that stings — extensions calls it on the
+  // materialized-view deployment path, which is the scenario #204 was found under.
+
+  "createPipeline against an unreachable cluster" should "return a failure, not throw" in {
+    clientOnDeadEndpoint.createPipeline("p", "{}").isFailure shouldBe true
+  }
+
+  "deletePipeline against an unreachable cluster" should "return a failure, not throw" in {
+    clientOnDeadEndpoint.deletePipeline("p", ifExists = false).isFailure shouldBe true
+  }
+
+  "getPipeline against an unreachable cluster" should "return a failure, not throw" in {
+    clientOnDeadEndpoint.getPipeline("p").isFailure shouldBe true
+  }
+
+  "pipelines against an unreachable cluster" should "return a failure, not throw" in {
+    clientOnDeadEndpoint.pipelines().isFailure shouldBe true
+  }
+
+  "createTemplate against an unreachable cluster" should "return a failure, not throw" in {
+    clientOnDeadEndpoint.createTemplate("t", "{}").isFailure shouldBe true
+  }
+
+  "getTemplate against an unreachable cluster" should "return a failure, not throw" in {
+    clientOnDeadEndpoint.getTemplate("t").isFailure shouldBe true
+  }
+
+  "listTemplates against an unreachable cluster" should "return a failure, not throw" in {
+    clientOnDeadEndpoint.listTemplates().isFailure shouldBe true
+  }
+
+  /** `templateExists` is the one method deliberately left off `executeJestAction`: it must keep
+    * answering "no" with a *success* carrying `false` when Elasticsearch 404s, or `DROP … IF
+    * EXISTS` would fail on the case it exists to tolerate. A transport fault is still a failure —
+    * that distinction is the whole point.
+    */
+  "templateExists against an unreachable cluster" should "return a failure, not throw" in {
+    // The public entry point probes the cluster version first to choose composable vs legacy, so
+    // the failure legitimately surfaces from there; `executeLegacyTemplateExists` below pins the
+    // converted method itself.
+    clientOnDeadEndpoint.templateExists("t").isFailure shouldBe true
+  }
+
+  "executeLegacyTemplateExists against an unreachable cluster" should "return a failure, not throw" in {
+    val result = clientOnDeadEndpoint.executeLegacyTemplateExists("t")
+    result.isFailure shouldBe true
+    result.error.map(_.operation) shouldBe Some(Some("legacyTemplateExists"))
+  }
+
+  "deleteTemplate with ifExists against an unreachable cluster" should "return a failure, not throw" in {
+    // Goes through templateExists first — a transport fault there must surface, not be read as
+    // "the template is absent, nothing to do".
+    clientOnDeadEndpoint.deleteTemplate("t", ifExists = true).isFailure shouldBe true
+  }
+
+  "deleteWatcher against an unreachable cluster" should "return a failure, not throw" in {
+    clientOnDeadEndpoint.deleteWatcher("w").isFailure shouldBe true
+  }
+
+  "getWatcherStatus against an unreachable cluster" should "return a failure, not throw" in {
+    clientOnDeadEndpoint.getWatcherStatus("w").isFailure shouldBe true
+  }
+
+  "createWatcher against an unreachable cluster" should "return a failure, not throw" in {
+    val result = clientOnDeadEndpoint.createWatcher(Watcher(id = "w"))
+    result.isFailure shouldBe true
+    result.error.map(_.operation) shouldBe Some(Some("createWatcher"))
+  }
+
+  /** `templateExists` answers a question, so it must distinguish "no" from "I could not ask". A 404
+    * is an answer and stays `ElasticSuccess(false)` — `DROP … IF EXISTS` propagates any failure, so
+    * making the 404 a failure would break the case that clause exists to tolerate. Any other status
+    * is *not* an answer: reporting a 503 as "absent" made `DROP … IF EXISTS` claim success while
+    * the template was still there.
+    *
+    * Served by an in-JVM `HttpServer` rather than Docker — the point is the status code, not
+    * Elasticsearch.
+    */
+  private def withStubCluster[T](status: Int)(f: ElasticClientApi => T): T = {
+    val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext(
+      "/",
+      new HttpHandler {
+        override def handle(exchange: HttpExchange): Unit = {
+          exchange.sendResponseHeaders(status, -1L)
+          exchange.close()
+        }
+      }
+    )
+    server.start()
+    try {
+      val conf = ConfigFactory.parseString(
+        s"""elastic {
+           |  credentials { scheme = "http", host = "127.0.0.1", port = ${server.getAddress.getPort} }
+           |  connection-timeout = 2 s
+           |  socket-timeout = 2 s
+           |}""".stripMargin
+      )
+      f(new JestClientSpi().client(conf))
+    } finally server.stop(0)
+  }
+
+  "executeLegacyTemplateExists" should "report a 404 as an absent template, not a failure" in {
+    withStubCluster(404) { client =>
+      client.executeLegacyTemplateExists("t") shouldBe ElasticSuccess(false)
+    }
+  }
+
+  it should "report a 200 as a present template" in {
+    withStubCluster(200) { client =>
+      client.executeLegacyTemplateExists("t") shouldBe ElasticSuccess(true)
+    }
+  }
+
+  it should "report a 503 as a failure rather than as an absent template" in {
+    withStubCluster(503) { client =>
+      val result = client.executeLegacyTemplateExists("t")
+      result.isFailure shouldBe true
+      result.error.flatMap(_.statusCode) shouldBe Some(503)
+    }
+  }
+
+  /** The corollary: `DROP … IF EXISTS` must not swallow an outage as "nothing to drop". */
+  "executeDeleteLegacyTemplate with ifExists" should "fail on a 503 rather than report success" in {
+    withStubCluster(503) { client =>
+      client.executeDeleteLegacyTemplate("t", ifExists = true).isFailure shouldBe true
+    }
+  }
+
+  it should "report no-op on a 404" in {
+    withStubCluster(404) { client =>
+      client.executeDeleteLegacyTemplate("t", ifExists = true) shouldBe ElasticSuccess(false)
+    }
+  }
+
+  /** The absent-resource contract the wrapper conversion had to preserve: these actions mark 404 as
+    * *succeeded* with no body, so a missing resource is `None` / empty, never a failure.
+    */
+  "getPipeline on a 404" should "yield None rather than a failure" in {
+    withStubCluster(404) { client =>
+      client.executeGetPipeline("p") shouldBe ElasticSuccess(None)
+    }
+  }
+
+  "getWatcherStatus on a 404" should "yield None rather than a failure" in {
+    withStubCluster(404) { client =>
+      client.executeGetWatcherStatus("w") shouldBe ElasticSuccess(None)
+    }
+  }
+
   /** The connection-refused cases above are `NonFatal`, so they would pass with a plain `Try` and
     * prove nothing about the half of the fix the issue actually spelled out: `NonFatal` does NOT
     * cover `LinkageError`, yet `NoClassDefFoundError` is an observed failure mode in the es6
@@ -84,6 +242,8 @@ class JestLicenseApiFaultSpec extends AnyFlatSpec with Matchers {
 
   it should "still let a VirtualMachineError through — the JVM is already lost" in {
     val helper = new JestClientSpi().client(ConfigFactory.empty()).asInstanceOf[JestClientHelpers]
-    an[OutOfMemoryError] should be thrownBy helper.tryAction[Int](throw new OutOfMemoryError("boom"))
+    an[OutOfMemoryError] should be thrownBy helper.tryAction[Int](
+      throw new OutOfMemoryError("boom")
+    )
   }
 }

--- a/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestLicenseApiFaultSpec.scala
+++ b/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestLicenseApiFaultSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 SOFTNETWORK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.softnetwork.elastic.client
+
+import app.softnetwork.elastic.client.jest.JestClientHelpers
+import app.softnetwork.elastic.client.spi.JestClientSpi
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.net.ServerSocket
+import scala.util.Failure
+
+/** SoftClient4ES#204 — `JestLicenseApi` called `apply().execute(...)` directly instead of routing
+  * through the module's Try-wrapping `executeJestAction`, so a network fault during `GET _license`
+  * **threw** (`IOException` / `CouldNotConnectException`) rather than returning an
+  * `ElasticFailure`. `LicenseApi` documents no exception contract and consumers — including core's
+  * own `enableBasicLicense`, which chains `licenseInfo` first — treat `ElasticResult` as total.
+  *
+  * No Docker: the point is precisely that nothing is listening. The port is obtained by opening a
+  * `ServerSocket` on an ephemeral port and closing it, so the number is real and free rather than
+  * a guess that some other process might occupy.
+  */
+class JestLicenseApiFaultSpec extends AnyFlatSpec with Matchers {
+
+  private def closedPort: Int = {
+    val socket = new ServerSocket(0)
+    val port = socket.getLocalPort
+    socket.close()
+    port
+  }
+
+  private def clientOnDeadEndpoint: ElasticClientApi = {
+    val conf: Config = ConfigFactory.parseString(
+      s"""elastic {
+         |  credentials { scheme = "http", host = "127.0.0.1", port = $closedPort }
+         |  connection-timeout = 250 ms
+         |  socket-timeout = 250 ms
+         |}""".stripMargin
+    )
+    new JestClientSpi().client(conf)
+  }
+
+  "licenseInfo against an unreachable cluster" should "return a failure, not throw" in {
+    val result = clientOnDeadEndpoint.licenseInfo
+    result.isFailure shouldBe true
+    result.error.map(_.operation) shouldBe Some(Some("licenseInfo"))
+  }
+
+  "enableBasicLicense against an unreachable cluster" should "return a failure, not throw" in {
+    val result = clientOnDeadEndpoint.enableBasicLicense()
+    result.isFailure shouldBe true
+  }
+
+  "enableTrialLicense against an unreachable cluster" should "return a failure, not throw" in {
+    val result = clientOnDeadEndpoint.enableTrialLicense()
+    result.isFailure shouldBe true
+  }
+
+  /** The connection-refused cases above are `NonFatal`, so they would pass with a plain `Try` and
+    * prove nothing about the half of the fix the issue actually spelled out: `NonFatal` does NOT
+    * cover `LinkageError`, yet `NoClassDefFoundError` is an observed failure mode in the es6
+    * closure (SoftClient4ES#168). This exercises `tryAction` directly.
+    */
+  "tryAction" should "convert a LinkageError into a Failure rather than let it escape" in {
+    val helper = new JestClientSpi().client(ConfigFactory.empty()).asInstanceOf[JestClientHelpers]
+    val error = new NoClassDefFoundError("org/apache/logging/log4j/LogManager")
+    helper.tryAction[Int](throw error) shouldBe Failure(error)
+  }
+
+  it should "still let a VirtualMachineError through — the JVM is already lost" in {
+    val helper = new JestClientSpi().client(ConfigFactory.empty()).asInstanceOf[JestClientHelpers]
+    an[OutOfMemoryError] should be thrownBy helper.tryAction[Int](throw new OutOfMemoryError("boom"))
+  }
+}

--- a/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestLicenseApiFaultSpec.scala
+++ b/es6/jest/src/test/scala/app/softnetwork/elastic/client/JestLicenseApiFaultSpec.scala
@@ -229,6 +229,74 @@ class JestLicenseApiFaultSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  /** SoftClient4ES#216 — the activation methods used to return a constant `true`:
+    * `executeJestBooleanAction` maps `_.isSucceeded`, but the transformer only runs when the result
+    * already succeeded. The boolean now comes from `<license>_was_started` in the body.
+    *
+    * The bodies below are the ones Elasticsearch 8.18.3 actually returned when probed. A *state*
+    * refusal is a 403 and was always a failure; the 200-with-`false` case is the acknowledgement
+    * refusal, whose body lists what the downgrade would disable.
+    */
+  private def withStubBody[T](status: Int, body: String)(f: ElasticClientApi => T): T = {
+    val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext(
+      "/",
+      new HttpHandler {
+        override def handle(exchange: HttpExchange): Unit = {
+          val bytes = body.getBytes("UTF-8")
+          exchange.getResponseHeaders.add("Content-Type", "application/json")
+          exchange.sendResponseHeaders(status, bytes.length.toLong)
+          exchange.getResponseBody.write(bytes)
+          exchange.close()
+        }
+      }
+    )
+    server.start()
+    try {
+      val conf = ConfigFactory.parseString(
+        s"""elastic {
+           |  credentials { scheme = "http", host = "127.0.0.1", port = ${server.getAddress.getPort} }
+           |  connection-timeout = 2 s
+           |  socket-timeout = 2 s
+           |}""".stripMargin
+      )
+      f(new JestClientSpi().client(conf))
+    } finally server.stop(0)
+  }
+
+  "enableBasicLicense" should "report true when the body says the licence was started" in {
+    withStubBody(200, """{"acknowledged":true,"basic_was_started":true}""") { client =>
+      client.executeEnableBasicLicense() shouldBe ElasticSuccess(true)
+    }
+  }
+
+  it should "report false on the acknowledgement refusal, which is an HTTP 200" in {
+    withStubBody(
+      200,
+      """{"acknowledged":false,"basic_was_started":false,"error_message":"Operation failed: Needs acknowledgement."}"""
+    ) { client =>
+      client.executeEnableBasicLicense() shouldBe ElasticSuccess(false)
+    }
+  }
+
+  "enableTrialLicense" should "report true when the body says the trial was started" in {
+    withStubBody(200, """{"acknowledged":true,"trial_was_started":true,"type":"trial"}""") {
+      client =>
+        client.executeEnableTrialLicense() shouldBe ElasticSuccess(true)
+    }
+  }
+
+  // The state refusals Elasticsearch answers with a 403 — already failures, asserted so the
+  // distinction from the 200-with-false case above stays pinned.
+  it should "report a failure on the 403 state refusal" in {
+    withStubBody(
+      403,
+      """{"acknowledged":true,"trial_was_started":false,"error_message":"Operation failed: Trial was already activated."}"""
+    ) { client =>
+      client.executeEnableTrialLicense().isFailure shouldBe true
+    }
+  }
+
   /** The connection-refused cases above are `NonFatal`, so they would pass with a plain `Try` and
     * prove nothing about the half of the fix the issue actually spelled out: `NonFatal` does NOT
     * cover `LinkageError`, yet `NoClassDefFoundError` is an observed failure mode in the es6

--- a/es6/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientApi.scala
+++ b/es6/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientApi.scala
@@ -2368,7 +2368,10 @@ trait RestHighLevelClientLicenseApi extends LicenseApi with RestHighLevelClientH
     )(
       executor = req => apply().license().startBasic(req, RequestOptions.DEFAULT)
     )(
-      transformer = resp => resp.isAcknowledged
+      // `isBasicStarted`, not `isAcknowledged`: a refusal for want of acknowledgement is an
+      // HTTP 200 whose `acknowledged` is false but whose meaning is "nothing was started"
+      // (SoftClient4ES#216). State refusals are 403 and already fail.
+      transformer = resp => resp.isBasicStarted
     )
   }
 
@@ -2381,7 +2384,7 @@ trait RestHighLevelClientLicenseApi extends LicenseApi with RestHighLevelClientH
     )(
       executor = req => apply().license().startTrial(req, RequestOptions.DEFAULT)
     )(
-      transformer = resp => resp.isAcknowledged
+      transformer = resp => resp.isTrialWasStarted
     )
   }
 }

--- a/es7/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientApi.scala
+++ b/es7/rest/src/main/scala/app/softnetwork/elastic/client/rest/RestHighLevelClientApi.scala
@@ -3115,7 +3115,10 @@ trait RestHighLevelClientLicenseApi extends LicenseApi with RestHighLevelClientH
     )(
       executor = req => apply().license().startBasic(req, RequestOptions.DEFAULT)
     )(
-      transformer = resp => resp.isAcknowledged
+      // `isBasicStarted`, not `isAcknowledged`: a refusal for want of acknowledgement is an
+      // HTTP 200 whose `acknowledged` is false but whose meaning is "nothing was started"
+      // (SoftClient4ES#216). State refusals are 403 and already fail.
+      transformer = resp => resp.isBasicStarted
     )
   }
 
@@ -3128,7 +3131,7 @@ trait RestHighLevelClientLicenseApi extends LicenseApi with RestHighLevelClientH
     )(
       executor = req => apply().license().startTrial(req, RequestOptions.DEFAULT)
     )(
-      transformer = resp => resp.isAcknowledged
+      transformer = resp => resp.isTrialWasStarted
     )
   }
 }

--- a/es8/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
+++ b/es8/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
@@ -2590,7 +2590,12 @@ trait JavaClientLicenseApi extends LicenseApi with JavaClientHelpers {
         .postStartBasic(
           PostStartBasicRequest.of(builder => builder.acknowledge(true))
         )
-    )(resp => resp.acknowledged())
+    )(
+      // `basicWasStarted`, not `acknowledged`: a refusal for want of acknowledgement is an
+      // HTTP 200 whose `acknowledged` is false but whose meaning is "nothing was started"
+      // (SoftClient4ES#216). State refusals are 403 and already fail.
+      resp => resp.basicWasStarted()
+    )
 
   override private[client] def executeEnableTrialLicense(): ElasticResult[Boolean] =
     executeJavaBooleanAction(
@@ -2603,5 +2608,5 @@ trait JavaClientLicenseApi extends LicenseApi with JavaClientHelpers {
         .postStartTrial(
           PostStartTrialRequest.of(builder => builder.acknowledge(true))
         )
-    )(resp => resp.acknowledged())
+    )(resp => resp.trialWasStarted())
 }

--- a/es9/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
+++ b/es9/java/src/main/scala/app/softnetwork/elastic/client/java/JavaClientApi.scala
@@ -2592,7 +2592,12 @@ trait JavaClientLicenseApi extends LicenseApi with JavaClientHelpers {
         .postStartBasic(
           PostStartBasicRequest.of(builder => builder.acknowledge(true))
         )
-    )(resp => resp.acknowledged())
+    )(
+      // `basicWasStarted`, not `acknowledged`: a refusal for want of acknowledgement is an
+      // HTTP 200 whose `acknowledged` is false but whose meaning is "nothing was started"
+      // (SoftClient4ES#216). State refusals are 403 and already fail.
+      resp => resp.basicWasStarted()
+    )
 
   override private[client] def executeEnableTrialLicense(): ElasticResult[Boolean] =
     executeJavaBooleanAction(
@@ -2605,5 +2610,5 @@ trait JavaClientLicenseApi extends LicenseApi with JavaClientHelpers {
         .postStartTrial(
           PostStartTrialRequest.of(builder => builder.acknowledge(true))
         )
-    )(resp => resp.acknowledged())
+    )(resp => resp.trialWasStarted())
 }

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/package.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/package.scala
@@ -1172,7 +1172,13 @@ package object sql {
         }
       val parts: Seq[String] = name.split("\\.").toSeq
       val tableAlias = parts.head
-      val table = request.tableAliases.find(t => t._2 == tableAlias).map(_._1)
+      // A qualifier needs something to qualify: `parts.head` is only a table alias when a column
+      // name follows it. Without the arity check a column that happens to share its table's name
+      // — `FROM status WHERE status = 'done'` — matched `tableAliases` and was rewritten to
+      // `parts.tail.mkString(".")`, i.e. the empty string, silently querying a nameless field.
+      val table =
+        if (parts.size > 1) request.tableAliases.find(t => t._2 == tableAlias).map(_._1)
+        else None
       if (table.nonEmpty) {
         request.unnestAliases.find(_._1 == tableAlias) match {
           case Some(tuple) if !nested =>

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/package.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/package.scala
@@ -835,7 +835,15 @@ package object sql {
 
   trait TokenRegex extends Token {
     def words: List[String] = List(sql)
-    lazy val regex: Regex = s"(?i)(${words.mkString("|")})\\b".r
+    // A literal space in a multi-word token (`GROUP BY`, `UNION ALL`, `IS NOT NULL`, …) matches
+    // one space and no other whitespace, so keyword-aligned SQL — `GROUP  BY`, or a newline
+    // between the words — missed the token. That used to be invisible: the production simply did
+    // not match and the rest of the statement was discarded. Now that `Parser.apply` requires the
+    // whole input to be consumed it would be a hard rejection of valid SQL, so accept any run of
+    // whitespace between the words. `\s+` cannot widen what matches otherwise: every alternative
+    // still has to match the same words in the same order.
+    lazy val regex: Regex =
+      s"(?i)(${words.map(_.replace(" ", "\\s+")).mkString("|")})\\b".r
   }
 
   trait Source extends Updateable {

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/parser/Parser.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/parser/Parser.scala
@@ -1189,8 +1189,32 @@ object Parser
         .map(_.split("--")(0).trim)
         .filterNot(w => w.isEmpty || w.startsWith("--"))
         .mkString(" ")
+        // Trailing statement terminators are idiomatic SQL and every caller that splits on `;`
+        // already drops them; keep tolerating them now that anything else left over is an error.
+        // A run rather than one, because tools that append `;` to SQL a user already terminated
+        // produce `;;`. Anchored, so a `;` inside a literal is out of reach — a literal always
+        // ends in its closing quote.
+        .replaceFirst("(?:;\\s*)+$", "")
+        .trim
     val reader = new PackratReader(new CharSequenceReader(normalizedQuery))
-    parse(statement, reader) match {
+    // `phrase`, not a bare `parse` (#213): a bare `parse` succeeds on the longest matching PREFIX
+    // and silently discards the rest, so the statement that ran was not the statement written.
+    // Measured before/after on this exact grammar:
+    //
+    //   DELETE FROM orders WHEREE id = 1     ran as DELETE FROM orders  -> emptied the index
+    //   DELETE FROM orders LIMIT 10          ran as DELETE FROM orders  -> emptied the index
+    //   UPDATE orders SET a = 1 LIMIT 10     updated every document
+    //   SELECT a FROM x UNION SELECT b ...   ran as SELECT a FROM x     (bare UNION is not the
+    //                                        UNION ALL token, so the whole second leg vanished)
+    //   SELECT * FROM t WHERE a IS  NOT  NULL  ran as SELECT * FROM t   (two spaces broke the
+    //                                        token match and the WHERE was dropped — fixed in
+    //                                        TokenRegex with \s+, and now loud here if it recurs)
+    //
+    // All of those are hard errors now. The per-statement guards added for #213 cover only the
+    // shapes someone enumerated; requiring the whole input to be consumed covers the rest. The
+    // one shape this cannot catch: `DELETE FROM orders customers` stays a valid single-table
+    // DELETE, because an alias without AS is standard SQL — pinned as such in ParserSpec.
+    parse(phrase(statement), reader) match {
       case NoSuccess(msg, _) =>
         Console.err.println(msg)
         Left(ParserError(msg))

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/parser/Parser.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/parser/Parser.scala
@@ -745,6 +745,34 @@ object Parser
       case None => None
     }
 
+  /** Resolve alias-qualified identifiers in a WHERE against its own FROM clause — `o.status`
+    * becomes `status`, tagged with `table = orders` — exactly as the SELECT path does. Any
+    * production that keeps the criteria while flattening the FROM to bare index names MUST run
+    * this: without it the alias is dropped from the index list but kept in the field name, and the
+    * query targets a field that exists in no index (#212).
+    *
+    * `Select(Nil)` keeps the throwaway request's SELECT pass a no-op — the default `Select()` is
+    * `SELECT *` — leaving `update()` to do its FROM and WHERE passes and nothing else. `update()`
+    * reaches the criteria through `map`, so a `Some` WHERE can never come back `None`; callers for
+    * which a lost WHERE would be destructive assert that anyway.
+    */
+  private def resolveWhere(f: From, w: Option[Where]): Option[Where] =
+    SingleSearch(select = Select(Nil), from = f, where = w).update().where
+
+  /** A single Elasticsearch search applies one query to every index it names, so a table-qualified
+    * predicate over a multi-index FROM asks for per-index scoping that cannot be honored — whether
+    * it correlates the indices (`WHERE o.id = c.order_id`, an ANSI-89 join, #191's defect in the
+    * older syntax) or merely scopes to one of them (`WHERE orders.status = 'F'`, which would
+    * silently filter `refunds` too).
+    *
+    * Testing for "any qualifier" rather than "qualifiers from two tables" is deliberate: the
+    * narrower test lets a correlation through whenever one side fails to resolve — a function
+    * argument (`WHERE o.id = LOWER(c.id)`), or a self-join through duplicate table names, where
+    * `From.tableAliases` is keyed by table name and keeps only the last alias.
+    */
+  private def qualifiedOverManyIndices(f: From, criteria: Option[Criteria]): Boolean =
+    f.tables.size > 1 && criteria.exists(_.referencedIdentifiers.exists(_.table.isDefined))
+
   // A watcher search input maps to Elasticsearch's `search` input, which knows nothing but a list
   // of indices — there is no join engine behind it. `from` parses `a JOIN b ON …` happily, so
   // without this guard the join is dropped and the watcher silently watches `a` alone (#191).
@@ -755,13 +783,25 @@ object Parser
     from ~ opt(where) ~ withinTimeout >> { case f ~ w ~ t =>
       f.joins match {
         case Nil =>
-          success(
-            SearchWatcherInput(
-              f.tables.map(_.name).distinct,
-              w.flatMap(_.criteria),
-              t
+          val criteria = resolveWhere(f, w).flatMap(_.criteria)
+          // `FROM a, b` stays a legitimate multi-index search; only a qualifier over it is
+          // unserviceable — see `qualifiedOverManyIndices`.
+          if (qualifiedOverManyIndices(f, criteria))
+            err(
+              s"A watcher input cannot qualify a column by table when it searches several " +
+              s"indices (${f.tables.map(_.name).mkString(", ")}): one Elasticsearch search " +
+              "applies one query to all of them, so it can neither join them nor scope a " +
+              "predicate to one. Watch a single index, drop the qualifiers, or pre-join the " +
+              "sources with a MATERIALIZED VIEW and watch the view."
             )
-          )
+          else
+            success(
+              SearchWatcherInput(
+                f.tables.map(_.name).distinct,
+                criteria,
+                t
+              )
+            )
         case joins =>
           err(
             s"JOIN is not supported in a watcher input (${joins.map(_.sql.trim).mkString(" ")}): " +
@@ -1070,20 +1110,70 @@ object Parser
       CopyInto(source.value, table, fileFormat = format, onConflict = conflict)
     }
 
-  /** UPDATE table SET col1 = v1, col2 = v2 [WHERE ...] */
+  /** UPDATE table SET col1 = v1, col2 = v2 [WHERE ...]
+    *
+    * UPDATE has no FROM clause. `opt(from)` is here only to catch one being written anyway —
+    * `Parser.apply` runs `parse`, not `phrase`, so an unconsumed `FROM customers JOIN x ON …` used
+    * to be discarded in silence and the UPDATE ran against the first table alone (#213). It catches
+    * both operand orders: written before the WHERE, `where.?` yields None and this fires.
+    */
   def update: PackratParser[Update] =
     (keyword("UPDATE") ~> ident) ~ (keyword("SET") ~> repsep(
       ident ~ "=" ~ (value | scriptValue),
       separator
-    )) ~ where.? ^^ { case table ~ assigns ~ w =>
-      val values = ListMap(assigns.map { case col ~ _ ~ v => col -> v }: _*)
-      Update(table, values, w)
+    )) ~ where.? ~ opt(from) >> { case table ~ assigns ~ w ~ extraFrom =>
+      extraFrom match {
+        case Some(f) =>
+          err(
+            s"UPDATE does not support a FROM clause (${f.sql.trim}): " +
+            "UPDATE targets exactly one table, named right after the UPDATE keyword. " +
+            "Filter with WHERE, or pre-join the sources with a MATERIALIZED VIEW."
+          )
+        case None =>
+          val values = ListMap(assigns.map { case col ~ _ ~ v => col -> v }: _*)
+          // UPDATE keeps only the bare table name, so its WHERE needs the same qualifier
+          // resolution DELETE and watcher inputs get — `WHERE orders.id = 1` must filter on `id`.
+          success(Update(table, values, resolveWhere(From(Seq(Table(table))), w)))
+      }
     }
 
-  /** DELETE FROM table [WHERE ...] */
+  /** DELETE FROM table [WHERE ...]
+    *
+    * Parses the full FROM shape — alias and joins included — rather than a bare `ident`, then
+    * rejects what DELETE cannot express. `Parser.apply` runs `parse`, not `phrase`, so everything
+    * past the first table name used to be discarded in silence: `DELETE FROM a, b WHERE …` became
+    * `DELETE FROM a` with **no** WHERE, which the client turns into `match_all` — wiping the whole
+    * index instead of the matching rows (#213).
+    */
   def delete: PackratParser[Delete] =
-    (keyword("DELETE") ~ keyword("FROM")) ~> ident ~ where.? ^^ { case table ~ w =>
-      Delete(Table(table), w)
+    (keyword("DELETE") ~ keyword("FROM")) ~> rep1sep(table, separator) ~ where.? >> {
+      case tables ~ w =>
+        tables.flatMap(_.joins) match {
+          case Nil if tables.size > 1 =>
+            err(
+              s"DELETE targets a single table, got ${tables.map(_.name).mkString(", ")}: " +
+              "issue one DELETE per table."
+            )
+          case Nil =>
+            resolveWhere(From(tables), w) match {
+              // Fail closed. A DELETE with no WHERE is `match_all`, so a WHERE lost in resolution
+              // would empty the index — the very outcome #213 is about. `update()` reaches the
+              // criteria through `map` and cannot drop it, which is exactly why this must stay
+              // loud rather than becoming a comment claiming it cannot happen.
+              case None if w.isDefined =>
+                err(
+                  s"Could not resolve the WHERE clause of DELETE FROM ${tables.head.name}: " +
+                  "refusing to run it as an unfiltered delete."
+                )
+              case resolved => success(Delete(tables.head, resolved))
+            }
+          case joins =>
+            err(
+              s"JOIN is not supported in DELETE (${joins.map(_.sql.trim).mkString(" ")}): " +
+              "Elasticsearch deletes by query over a single index. Select the ids to remove with " +
+              "a JOIN query first, then DELETE on that key."
+            )
+        }
     }
 
   def dmlStatement: PackratParser[DmlStatement] = insert | update | delete | copy

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/parser/Parser.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/parser/Parser.scala
@@ -1094,13 +1094,36 @@ object Parser
         }
     }
 
+  /** FILE_FORMAT [=] {PARQUET | JSON | JSON_ARRAY | DELTA_LAKE} — bare or quoted, `=` optional.
+    *
+    * `FILE_FORMAT = X` is the form every published example uses (documentation, help JSON — and
+    * `FileFormat.sql` itself renders it), yet the grammar only accepted the bare `FILE_FORMAT X`:
+    * under the pre-#213 prefix parse, `opt(fileFormat)` backtracked on the `=` and the clause —
+    * plus any ON CONFLICT after it — was discarded in silence, with format auto-detection masking
+    * the loss. A FILE_FORMAT followed by anything but a known format is a hard `err` for the same
+    * reason: backtracking here can only ever mean dropping what the user wrote.
+    */
   def fileFormat: PackratParser[FileFormat] =
-    (keyword("FILE_FORMAT") ~> (
+    (keyword("FILE_FORMAT") ~ opt("=")) ~> (
       (keyword("PARQUET") ^^^ Parquet) |
       (keyword("JSON_ARRAY") ^^^ JsonArray) |
       (keyword("JSON") ^^^ Json) |
-      (keyword("DELTA_LAKE") ^^^ Delta)
-    )) ^^ { ff => ff }
+      (keyword("DELTA_LAKE") ^^^ Delta) |
+      // Quoted format names (the form dml_statements.md documents) land here; so does anything
+      // unrecognised, which must err rather than backtrack into a silent drop.
+      ((literal ^^ (_.value) | ident) >> { name =>
+        name.toUpperCase(java.util.Locale.ROOT) match {
+          case "PARQUET"    => success(Parquet)
+          case "JSON_ARRAY" => success(JsonArray)
+          case "JSON"       => success(Json)
+          case "DELTA_LAKE" => success(Delta)
+          case other =>
+            err(
+              s"Unsupported FILE_FORMAT '$other': expected PARQUET, JSON, JSON_ARRAY or DELTA_LAKE"
+            )
+        }
+      })
+    )
 
   /** COPY INTO table FROM source */
   def copy: PackratParser[CopyInto] =
@@ -1180,15 +1203,48 @@ object Parser
 
   def statement: PackratParser[Statement] = ddlStatement | dqlStatement | dmlStatement
 
+  /** Strip `--` comments and collapse newlines OUTSIDE string literals only. The previous
+    * line-based normalizer (`split("\n").map(_.split("--")(0))`) was blind to quotes: it cut `WHERE
+    * code = 'AB--12'` at the `--`, severing the literal and failing a valid statement. Literal
+    * interiors — including their backslash escapes — are copied verbatim.
+    */
+  private def normalize(query: String): String = {
+    val out = new StringBuilder(query.length)
+    var quote: Char = 0
+    var i = 0
+    while (i < query.length) {
+      val c = query.charAt(i)
+      if (quote != 0) {
+        out.append(c)
+        if (c == '\\' && i + 1 < query.length) {
+          out.append(query.charAt(i + 1))
+          i += 1
+        } else if (c == quote) {
+          quote = 0
+        }
+        i += 1
+      } else if (c == '-' && i + 1 < query.length && query.charAt(i + 1) == '-') {
+        // comment runs to end of line; the newline itself is handled by the next iteration
+        while (i < query.length && query.charAt(i) != '\n') i += 1
+      } else {
+        c match {
+          case '\'' | '"' =>
+            quote = c
+            out.append(c)
+          case '\n' | '\r' => out.append(' ')
+          case _           => out.append(c)
+        }
+        i += 1
+      }
+    }
+    out.toString
+  }
+
   def apply(
     query: String
   ): Either[ParserError, Statement] = {
     val normalizedQuery =
-      query
-        .split("\n")
-        .map(_.split("--")(0).trim)
-        .filterNot(w => w.isEmpty || w.startsWith("--"))
-        .mkString(" ")
+      normalize(query)
         // Trailing statement terminators are idiomatic SQL and every caller that splits on `;`
         // already drops them; keep tolerating them now that anything else left over is an error.
         // A run rather than one, because tools that append `;` to SQL a user already terminated

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/parser/Parser.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/parser/Parser.scala
@@ -745,13 +745,30 @@ object Parser
       case None => None
     }
 
+  // A watcher search input maps to Elasticsearch's `search` input, which knows nothing but a list
+  // of indices — there is no join engine behind it. `from` parses `a JOIN b ON …` happily, so
+  // without this guard the join is dropped and the watcher silently watches `a` alone (#191).
+  // `err` (not `failure`) is deliberate: it short-circuits the enclosing alternatives instead of
+  // letting `watcherInput` fall through to `success(EmptyWatcherInput)` and report a position
+  // error that names neither JOIN nor the watcher.
   def searchInput: PackratParser[SearchWatcherInput] =
-    from ~ opt(where) ~ withinTimeout ^^ { case f ~ w ~ t =>
-      SearchWatcherInput(
-        f.tables.map(_.name).distinct,
-        w.flatMap(_.criteria),
-        t
-      )
+    from ~ opt(where) ~ withinTimeout >> { case f ~ w ~ t =>
+      f.joins match {
+        case Nil =>
+          success(
+            SearchWatcherInput(
+              f.tables.map(_.name).distinct,
+              w.flatMap(_.criteria),
+              t
+            )
+          )
+        case joins =>
+          err(
+            s"JOIN is not supported in a watcher input (${joins.map(_.sql.trim).mkString(" ")}): " +
+            "a watcher input can only search one or more indices (FROM index1, index2). " +
+            "Pre-join the sources with a MATERIALIZED VIEW and have the watcher search the view."
+          )
+      }
     }
 
   def httpInput: PackratParser[HttpInput] =

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/parser/type/package.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/parser/type/package.scala
@@ -38,11 +38,16 @@ package object `type` {
 
   trait TypeParser { self: Parser =>
 
+    /** Each branch is ONE atomic regex, quotes included. Splitting it into `"'" ~> content ~> "'"`
+      * lets RegexParsers skip whitespace between the opening quote and the content, so `' Bob'`
+      * silently parsed as `'Bob'` — the literal's interior must never be subject to whitespace
+      * skipping (COPY INTO paths, for one, contractually preserve it — see LocalPath).
+      */
     def literal: PackratParser[StringValue] =
-      (("\"" ~> """([^"\\]|\\.)*""".r <~ "\"") ^^ { str =>
-        StringValue(str.replace("\\\"", "\"").replace("\\\\", "\\"))
-      }) | (("'" ~> """([^'\\]|\\.)*""".r <~ "'") ^^ { str =>
-        StringValue(str.replace("\\'", "'").replace("\\\\", "\\"))
+      (""""([^"\\]|\\.)*"""".r ^^ { str =>
+        StringValue(str.substring(1, str.length - 1).replace("\\\"", "\"").replace("\\\\", "\\"))
+      }) | ("""'([^'\\]|\\.)*'""".r ^^ { str =>
+        StringValue(str.substring(1, str.length - 1).replace("\\'", "'").replace("\\\\", "\\"))
       })
 
     def long: PackratParser[LongValue] =

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/query/OrderBy.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/query/OrderBy.scala
@@ -36,7 +36,8 @@ case object NullsLast extends Expr("NULLS LAST") with NullOrdering
 case class FieldSort(
   field: Identifier,
   order: Option[SortOrder],
-  nullOrdering: Option[NullOrdering] = None
+  nullOrdering: Option[NullOrdering] = None,
+  bareTableAlias: Option[String] = None
 ) extends FunctionChain
     with Updateable {
   lazy val functions: List[Function] = field.functions
@@ -48,16 +49,26 @@ case class FieldSort(
   override def sql: String =
     s"${field.sql} $direction${nullOrdering.map(n => s" ${n.sql}").getOrElse("")}"
   override def update(request: SingleSearch): FieldSort = this.copy(
-    field = field.update(request)
+    field = field.update(request),
+    // `ORDER BY e` where `e` aliases a FROM table sorts on nothing (#159). It used to be caught
+    // downstream, because `Identifier.update` rewrote any bare name matching an alias to the
+    // empty string; that rewrite also broke a column legitimately sharing its table's name, so
+    // it is gone and the collision is recorded here, where the FROM aliases are still in scope.
+    bareTableAlias =
+      if (!field.name.contains('.') && request.tableAliases.exists(_._2 == field.name))
+        Some(field.name)
+      else
+        None
   )
-  // A sort identifier colliding with a table alias (e.g. `ORDER BY e` where `e`
-  // aliases a FROM table) leaves the alias-split with an empty column name —
-  // reject it instead of rendering a dangling qualifier (#159).
   override def validate(): Either[String, Unit] =
-    field.tableAlias match {
-      case Some(alias) if field.name.isEmpty || field.name.endsWith(".") =>
-        Left(s"Column name expected after table alias '$alias'")
-      case _ => super.validate()
+    bareTableAlias match {
+      case Some(alias) => Left(s"Column name expected after table alias '$alias'")
+      case None =>
+        field.tableAlias match {
+          case Some(alias) if field.name.isEmpty || field.name.endsWith(".") =>
+            Left(s"Column name expected after table alias '$alias'")
+          case _ => super.validate()
+        }
     }
   def isScriptSort: Boolean = functions.nonEmpty && !hasAggregation && field.fieldAlias.isEmpty
 

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/query/Where.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/query/Where.scala
@@ -39,6 +39,23 @@ sealed trait Criteria extends Updateable with PainlessScript {
     case _                               => Nil
   }
 
+  /** Every identifier this criteria names directly — both operands of an equality included.
+    * Distinct from [[dependencies]], which returns the identifiers reached *through* an
+    * identifier's functions and so is empty for a plain `a = 1`.
+    */
+  def referencedIdentifiers: Seq[Identifier] = this match {
+    case Predicate(left, _, right, _, _) =>
+      left.referencedIdentifiers ++ right.referencedIdentifiers
+    case e: Expression =>
+      e.identifier +: (e.maybeValue match {
+        case Some(id: Identifier) => Seq(id)
+        case _                    => Nil
+      })
+    case relation: ElasticRelation => relation.criteria.referencedIdentifiers
+    case m: MultiMatchCriteria     => m.identifiers
+    case _                         => Nil
+  }
+
   def nested: Boolean = false
 
   def nestedElement: Option[NestedElement]

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/query/package.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/query/package.scala
@@ -616,7 +616,10 @@ package object query {
     onConflict: Option[OnConflict] = None
   ) extends DmlStatement {
     override def sql: String = {
-      s"COPY INTO $targetTable FROM $source${asString(fileFormat)}${asString(onConflict)}"
+      // The grammar only accepts a quoted source literal, so render one — an unquoted path
+      // (`FROM /tmp/data.json`) is not valid SQL and cannot survive a re-parse.
+      val quoted = s"'${source.replace("\\", "\\\\").replace("'", "\\'")}'"
+      s"COPY INTO $targetTable FROM $quoted${asString(fileFormat)}${asString(onConflict)}"
     }
   }
 

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/schema/package.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/schema/package.scala
@@ -1969,6 +1969,11 @@ package object schema {
         val aliasesNode = mapper.createObjectNode()
         indexAliases.foreach { alias =>
           aliasesNode.set(alias.alias, alias.node)
+          // Same value-discard trap as #211: `foreach`'s `U` and `ObjectNode.set`'s `T` are both
+          // free, so together they infer `Nothing` and the call site gets a cast that throws.
+          // Without this `()`, every partitioned CREATE TABLE declaring an alias died with a
+          // ClassCastException before its template was sent.
+          ()
         }
         template.set("aliases", aliasesNode)
       }

--- a/sql/src/main/scala/app/softnetwork/elastic/sql/watcher/WatcherInput.scala
+++ b/sql/src/main/scala/app/softnetwork/elastic/sql/watcher/WatcherInput.scala
@@ -72,7 +72,13 @@ case class SearchWatcherInput(
 
     val body = mapper.createObjectNode()
     query match {
-      case Some(q) => body.set("query", implicitly[JsonNode](q))
+      // The trailing `()` is load-bearing. `ObjectNode.set` is `<T extends JsonNode> T set(…)`,
+      // and this `match` sits in statement position: without it, the other branch's `Unit` forces
+      // `T` to unify with `Unit`, scalac infers `Nothing` and emits a cast to `BoxedUnit`, so
+      // *every* watcher carrying a WHERE died with a ClassCastException before reaching ES (#211).
+      case Some(q) =>
+        body.set("query", implicitly[JsonNode](q))
+        ()
       case None =>
         val q = mapper.createObjectNode()
         val matchAll = mapper.createObjectNode()

--- a/sql/src/test/scala/app/softnetwork/elastic/sql/parser/ParserSpec.scala
+++ b/sql/src/test/scala/app/softnetwork/elastic/sql/parser/ParserSpec.scala
@@ -2835,6 +2835,54 @@ class ParserSpec extends AnyFlatSpec with Matchers {
 
   // The join guard runs in the continuation of `from ~ opt(where) ~ withinTimeout`, so the WHERE
   // has to keep flowing into the input on the accepted path.
+  /** The second instance of #211's value-discard trap, found sweeping the other node builders:
+    * `indexAliases.foreach { alias => aliasesNode.set(…) }` left both `foreach`'s `U` and
+    * `ObjectNode.set`'s `T` free, so they inferred `Nothing` together and the call site got a cast
+    * that threw. Every partitioned CREATE TABLE declaring an alias died with a ClassCastException
+    * before its template was sent — `GatewayApi.createIndexOrTemplate` is the production caller.
+    */
+  it should "build the index template of a partitioned table declaring an alias" in {
+    val sql =
+      """CREATE TABLE events (id KEYWORD, ts TIMESTAMP)
+        | PARTITION BY ts (DAY),
+        | OPTIONS (aliases = (events_all = (routing = "r")))""".stripMargin
+    val result = Parser(sql)
+    result.isRight shouldBe true
+    result.toOption.get match {
+      case create: CreateTable =>
+        val template = create.schema.indexTemplate.toString
+        template should include("\"index_patterns\":[\"events-*\"]")
+        template should include("\"aliases\":{\"events_all\":")
+      case other => fail(s"Expected CreateTable, got $other")
+    }
+  }
+
+  /** #211 — `ObjectNode.set` is `<T extends JsonNode> T set(…)`, and the `query` assignment sits in
+    * a `match` in statement position. The other branch's `Unit` used to force `T` to unify with
+    * `Unit`, so scalac inferred `Nothing` and emitted a cast to `BoxedUnit`: **every** watcher
+    * carrying a WHERE died with a `ClassCastException` before its JSON reached Elasticsearch. No
+    * previous watcher test used a WHERE, so `query` was always `None` and only the safe branch ran.
+    */
+  it should "build the watcher JSON for a search input with a WHERE clause" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM logs-2025 WHERE level = 'ERROR' WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    val result = Parser(sql)
+    result.isRight shouldBe true
+    result.toOption.get match {
+      case create: CreateWatcher =>
+        // `criteriaToNode` is stubbed to an empty object in this spec — the bridge specs assert
+        // the real query body. What matters here is that building it does not throw.
+        create.watcher.node.toString shouldBe
+          """{"trigger":{"schedule":{"interval":"5m"}},"input":{"search":{"request":{"indices":["logs-2025"],"body":{"query":{}}},"timeout":"2m"}},"condition":{"always":{}},"actions":{"log_action":{"logging":{"text":"Watcher triggered","level":"info"}}}}"""
+      case other => fail(s"Expected CreateWatcher, got $other")
+    }
+  }
+
   it should "parse a search input with a WHERE clause" in {
     val sql =
       """CREATE OR REPLACE WATCHER my_watcher AS

--- a/sql/src/test/scala/app/softnetwork/elastic/sql/parser/ParserSpec.scala
+++ b/sql/src/test/scala/app/softnetwork/elastic/sql/parser/ParserSpec.scala
@@ -2810,6 +2810,161 @@ class ParserSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  // --- #191: a watcher search input has no join engine behind it ---
+
+  it should "parse a search input over several indices" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM logs-2025, logs-2024 WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    val result = Parser(sql)
+    result.isRight shouldBe true
+    result.toOption.get match {
+      case create: CreateWatcher =>
+        create.input shouldBe SearchWatcherInput(
+          index = Seq("logs-2025", "logs-2024"),
+          query = None,
+          timeout = Some(Delay(TransformTimeUnit.Minutes, 2))
+        )
+      case other => fail(s"Expected CreateWatcher, got $other")
+    }
+  }
+
+  // The join guard runs in the continuation of `from ~ opt(where) ~ withinTimeout`, so the WHERE
+  // has to keep flowing into the input on the accepted path.
+  it should "parse a search input with a WHERE clause" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM logs-2025 WHERE level = 'ERROR' WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    val result = Parser(sql)
+    result.isRight shouldBe true
+    result.toOption.get match {
+      case create: CreateWatcher =>
+        create.input match {
+          case input: SearchWatcherInput =>
+            input.index shouldBe Seq("logs-2025")
+            input.query.map(_.sql) shouldBe Some("level = 'ERROR'")
+            input.timeout shouldBe Some(Delay(TransformTimeUnit.Minutes, 2))
+          case other => fail(s"Expected SearchWatcherInput, got $other")
+        }
+      case other => fail(s"Expected CreateWatcher, got $other")
+    }
+  }
+
+  /** The `FROM` of a watcher input parses through the same `from` production as a `SELECT`, so a
+    * `JOIN` used to parse and then be silently dropped — the watcher watched the first table only,
+    * with no error and no warning. Rejecting it is the contract until (if ever) it is implemented.
+    */
+  private val watcherJoinRejection = "JOIN is not supported in a watcher input"
+
+  it should "reject a JOIN in a watcher search input" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders o JOIN customers c ON o.customer_id = c.id WHERE o.status = 'FAILED' WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    val result = Parser(sql)
+    result.isLeft shouldBe true
+    val msg = result.swap.toOption.get.msg
+    msg should include(watcherJoinRejection)
+    msg should include("JOIN customers")
+    msg should include("MATERIALIZED VIEW")
+  }
+
+  it should "reject an outer JOIN in a CREATE WATCHER search input" in {
+    val sql =
+      """CREATE WATCHER IF NOT EXISTS my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders o LEFT JOIN customers c ON o.customer_id = c.id WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    val result = Parser(sql)
+    result.isLeft shouldBe true
+    result.swap.toOption.get.msg should include(watcherJoinRejection)
+  }
+
+  // The guard sits in the continuation of `from ~ opt(where) ~ withinTimeout`, so it must not
+  // depend on the two optional clauses being present — this is the barest shape that can carry a
+  // JOIN.
+  it should "reject a JOIN in a watcher search input with neither WHERE nor WITHIN" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders JOIN customers ON orders.customer_id = customers.id
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    val result = Parser(sql)
+    result.isLeft shouldBe true
+    result.swap.toOption.get.msg should include(watcherJoinRejection)
+  }
+
+  // CROSS JOIN is the one join type `Join.validate` accepts without an ON clause — the rejection
+  // must not be an accident of the missing ON.
+  it should "reject a CROSS JOIN in a watcher search input" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders CROSS JOIN customers WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    val result = Parser(sql)
+    result.isLeft shouldBe true
+    result.swap.toOption.get.msg should include("CROSS JOIN customers")
+  }
+
+  it should "report every join of a chain in a watcher search input" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM a JOIN b ON a.id = b.id JOIN c ON b.id = c.id WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    val result = Parser(sql)
+    result.isLeft shouldBe true
+    val msg = result.swap.toOption.get.msg
+    msg should include("JOIN b ON a.id = b.id")
+    msg should include("JOIN c ON b.id = c.id")
+  }
+
+  it should "reject an UNNEST in a watcher search input" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders JOIN UNNEST(orders.items) AS item WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    val result = Parser(sql)
+    result.isLeft shouldBe true
+    result.swap.toOption.get.msg should include(watcherJoinRejection)
+  }
+
+  it should "reject a JOIN in a chained watcher search input" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | WITH INPUTS search_data AS FROM orders o JOIN customers c ON o.customer_id = c.id WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    val result = Parser(sql)
+    result.isLeft shouldBe true
+    result.swap.toOption.get.msg should include(watcherJoinRejection)
+  }
+
   behavior of "Parser DDL with Enrich Statements"
 
   it should "parse CREATE ENRICH POLICY without WHERE clause" in {

--- a/sql/src/test/scala/app/softnetwork/elastic/sql/parser/ParserSpec.scala
+++ b/sql/src/test/scala/app/softnetwork/elastic/sql/parser/ParserSpec.scala
@@ -3618,6 +3618,117 @@ class ParserSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  // COPY INTO had ZERO parser-level coverage before these tests: the production was only ever
+  // exercised through the Docker integration suites, so nothing caught that `FILE_FORMAT = X` —
+  // the form used by every documented example and every integration test — never parsed. Under
+  // the pre-#213 prefix parse, `opt(fileFormat)` backtracked on the `=` and silently dropped the
+  // clause AND any ON CONFLICT after it (format auto-detection masked the loss); `phrase` turned
+  // that into a hard failure in CI, which is how this was found.
+
+  it should "parse COPY INTO with FILE_FORMAT = and ON CONFLICT DO UPDATE" in {
+    // The exact shape used by GatewayApiIntegrationSpec / ReplGatewayIntegrationSpec.
+    val sql =
+      """COPY INTO copy_into_test FROM "/tmp/data.json" FILE_FORMAT = JSON_ARRAY ON CONFLICT DO UPDATE"""
+    Parser(sql) shouldBe Right(
+      CopyInto("/tmp/data.json", "copy_into_test", Some(JsonArray), Some(OnConflict(None, true)))
+    )
+  }
+
+  it should "parse COPY INTO with a quoted FILE_FORMAT value" in {
+    // documentation/sql/dml_statements.md documents the quoted form: FILE_FORMAT = 'JSON'
+    val sql = "COPY INTO users FROM 's3://bucket/users.json' FILE_FORMAT = 'JSON'"
+    Parser(sql) shouldBe Right(
+      CopyInto("s3://bucket/users.json", "users", Some(Json), None)
+    )
+  }
+
+  it should "parse COPY INTO with FILE_FORMAT without the equals sign" in {
+    // The only form the old grammar accepted — must keep working.
+    val sql = "COPY INTO users FROM '/data/users.parquet' FILE_FORMAT PARQUET"
+    Parser(sql) shouldBe Right(
+      CopyInto("/data/users.parquet", "users", Some(Parquet), None)
+    )
+  }
+
+  it should "parse COPY INTO with a lowercase quoted FILE_FORMAT value" in {
+    val sql = "COPY INTO events FROM '/data/events' FILE_FORMAT = 'delta_lake'"
+    Parser(sql) shouldBe Right(
+      CopyInto("/data/events", "events", Some(Delta), None)
+    )
+  }
+
+  it should "parse COPY INTO with FILE_FORMAT and a conflict target" in {
+    // The CopyIntoS3IntegrationSpec shape.
+    val sql =
+      "COPY INTO scores FROM 's3://bucket/scores.json' FILE_FORMAT = JSON_ARRAY ON CONFLICT (uuid) DO UPDATE"
+    Parser(sql) shouldBe Right(
+      CopyInto(
+        "s3://bucket/scores.json",
+        "scores",
+        Some(JsonArray),
+        Some(OnConflict(Some(List("uuid")), true))
+      )
+    )
+  }
+
+  it should "parse COPY INTO without any optional clause" in {
+    val sql = """COPY INTO copy_into_test FROM "/tmp/data.jsonl""""
+    Parser(sql) shouldBe Right(CopyInto("/tmp/data.jsonl", "copy_into_test", None, None))
+  }
+
+  it should "reject an unsupported FILE_FORMAT loudly" in {
+    val result = Parser("COPY INTO users FROM '/data/users.csv' FILE_FORMAT = CSV")
+    result.isLeft shouldBe true
+    result.swap.toOption.get.msg should include("Unsupported FILE_FORMAT 'CSV'")
+  }
+
+  it should "re-parse the SQL a CopyInto renders" in {
+    // FileFormat.sql renders `FILE_FORMAT = NAME`; before the `=` was accepted the AST's own
+    // rendering did not survive a round-trip through the parser.
+    val stmt =
+      CopyInto("/tmp/data.json", "copy_into_test", Some(JsonArray), Some(OnConflict(None, true)))
+    Parser(stmt.sql) shouldBe Right(stmt)
+  }
+
+  it should "round-trip CopyInto sources that probe the normalizer and the literal parser" in {
+    // `--` in the path: the old line-based comment stripper cut the literal at the `--`.
+    // Leading whitespace: the old two-token literal parser silently skipped it after the
+    // opening quote, although LocalPath contractually preserves whitespace in COPY INTO paths.
+    Seq(
+      CopyInto("/data/export--2026.json", "t", Some(Json), None),
+      CopyInto(" /tmp/leading-space.json", "t", None, None),
+      CopyInto("\t/tmp/leading-tab.json", "t", None, None),
+      CopyInto("C:\\data\\x.json", "t", None, None)
+    ).foreach { stmt =>
+      Parser(stmt.sql) shouldBe Right(stmt)
+    }
+  }
+
+  // --- Normalization: comments and literals ---
+
+  behavior of "Parser normalization"
+
+  it should "not cut a string literal containing --" in {
+    val result = Parser("SELECT * FROM products WHERE code = 'AB--12'")
+    result.isRight shouldBe true
+    result.toOption.get.sql should include("'AB--12'")
+  }
+
+  it should "strip comments outside literals across multiple lines" in {
+    val sql =
+      """-- leading comment
+        |SELECT * FROM users -- trailing comment with an apostrophe: don't split
+        |WHERE id = 1
+        |""".stripMargin
+    Parser(sql) shouldBe Parser("SELECT * FROM users WHERE id = 1")
+  }
+
+  it should "preserve leading whitespace inside a string literal" in {
+    val result = Parser("SELECT * FROM users WHERE name = ' Bob'")
+    result.isRight shouldBe true
+    result.toOption.get.sql should include("' Bob'")
+  }
+
   it should "parse UPDATE" in {
     val sql = "UPDATE users SET name = 'Bob', age = 42 WHERE id = 1"
     val result = Parser(sql)

--- a/sql/src/test/scala/app/softnetwork/elastic/sql/parser/ParserSpec.scala
+++ b/sql/src/test/scala/app/softnetwork/elastic/sql/parser/ParserSpec.scala
@@ -4027,6 +4027,84 @@ class ParserSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  /** The other half of #213. The per-statement guards above only reject shapes someone enumerated;
+    * `Parser.apply` now requires the whole input to be consumed, which covers the rest. Each of
+    * these previously parsed as a prefix and ran with everything after it discarded — and on a
+    * DELETE, a discarded WHERE means `match_all`, i.e. the whole index.
+    */
+  it should "reject trailing input rather than silently discarding it" in {
+    val discarded = Seq(
+      // one letter off `WHERE`, so the alias regex's keyword lookahead misses it: `WHEREE` is
+      // taken as the table alias and `id = 1` used to be dropped, deleting every document
+      "DELETE FROM orders WHEREE id = 1",
+      "DELETE FROM orders LIMIT 10",
+      "DELETE FROM orders,",
+      "UPDATE orders SET a = 1 LIMIT 10",
+      "SELECT * FROM orders GARBAGE HERE"
+    )
+    discarded.foreach { sql =>
+      withClue(s"[$sql] ") {
+        Parser(sql).isLeft shouldBe true
+      }
+    }
+  }
+
+  /** `DELETE FROM orders customers` is NOT trailing junk and `phrase` rightly does not reject it:
+    * an alias without `AS` is standard SQL, so this is `DELETE FROM orders AS customers`. A missed
+    * comma therefore still reads as an alias — pinned here so the limit of the #213 fix is explicit
+    * rather than assumed.
+    */
+  it should "read a bare second word after a DELETE table as an alias, not a second table" in {
+    Parser("DELETE FROM orders customers").toOption.get match {
+      case d: Delete =>
+        d.table.name shouldBe "orders"
+        d.table.tableAlias.map(_.alias) shouldBe Some("customers")
+      case other => fail(s"Expected Delete, got $other")
+    }
+  }
+
+  it should "reject a trailing clause after the end of a watcher" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM a WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "x" AT INFO
+        | END JOIN b ON a.x = b.x""".stripMargin
+    Parser(sql).isLeft shouldBe true
+  }
+
+  /** Found by the `phrase` change. The union token is `Expr("UNION ALL")`, so a bare `UNION` never
+    * matched the separator: `rep1sep` stopped after the first leg and the rest was discarded, and
+    * the query silently returned **only the first leg's rows**. `UNION` and `UNION ALL` are not
+    * synonyms — one de-duplicates — so rejecting the unimplemented one is the honest answer.
+    */
+  it should "reject a bare UNION rather than silently returning the first leg" in {
+    Parser("SELECT a FROM x UNION SELECT b FROM y").isLeft shouldBe true
+    // the supported spelling still works — see "parse UNION ALL" above for the full assertion
+    Parser("SELECT a FROM x UNION ALL SELECT b FROM y").isRight shouldBe true
+  }
+
+  /** Multi-word tokens (`GROUP BY`, `IS NOT NULL`, `UNION ALL`, …) used to match exactly one space,
+    * so keyword-aligned SQL missed the token and — under the old lenient parse — the rest of the
+    * statement was silently dropped: `WHERE a IS NOT NULL` ran as a bare `SELECT * FROM t`, every
+    * row. `TokenRegex` now accepts any whitespace run between the words; with `phrase`, a future
+    * regression here fails loudly instead of dropping clauses.
+    */
+  it should "match multi-word tokens across any whitespace" in {
+    Parser("SELECT * FROM t WHERE a IS  NOT  NULL").isRight shouldBe true
+    Parser("SELECT COUNT(*) FROM t GROUP  BY a").isRight shouldBe true
+    Parser("SELECT a FROM x UNION  ALL SELECT b FROM y").isRight shouldBe true
+  }
+
+  // A single statement terminator stays idiomatic — the REPL already strips it, but JDBC/ADBC
+  // callers pass statements verbatim.
+  it should "still accept a single trailing semicolon" in {
+    Parser("SELECT * FROM orders WHERE status = 'FAILED';").isRight shouldBe true
+    Parser("DELETE FROM orders WHERE status = 'FAILED' ;").isRight shouldBe true
+    Parser("UPDATE orders SET a = 1 WHERE b = 2;").isRight shouldBe true
+  }
+
   behavior of "Parser Cluster"
 
   it should "parse SHOW CLUSTER NAME" in {

--- a/sql/src/test/scala/app/softnetwork/elastic/sql/parser/ParserSpec.scala
+++ b/sql/src/test/scala/app/softnetwork/elastic/sql/parser/ParserSpec.scala
@@ -2965,6 +2965,183 @@ class ParserSpec extends AnyFlatSpec with Matchers {
     result.swap.toOption.get.msg should include(watcherJoinRejection)
   }
 
+  // --- #212: the FROM aliases are flattened away, so the WHERE must not keep them ---
+
+  /** `f.tables.map(_.name)` drops the alias from the index list. If the criteria keeps the
+    * qualifier, the watcher queries `o.status` — a field that exists in no index — and silently
+    * never matches. `.sql` still renders the qualified form (it is the re-parseable round trip);
+    * `Identifier.name` is what the bridge turns into the ES field, so that is what these assert.
+    */
+  private def watcherCriteriaIdentifiers(sql: String): Seq[Identifier] = {
+    val result = Parser(sql)
+    result.isRight shouldBe true
+    result.toOption.get match {
+      case create: CreateWatcher =>
+        create.input match {
+          case input: SearchWatcherInput =>
+            input.query.map(_.referencedIdentifiers).getOrElse(Nil)
+          case other => fail(s"Expected SearchWatcherInput, got $other")
+        }
+      case other => fail(s"Expected CreateWatcher, got $other")
+    }
+  }
+
+  it should "resolve an alias-qualified WHERE in a watcher search input" in {
+    val identifiers = watcherCriteriaIdentifiers(
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders o WHERE o.status = 'FAILED' WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    )
+    identifiers.map(_.name) shouldBe Seq("status")
+    identifiers.map(_.table) shouldBe Seq(Some("orders"))
+  }
+
+  it should "resolve a table-qualified WHERE in a watcher search input" in {
+    val identifiers = watcherCriteriaIdentifiers(
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders WHERE orders.status = 'FAILED' WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    )
+    identifiers.map(_.name) shouldBe Seq("status")
+  }
+
+  // A dotted name whose head matches no table is a nested field, not a qualifier — it must
+  // survive untouched.
+  it should "leave a nested field path alone in a watcher search input" in {
+    val identifiers = watcherCriteriaIdentifiers(
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders WHERE items.price > 10 WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    )
+    identifiers.map(_.name) shouldBe Seq("items.price")
+    identifiers.map(_.table) shouldBe Seq(None)
+  }
+
+  /** One Elasticsearch search applies one query to every index it names, so any table-qualified
+    * predicate over a multi-index FROM is unserviceable — whether it correlates the indices (an
+    * ANSI-89 join, #191's defect in comma form) or merely scopes to one of them. Each of these
+    * shapes defeats a narrower "identifiers from two different tables" test.
+    */
+  private val multiIndexQualifierRejection =
+    "cannot qualify a column by table when it searches several indices"
+
+  it should "reject a WHERE that correlates two indices in a watcher search input" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders o, customers c WHERE o.customer_id = c.id WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    val result = Parser(sql)
+    result.isLeft shouldBe true
+    val msg = result.swap.toOption.get.msg
+    msg should include(multiIndexQualifierRejection)
+    msg should include("orders, customers")
+    msg should include("MATERIALIZED VIEW")
+  }
+
+  // Scoping a predicate to one of several indices is equally unserviceable: the predicate would
+  // silently be applied to the other index too.
+  it should "reject a WHERE qualified with a single index in a multi-index watcher input" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders, refunds WHERE orders.status = 'FAILED' WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    Parser(sql).swap.toOption.get.msg should include(multiIndexQualifierRejection)
+  }
+
+  // A correlation hidden in a function argument: only one operand resolves to a table, so a
+  // "two distinct tables" test would wave this through.
+  it should "reject a correlation wrapped in a function in a watcher search input" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders o, customers c WHERE o.id = LOWER(c.id) WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    Parser(sql).swap.toOption.get.msg should include(multiIndexQualifierRejection)
+  }
+
+  // A self-join through duplicate table names: `From.tableAliases` is keyed by table name and
+  // keeps only the last alias, so `o.id` never resolves and a "two distinct tables" test sees one.
+  it should "reject a self-correlation through duplicate table names in a watcher input" in {
+    val sql =
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders o, orders p WHERE o.id = p.parent_id WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    Parser(sql).swap.toOption.get.msg should include(multiIndexQualifierRejection)
+  }
+
+  /** The arity guard added to `Identifier.update` for this: a bare name matching a table used to be
+    * rewritten to the empty string, so a column sharing its index's name queried a nameless field.
+    * Unqualified names must survive resolution untouched.
+    */
+  it should "not mistake a column sharing its table's name for a qualifier" in {
+    val identifiers = watcherCriteriaIdentifiers(
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM status WHERE status = 'done' WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    )
+    identifiers.map(_.name) shouldBe Seq("status")
+  }
+
+  it should "not mistake a column sharing its table's alias for a qualifier" in {
+    val identifiers = watcherCriteriaIdentifiers(
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders o WHERE o = 1 WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    )
+    identifiers.map(_.name) shouldBe Seq("o")
+  }
+
+  // `FROM a, b` remains a legitimate multi-index search — only a WHERE spanning both is a join.
+  it should "accept a multi-index watcher search input whose WHERE spans neither table" in {
+    val identifiers = watcherCriteriaIdentifiers(
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM logs-2025, logs-2024 WHERE level = 'ERROR' WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    )
+    identifiers.map(_.name) shouldBe Seq("level")
+  }
+
+  it should "accept several predicates qualified with the same alias" in {
+    val identifiers = watcherCriteriaIdentifiers(
+      """CREATE OR REPLACE WATCHER my_watcher AS
+        | EVERY 5 MINUTES
+        | FROM orders o WHERE o.status = 'FAILED' AND o.total > 100 WITHIN 2 MINUTES
+        | ALWAYS DO
+        | log_action AS LOG "Watcher triggered" AT INFO
+        | END""".stripMargin
+    )
+    identifiers.map(_.name) shouldBe Seq("status", "total")
+  }
+
   behavior of "Parser DDL with Enrich Statements"
 
   it should "parse CREATE ENRICH POLICY without WHERE clause" in {
@@ -3694,6 +3871,112 @@ class ParserSpec extends AnyFlatSpec with Matchers {
     // INNER/LEFT/RIGHT/FULL JOIN still require ON — only the alias rule is relaxed.
     val sql = "SELECT * FROM orders LEFT JOIN customers"
     Parser(sql).isLeft shouldBe true
+  }
+
+  // --- #213: everything past the first table name used to be discarded in silence ---
+
+  /** The dangerous one. `DELETE FROM a, b WHERE …` parsed as `DELETE FROM a` with **no** WHERE,
+    * because `Parser.apply` runs `parse` rather than `phrase` and `delete` took a bare `ident`.
+    * `IndicesApi` then reads the missing WHERE as "delete everything" and issues `match_all` — the
+    * whole index, instead of the one matching row.
+    */
+  it should "reject a multi-table DELETE instead of silently dropping the WHERE" in {
+    val result = Parser("DELETE FROM orders, customers WHERE orders.id = 1")
+    result.isLeft shouldBe true
+    val msg = result.swap.toOption.get.msg
+    msg should include("DELETE targets a single table")
+    msg should include("orders, customers")
+  }
+
+  it should "reject a JOIN in a DELETE" in {
+    val result = Parser("DELETE FROM orders JOIN customers ON orders.id = customers.id")
+    result.isLeft shouldBe true
+    result.swap.toOption.get.msg should include("JOIN is not supported in DELETE")
+  }
+
+  it should "parse a DELETE with a table alias and resolve the alias in the WHERE" in {
+    // Previously the alias was left unconsumed, `where.?` matched nothing, and the statement
+    // deleted every document in the index.
+    val result = Parser("DELETE FROM orders o WHERE o.status = 'FAILED'")
+    result.isRight shouldBe true
+    result.toOption.get match {
+      case d: Delete =>
+        d.table.name shouldBe "orders"
+        d.where.flatMap(_.criteria).map(_.referencedIdentifiers.map(_.name)) shouldBe Some(
+          Seq("status")
+        )
+      case other => fail(s"Expected Delete, got $other")
+    }
+  }
+
+  it should "parse a plain DELETE unchanged" in {
+    val result = Parser("DELETE FROM orders WHERE status = 'FAILED'")
+    result.isRight shouldBe true
+    result.toOption.get match {
+      case d: Delete =>
+        d.table.name shouldBe "orders"
+        d.where.flatMap(_.criteria).map(_.sql) shouldBe Some("status = 'FAILED'")
+      case other => fail(s"Expected Delete, got $other")
+    }
+  }
+
+  it should "parse a DELETE without a WHERE unchanged" in {
+    val result = Parser("DELETE FROM orders")
+    result.isRight shouldBe true
+    result.toOption.get match {
+      case d: Delete =>
+        d.table.name shouldBe "orders"
+        d.where shouldBe None
+      case other => fail(s"Expected Delete, got $other")
+    }
+  }
+
+  // UPDATE has no FROM clause; one written anyway used to be discarded with everything after it.
+  it should "reject a FROM clause in an UPDATE" in {
+    val result = Parser("UPDATE orders SET a = 1 FROM customers JOIN x ON a.b = c.d")
+    result.isLeft shouldBe true
+    result.swap.toOption.get.msg should include("UPDATE does not support a FROM clause")
+  }
+
+  // Postgres puts FROM before WHERE — `where.?` yields None there, so the guard still fires.
+  it should "reject a FROM clause written before the WHERE in an UPDATE" in {
+    val result = Parser("UPDATE orders SET a = 1 FROM customers WHERE b = 2")
+    result.isLeft shouldBe true
+    result.swap.toOption.get.msg should include("UPDATE does not support a FROM clause")
+  }
+
+  it should "parse a plain UPDATE unchanged" in {
+    val result = Parser("UPDATE orders SET a = 1 WHERE b = 2")
+    result.isRight shouldBe true
+    result.toOption.get.sql shouldBe "UPDATE orders SET a = 1 WHERE b = 2"
+  }
+
+  // UPDATE keeps only the bare table name, so its WHERE needs the same qualifier resolution
+  // DELETE and watcher inputs get — otherwise it filters on `orders.id` and matches nothing.
+  it should "resolve a table-qualified WHERE in an UPDATE" in {
+    val result = Parser("UPDATE orders SET a = 1 WHERE orders.id = 2")
+    result.isRight shouldBe true
+    result.toOption.get match {
+      case u: Update =>
+        u.where.flatMap(_.criteria).map(_.referencedIdentifiers.map(_.name)) shouldBe Some(
+          Seq("id")
+        )
+      case other => fail(s"Expected Update, got $other")
+    }
+  }
+
+  // A column sharing its table's name is a column, not a dangling qualifier — the SELECT path
+  // used to rewrite it to the empty string too.
+  it should "not mistake a column sharing its table's name for a qualifier in a SELECT" in {
+    val result = Parser("SELECT * FROM status WHERE status = 'done'")
+    result.isRight shouldBe true
+    result.toOption.get match {
+      case s: SingleSearch =>
+        s.where.flatMap(_.criteria).map(_.referencedIdentifiers.map(_.name)) shouldBe Some(
+          Seq("status")
+        )
+      case other => fail(s"Expected SingleSearch, got $other")
+    }
   }
 
   behavior of "Parser Cluster"


### PR DESCRIPTION
Fixes #191, #204, #211, #212, #213, #215, #216.

Five defects in one family: a clause or a fault the code accepted, silently discarded or turned into a crash, and then acted on as if nothing had happened. Four were found reviewing the first.

---

## #191 — `CREATE WATCHER … FROM a JOIN b ON …` dropped the JOIN

`searchInput` built `SearchWatcherInput` from `f.tables.map(_.name).distinct` only, so **the watcher watched `a` alone — no error, no warning.** Before softclient4es-arrow R1FIX.6 this was masked by `JoinDetector.classify` mis-routing to the cross-index JOIN engine, which rejected it loudly (blaming "Federation", the wrong message). Correcting the routing turned a loudly-wrong error into a silent wrong answer.

Resolution: the issue's first option — reject. A watcher input maps to Elasticsearch's `search` input, a list of indices with no join engine behind it. `err` (not `failure`) is deliberate: `Error.append` returns `this`, so it short-circuits every enclosing alternative instead of falling through to `success(EmptyWatcherInput)` and reporting a position error naming neither JOIN nor the watcher.

Rejected: plain / `INNER` / `LEFT` / `CROSS JOIN` (the one type `Join.validate` allows without `ON`), join chains (**every** join named), `JOIN UNNEST(...)`, chained `WITH INPUTS`, and a join with neither `WHERE` nor `WITHIN` — pinning that the guard does not depend on the optional clauses.

## #212 — the same watcher input dropped table aliases but kept them in the WHERE

`FROM orders o WHERE o.status = 'FAILED'` emitted `{"term":{"o.status":…}}` — a field in no index — so the watcher silently never matched. A `resolveWhere` helper now runs the criteria through the SELECT path's own resolution; `DELETE` and `UPDATE`, which flatten their FROM the same way, use it too.

A qualifier over a **multi-index** FROM is rejected outright — one search applies one query to every index it names, so it can neither join them nor scope a predicate to one:

```sql
FROM orders o, customers c WHERE o.customer_id = c.id  -- rejected: a join in comma clothing
FROM orders, refunds WHERE orders.status = 'FAILED'    -- rejected: would filter refunds too
FROM logs-2025, logs-2024 WHERE level = 'ERROR'        -- fine: no qualifier
```

Testing for *any* qualifier rather than "qualifiers from two tables" is deliberate: the narrow test is defeated by a correlation wrapped in a function (only one side resolves) and by a self-join through duplicate table names (`From.tableAliases` keeps only the last alias). Both have tests.

## #213 — `DELETE FROM a, b WHERE …` wiped the whole index

`Parser.apply` runs `parse`, not `phrase`, so trailing input is discarded, and `delete` took a bare `ident`. `DELETE FROM orders, customers WHERE orders.id = 1` parsed as `Delete(Table("orders"), where = None)` — and `IndicesApi` reads a missing WHERE as "delete everything", issuing `match_all`. **The whole index, instead of one document.**

Implemented per the issue's **second** option rather than switching to `phrase`: `delete` parses the full FROM shape and rejects multi-table and join-bearing forms; `update` rejects a FROM clause it never supported, in either operand order. DELETE fails closed if resolution were ever to lose a WHERE. A table alias is now accepted and resolved — `DELETE FROM orders o WHERE o.status = 'FAILED'` previously left the alias unconsumed, matched no WHERE, and deleted every document.

**Both halves are now implemented.** `Parser.apply` uses `phrase`, so the whole input must be consumed — measured before/after:

| SQL as written | Before | After |
|---|---|---|
| `DELETE FROM orders WHEREE id = 1` | ran as `DELETE FROM orders` → **emptied the index** | rejected |
| `DELETE FROM orders LIMIT 10` | ran as `DELETE FROM orders` → **emptied the index** | rejected |
| `UPDATE orders SET a = 1 LIMIT 10` | **updated every document** | rejected |
| `SELECT a FROM x UNION SELECT b FROM y` | ran as `SELECT a FROM x` — second leg silently dropped | rejected |
| `SELECT * FROM t WHERE a IS  NOT  NULL` | **WHERE silently dropped** → all rows | accepted, WHERE honored |
| `SELECT * FROM t ORDER BY a OFFSET 5` | OFFSET silently ignored | rejected |
| `SELECT * FROM t;` / `;;` | accepted | accepted (unchanged) |
| `run("a; b")` via GatewayApi | ran only `a`, silently | runs both sequentially |
| `DELETE FROM orders customers` | alias parse | alias parse (unchanged — an alias without `AS` is standard SQL; pinned) |
| `COPY INTO t FROM 'f.json' FILE_FORMAT = JSON_ARRAY ON CONFLICT DO UPDATE` | **format AND upsert clause silently dropped** (auto-detection masked it) | both honored |
| `WHERE code = 'AB--12'` | literal cut at `--` by the comment stripper | literal preserved |
| `WHERE name = ' Bob'` | silently matched `'Bob'` (leading space skipped inside the quotes) | matches `' Bob'` |

Two latent defects this forced into the open, both previously silent: bare `UNION` never matched the `UNION ALL` token (the second leg vanished — now rejected, they are not synonyms), and multi-word tokens matched exactly one space, so keyword-aligned SQL dropped whole clauses (`TokenRegex` now accepts any whitespace run).

## #211 — every watcher with a `WHERE` crashed before reaching Elasticsearch

`ObjectNode.set` is `<T extends JsonNode> T set(…)`, and the `query` assignment was the last expression of a `match` in statement position: the other branch's `Unit` forced `T` to unify with `Unit`, scalac inferred `Nothing`, and emitted a cast to `BoxedUnit`. The documented `FROM logs-* WHERE level = 'ERROR'` example could not be deployed **at all**. No watcher test used a WHERE, so `query` was always `None` and only the safe branch ever ran.

Sweeping the other node builders — which #211 asked for — found the trap a second time in `Table.indexTemplate`: `indexAliases.foreach { alias => aliasesNode.set(…) }` left `foreach`'s `U` and `set`'s `T` both free, so they inferred `Nothing` together. **Every partitioned `CREATE TABLE` declaring an alias died the same way**, with `GatewayApi.createIndexOrTemplate` as the production caller. Both regression tests fail with the exact `cannot be cast to scala.runtime.Nothing$` before the fix.

## #204 — es6 jest licence calls threw instead of returning a failure

`JestLicenseApi` called `apply().execute(...)` directly rather than the module's Try-wrapping `executeJestAction`, so a network fault during `GET _license` threw (`IOException` / `CouldNotConnectException`) although `LicenseApi` documents no exception contract and consumers — including core's `enableBasicLicense`, which chains `licenseInfo` first — treat `ElasticResult` as total. All three methods now route through the wrapper, gaining the HTTP status and the operation name. `getJsonString` is wrapped in `Option`, not `Some` — a succeeded JestResult can carry a null body.

The issue's R1FIX.3 rule required the guard to cover `LinkageError`, which `NonFatal` (and therefore `Try`) does not, while `NoClassDefFoundError` is an observed failure mode in the es6 closure (#168). `JestClientHelpers` gained `tryAction` for that, used on both the execute and transformer steps; `VirtualMachineError`s still propagate.

Also from the review: the **async** wrapper submitted its action outside any guard, so a synchronous throw escaped before the promise was completed and the caller's `Future` never completed — the REPL hang core's `statusOrServerError` documents. Now guarded.

## #215 — twelve more jest calls threw on a network fault

#204 said `executeLicenseInfo` was "the odd man out" and every other jest API already routed through the wrapper. **It did not.** Twelve more sites called `apply().execute(...)` directly. `JestWatcherApi` is the one that stings: extensions calls it on the materialized-view deployment path — the scenario #204 was found under, where a transient socket fault became a full MV rollback.

Converted: `createPipeline`, `deletePipeline`, `getPipeline`, `listPipelines`, `createLegacyTemplate`, `deleteLegacyTemplate`, `getLegacyTemplate`, `listLegacyTemplates`, `deleteWatcher`, `getWatcherStatus`. Response parsing moves into the transformer, which the wrapper guards — `getWatcherStatus` walks the response with bare `get(...)` calls, so an unexpected shape is now a failure rather than an NPE escaping the `ElasticResult` protocol.

Two methods deliberately keep an explicit shape, both commented:

- **`executeLegacyTemplateExists`** — an existence probe answers "no" with a 404, and the wrapper would make that an `ElasticFailure`, which `executeDeleteLegacyTemplate(ifExists = true)` propagates. `DROP … IF EXISTS` would fail on the case that clause exists to tolerate.
- **`executeCreateWatcher`** — keeps the response-body diagnostic `logError` does not emit, now also propagating `statusCode` and `operation`.

Absent-resource contracts are preserved *by construction*: `Pipeline.Get`, `Pipeline.List`, `Template.Get` and `JestWatcher.Get` mark 404 as **succeeded** with no body, and the wrapper keys off the same `isSucceeded` the hand-written matches did.

---

## #216 — the licence-activation Boolean was a constant

`executeJestBooleanAction` maps `_.isSucceeded`, but the transformer only runs when the result already succeeded — so `enableBasicLicense()`/`enableTrialLicense()` could only ever return `ElasticSuccess(true)` or a failure. Measured against a real `elasticsearch:8.18.3`: a *state* refusal ("Current license is basic", "Trial was already activated") is HTTP **403** and already failed correctly; the refusal for want of acknowledgement is HTTP **200** carrying `basic_was_started: false` — the response that lists what the downgrade would disable, Watcher included. Unreachable today only because every client hard-codes `acknowledge=true`.

All five clients now return the started flag from the body: es6-jest reads `<license>_was_started` from the JSON, es6/es7-rest use `isBasicStarted`/`isTrialWasStarted`, es8/es9 use `basicWasStarted()`/`trialWasStarted()`. Tested against the measured 8.18.3 response bodies served from an in-JVM `HttpServer`, including the 200-with-`false` case, which fails against the old constant.

---

---

## Fallout found by the pre-commit reviews, fixed here

- **`Identifier.update` treated any bare name matching a FROM table as a qualifier**, rewriting it to `parts.tail.mkString(".")` — the empty string. `FROM status WHERE status = 'done'` queried a **nameless** field. Newly reachable from the watcher/DELETE/UPDATE paths via #212, and already wrong on the SELECT path. Now requires an actual qualifier.
- **#159's `ORDER BY <bare table alias>` rejection was relying on that empty-name rewrite.** Detection moved into `FieldSort.update`, where the FROM aliases are in scope, via a `bareTableAlias` marker. Both #159 tests still pass.
- **`executeLegacyTemplateExists` mapped *any* non-200 to `false`**, so a 503 read as "absent" and `DROP … IF EXISTS` reported success while the template was still there. Only 200 and 404 are answers now; anything else is a failure carrying the status. An outage is not an absence.
- **The async jest wrapper ran its transformer and its `statusOf` read through plain `Try`**, so the very `LinkageError` the sync path was hardened against would escape the callback without completing the promise — a hang rather than an error.

## Found by this PR's CI — COPY INTO `FILE_FORMAT =` never parsed

The integration suites (the only COPY INTO coverage — the production had **zero** parser-level tests) went red on `COPY INTO … FILE_FORMAT = JSON_ARRAY ON CONFLICT DO UPDATE`: the grammar never accepted the `=` that every test, help entry and doc example uses. Under the old prefix parse, `opt(fileFormat)` backtracked at the `=` and silently dropped the format **and the `ON CONFLICT` after it** — auto-detection masked the loss for years. Now: `FILE_FORMAT [=] <fmt>` parses (bare or quoted, case-insensitive), an unknown format is a hard error, `CopyInto.sql` renders a quoted re-parseable source, and 12 parser tests pin it.

Adversarial review of that fix surfaced two literal-corruption defects, both fixed: the line-based comment stripper (in `Parser.apply` **and** duplicated quote-blind in `GatewayApi.run`) severed any literal containing `--`, and the two-token literal production let whitespace skipping eat leading spaces inside quotes. The normalizer is now a single literal-aware scan and each literal branch is one atomic regex. Doc drift found by the same sweep: `materialized_views.md` used a `WITH (format = 'json')` clause that never existed, `gateway.md` an unsupported `classpath:` scheme, and the COPY INTO help JSON promised CSV/JSONL support (both hard-err) while denying the remote filesystems that `CopyIntoS3IntegrationSpec` exercises.

## Verification

`JestLicenseApiFaultSpec` is 29 tests — connection-refused faults across all fifteen converted methods, plus the 404/200/503 contracts pinned against an in-JVM `HttpServer` (no Docker). 8 of them fail without the #215 conversion; both 503 cases fail without the fix above.

`sql` **453** tests on Scala 2.12 **and** 2.13 · bridge template and all four `es{6,7,8,9}` bridges **120** each (es6's is hand-maintained, not `copyBridge`-generated, and was updated separately; es9 run under `sbt17`) · `core` **737** · `macrosTests` **18** · es6/es7-rest and es6-jest compile · `scalafmtCheckAll` clean · the three CI-failing ES8 integration suites (`CopyIntoS3`, `GatewayApi`, `ReplGateway`) re-run green locally against real ES 8.18 (102 tests).

Both new crash tests and the licence fault spec were verified to **fail without their fix** — `cannot be cast to scala.runtime.Nothing$` and `CouldNotConnectException` respectively. `tryAction`'s `LinkageError` branch is tested directly, since a connection-refused fault is `NonFatal` and would pass with a plain `Try`.

`from` has exactly two call sites — `single` (SELECT, untouched) and `searchInput` — so no other statement kind is affected by the #191 guard.

## Docs

`documentation/sql/ddl_statements.md` (Search Input), `documentation/sql/dml_statements.md` (UPDATE, DELETE), `documentation/sql/joins.md`.

## ⚠️ Release-note items

- **SQL that previously "worked" by silently running a prefix now errors.** A stray clause after a statement gets a parse error instead of a partial execution. Trailing `;` runs remain accepted.
- **`GatewayApi.run` multi-statement input now actually runs every statement.** The documented split on `;` was dead code (anchored regex) — `run("a; b")` silently executed `a` alone. It now splits for real (quote- and comment-aware: `;` inside a literal or a `--` comment is not a boundary), runs the statements sequentially and returns the last result, stopping at the first failure. The REPL batch path inherits the same splitter, fixing scripts whose literals contain `;`.
- **softclient4es-arrow's `probeSchema`** appends `LIMIT 1` to user SQL without stripping a trailing `;`; the resulting mid-string `;` was silently discarded before and is rejected now. One-line `stripSuffix(";")` needed when arrow bumps core.
- **COPY INTO now honors what was written.** A `FILE_FORMAT = X` that was silently ignored (auto-detection ran instead) is now applied, an `ON CONFLICT DO UPDATE` after it now upserts where it previously did nothing, and an unsupported format (`CSV`, `JSONL`…) errors instead of being dropped. Statements that "worked" only because the declared format was discarded will change behaviour.
- **String literals are preserved exactly.** `'AB--12'` no longer breaks the statement at the `--`, and `' Bob'` no longer silently matches `'Bob'` — a query that depended on leading whitespace inside quotes being stripped now matches the literal as written.

## Filed while reviewing, deliberately not fixed here

- **#217** — `JestScrollApi` recovers a failed scroll page into *end-of-stream*, so a mid-scroll fault returns partial rows and reports success. Since #209 routes every un-LIMITed `SELECT` through `scroll`, that now reaches ordinary queries on ES6 — the #205/#207/#209 silent-truncation family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



